### PR TITLE
Simplification around remote allocation

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -522,6 +522,9 @@ namespace snmalloc
       size_t size = 0;
       RemoteList list[REMOTE_SLOTS];
 
+      /// Used to find the index into the array of queues for remote
+      /// deallocation
+      /// r is used for which round of sending this is.
       inline size_t get_slot(size_t id, size_t r)
       {
         constexpr size_t allocator_size =

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -50,7 +50,8 @@ namespace snmalloc
       if (p != nullptr)
         return p;
 
-      p = (T*)memory_provider.alloc_chunk(sizeof(T));
+      p = (T*)memory_provider
+            .template alloc_chunk<bits::next_pow2_const(sizeof(T))>(sizeof(T));
 
       new (p) T(std::forward<Args...>(args)...);
 

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -30,6 +30,10 @@ namespace snmalloc
     }
   };
 
+  static_assert(
+    sizeof(Remote) <= MIN_ALLOC_SIZE,
+    "Needs to be able to fit in smallest allocation.");
+
   struct RemoteAllocator
   {
     using alloc_id_t = Remote::alloc_id_t;

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -10,13 +10,6 @@ namespace snmalloc
 {
   struct Remote
   {
-    static const size_t PTR_BITS = sizeof(void*) * 8;
-    static const size_t SIZECLASS_BITS =
-      bits::next_pow2_bits_const(NUM_SIZECLASSES);
-    static const bool USE_TOP_BITS =
-      SIZECLASS_BITS + bits::ADDRESS_BITS < PTR_BITS;
-    static const uintptr_t SIZECLASS_MASK = ((1ULL << SIZECLASS_BITS) - 1);
-
     using alloc_id_t = size_t;
     union
     {
@@ -24,65 +17,18 @@ namespace snmalloc
       Remote* non_atomic_next;
     };
 
-    // Uses an intptr_t so that when we use the TOP_BITS to encode the
-    // sizeclass, then we can use signed shift to correctly handle kernel versus
-    // user mode.
-    intptr_t value;
+    alloc_id_t allocator_id;
 
-    // This will not exist for the minimum object size. This is only used if
-    // USE_TOP_BITS is false, and the bottom bit of value is set.
-    uint8_t possible_sizeclass;
-
-    void set_sizeclass_and_target_id(alloc_id_t id, uint8_t sizeclass)
+    void set_target_id(alloc_id_t id)
     {
-      if constexpr (USE_TOP_BITS)
-      {
-        value = (intptr_t)(
-          (id << SIZECLASS_BITS) | ((static_cast<uintptr_t>(sizeclass))));
-      }
-      else
-      {
-        assert((id & 1) == 0);
-        if (sizeclass == 0)
-        {
-          value = (intptr_t)(id | 1);
-        }
-        else
-        {
-          value = (intptr_t)id;
-          possible_sizeclass = sizeclass;
-        }
-      }
+      allocator_id = id;
     }
 
     alloc_id_t target_id()
     {
-      if constexpr (USE_TOP_BITS)
-      {
-        return (alloc_id_t)(value >> SIZECLASS_BITS);
-      }
-      else
-      {
-        return (alloc_id_t)(value & ~1);
-      }
-    }
-
-    uint8_t sizeclass()
-    {
-      if constexpr (USE_TOP_BITS)
-      {
-        return (static_cast<uint8_t>((uintptr_t)value & SIZECLASS_MASK));
-      }
-      else
-      {
-        return ((value & 1) == 1) ? 0 : possible_sizeclass;
-      }
+      return allocator_id;
     }
   };
-
-  static_assert(
-    (offsetof(Remote, possible_sizeclass)) <= MIN_ALLOC_SIZE,
-    "Need to be able to cast any small alloc to Remote");
 
   struct RemoteAllocator
   {


### PR DESCRIPTION
This removes storing the sizeclass in the remote allocation.  On the most common paths, we touch the cache lines that contain the size class, so there is no noticeable perf improve from storing this in the block. 