### PR TITLE
Pal zero bug alignment

### DIFF
--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -196,13 +196,15 @@ namespace snmalloc
             memory_provider.template zero<true>(p, OS_PAGE_SIZE);
 
           memory_provider.template notify_using<zero_mem>(
-            (void*)((size_t)p + OS_PAGE_SIZE), size - OS_PAGE_SIZE);
+            (void*)((size_t)p + OS_PAGE_SIZE),
+            bits::align_up(size, OS_PAGE_SIZE) - OS_PAGE_SIZE);
         }
         else
         {
           // This is a superslab that has not been decommitted.
           if (zero_mem == YesZero)
-            memory_provider.template zero<true>(p, size);
+            memory_provider.template zero<true>(
+              p, bits::align_up(size, OS_PAGE_SIZE));
         }
       }
 

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -277,6 +277,17 @@ void test_alloc_16M()
   alloc->dealloc(p1);
 }
 
+void test_calloc_16M()
+{
+  auto* alloc = ThreadAlloc::get();
+  // sizes >= 16M use large_alloc
+  const size_t size = 16'000'000;
+
+  void* p1 = alloc->alloc<YesZero>(size);
+  assert(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  alloc->dealloc(p1);
+}
+
 int main(int argc, char** argv)
 {
 #ifdef USE_SYSTEMATIC_TESTING
@@ -296,6 +307,7 @@ int main(int argc, char** argv)
   test_double_alloc();
   test_external_pointer();
   test_alloc_16M();
+  test_calloc_16M();
 
   return 0;
 }


### PR DESCRIPTION
This fixes a bug found by PR #20.

The PAL requires the values to be page aligned, but in a large alloc case they weren't.