### PR TITLE
Fix assertion failure in memalign

### DIFF
--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -140,7 +140,7 @@ extern "C"
     for (; sc < NUM_SIZECLASSES; sc++)
     {
       size = sizeclass_to_size(sc);
-      if ((size & (~size - 1)) >= alignment)
+      if ((size & (~size + 1)) >= alignment)
       {
         return SNMALLOC_NAME_MANGLE(aligned_alloc)(alignment, size);
       }


### PR DESCRIPTION
Fix a bug in memalign introduced in [8d07448](https://github.com/Microsoft/snmalloc/commit/8d074468ae6040a4f01d98b91276357a80d072ab).