### PR TITLE
Fixes remote and pagemap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(MSVC)
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
 else()
   find_package(Threads REQUIRED)
-  add_compile_options(-mcx16 -march=native -Wall -Wextra -Werror -g)
+  add_compile_options(-mcx16 -march=native -Wall -Wextra -Werror -Wsign-conversion -g)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -68,7 +68,8 @@ namespace snmalloc
      * Primitive allocator for structure that are required before
      * the allocator can be running.
      ***/
-    void* alloc_chunk(size_t size, size_t alignment = 64)
+    template<size_t alignment = 64>
+    void* alloc_chunk(size_t size)
     {
       // Cache line align
       size = bits::align_up(size, 64);

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -51,6 +51,13 @@ namespace snmalloc
       return std::make_pair(r, size);
     }
 
+    void new_block()
+    {
+      auto r_size = reserve_block();
+      bump = (size_t)r_size.first;
+      remaining = r_size.second;
+    }
+
   public:
     /**
      * Stack of large allocations that have been returned for reuse.
@@ -61,7 +68,7 @@ namespace snmalloc
      * Primitive allocator for structure that are required before
      * the allocator can be running.
      ***/
-    void* alloc_chunk(size_t size)
+    void* alloc_chunk(size_t size, size_t alignment = 64)
     {
       // Cache line align
       size = bits::align_up(size, 64);
@@ -70,12 +77,20 @@ namespace snmalloc
       {
         FlagLock f(lock);
 
+        auto aligned_bump = bits::align_up(bump, alignment);
+        if ((aligned_bump - bump) < size)
+        {
+          new_block();
+        }
+        else
+        {
+          remaining -= aligned_bump - bump;
+          bump = aligned_bump;
+        }
+
         if (remaining < size)
         {
-          auto r_size = reserve_block();
-
-          bump = (size_t)r_size.first;
-          remaining = r_size.second;
+          new_block();
         }
 
         p = (void*)bump;

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -86,7 +86,8 @@ namespace snmalloc
                 value, (PagemapEntry*)LOCKED_ENTRY, std::memory_order_relaxed))
           {
             auto& v = default_memory_provider;
-            value = (PagemapEntry*)v.alloc_chunk(PAGEMAP_NODE_SIZE);
+            value =
+              (PagemapEntry*)v.alloc_chunk(PAGEMAP_NODE_SIZE, OS_PAGE_SIZE);
             e->store(value, std::memory_order_release);
           }
           else
@@ -160,6 +161,13 @@ namespace snmalloc
       return &(leaf_ix.first->values[leaf_ix.second]);
     }
 
+    std::atomic<T>* get_ptr(void* p)
+    {
+      bool success;
+      return get_addr<true>(p, success);
+    }
+
+  public:
     /**
      * Returns the index of a pagemap entry within a given page.  This is used
      * in code that propagates changes to the pagemap elsewhere.
@@ -182,13 +190,6 @@ namespace snmalloc
         reinterpret_cast<uintptr_t>(get_addr<true>(p, success)));
     }
 
-    std::atomic<T>* get_ptr(void* p)
-    {
-      bool success;
-      return get_addr<true>(p, success);
-    }
-
-  public:
     T get(void* p)
     {
       bool success;

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -87,7 +87,7 @@ namespace snmalloc
           {
             auto& v = default_memory_provider;
             value =
-              (PagemapEntry*)v.alloc_chunk(PAGEMAP_NODE_SIZE, OS_PAGE_SIZE);
+              (PagemapEntry*)v.alloc_chunk<OS_PAGE_SIZE>(PAGEMAP_NODE_SIZE);
             e->store(value, std::memory_order_release);
           }
           else


### PR DESCRIPTION
This PR makes the pagemap have OS_PAGE_SIZE alignment, and fixes the surrounding API.

Additionally, it fixes the encoding of sizeclasses into the top bits of remote allocation, to use the bottom bits, and shift the pointers up.  This allows a right signed shift to preserve the sign extended address space.
