### PR TITLE
Merge changes required for using snmalloc in FreeBSD libc

### DIFF
--- a/src/mem/slowalloc.h
+++ b/src/mem/slowalloc.h
@@ -1,0 +1,68 @@
+#include "globalalloc.h"
+
+namespace snmalloc
+{
+  /**
+   * RAII wrapper around an `Alloc`.  This class gets an allocator from the
+   * global pool and wraps it so that `Alloc` methods can be called
+   * directly via the `->` operator on this class.  When this object is
+   * destroyed, it returns the allocator to the global pool.
+   *
+   * This does not depend on thread-local storage working, so can be used for
+   * bootstrapping.
+   */
+  struct SlowAllocator
+  {
+    /**
+     * The allocator that this wrapper will use.
+     */
+    Alloc* alloc;
+    /**
+     * Constructor.  Claims an allocator from the global pool
+     */
+    SlowAllocator() : alloc(current_alloc_pool()->acquire()) {}
+    /**
+     * Copying is not supported, it could easily lead to accidental sharing of
+     * allocators.
+     */
+    SlowAllocator(const SlowAllocator&) = delete;
+    /**
+     * Moving is not supported, though it would be easy to add if there's a use
+     * case for it.
+     */
+    SlowAllocator(SlowAllocator&&) = delete;
+    /**
+     * Copying is not supported, it could easily lead to accidental sharing of
+     * allocators.
+     */
+    SlowAllocator& operator=(const SlowAllocator&) = delete;
+    /**
+     * Moving is not supported, though it would be easy to add if there's a use
+     * case for it.
+     */
+    SlowAllocator& operator=(SlowAllocator&&) = delete;
+    /**
+     * Destructor.  Returns the allocator to the pool.
+     */
+    ~SlowAllocator()
+    {
+      current_alloc_pool()->release(alloc);
+    }
+    /**
+     * Arrow operator, allows methods exposed by `Alloc` to be called on the
+     * wrapper.
+     */
+    Alloc* operator->()
+    {
+      return alloc;
+    }
+  };
+  /**
+   * Returns a new slow allocator.  When the `SlowAllocator` goes out of scope,
+   * the underlying `Alloc` will be returned to the pool.
+   */
+  inline SlowAllocator get_slow_allocator()
+  {
+    return SlowAllocator{};
+  }
+}

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -4,10 +4,10 @@
 #  include "../ds/bits.h"
 #  include "../mem/allocconfig.h"
 
-#  include <sys/mman.h>
-#  include <strings.h>
-#  include <stdio.h>
 #  include <pthread.h>
+#  include <stdio.h>
+#  include <strings.h>
+#  include <sys/mman.h>
 
 namespace snmalloc
 {

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -5,6 +5,9 @@
 #  include "../mem/allocconfig.h"
 
 #  include <sys/mman.h>
+#  include <strings.h>
+#  include <stdio.h>
+#  include <pthread.h>
 
 namespace snmalloc
 {


### PR DESCRIPTION
With these changes, 32- and 64-bit userland builds, static and dynamically linked 64-bit versions are tested (32-bit ones are not, but hopefully work!).