### PR TITLE
Fix the condition on when to allocate a new block.

### DIFF
--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -80,7 +80,7 @@ namespace snmalloc
         FlagLock f(lock);
 
         auto aligned_bump = bits::align_up(bump, alignment);
-        if ((aligned_bump - bump) < size)
+        if ((aligned_bump - bump) > remaining)
         {
           new_block();
         }


### PR DESCRIPTION
Previously we would pretty much always allocate a new block for each allocator, making them 16MiB aligned.