### PR TITLE
Disable rtti / exceptions on the non-Windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(MSVC)
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
 else()
   find_package(Threads REQUIRED)
-  add_compile_options(-mcx16 -march=native -Wall -Wextra -Werror -Wsign-conversion -g)
+  add_compile_options(-mcx16 -march=native -Wall -Wextra -Werror -Wsign-conversion -g -fno-exceptions -fno-rtti)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
RTTI makes the binaries bigger, exceptions make life harder for
optimisers.  Neither are actually used.

This doesn't preclude anything #including snmalloc.h with RTTI enabled,
it just disables it in the shim libraries and tests.

The FreeBSD libc builds were already doing this with no ill effect.