### PR TITLE
Tweaks to end bounds checking.

### DIFF
--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -17,7 +17,7 @@ extern "C"
 {
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(__malloc_end_pointer)(void* ptr)
   {
-    return Alloc::external_pointer<End>(ptr);
+    return Alloc::external_pointer<OnePastEnd>(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(malloc)(size_t size)


### PR DESCRIPTION
Introduce a `OnePastEnd` option for the pointer immediately after the
end of the allocation.  This simplifies some of the logic in callers,
where they wants to say 'is base + length safe to use?'.

Also restructure some of the other logic somewhat.