### PR TITLE
Initial cut at a lazy decommit strategy.

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1004,7 +1004,7 @@ namespace snmalloc
             static_assert(
               std::remove_reference_t<decltype(
                 large_allocator
-                  .memory_provider)>::supports_low_memory_notification,
+                  .memory_provider)>::pal_supports<LowMemoryNotification>(),
               "A lazy decommit strategy cannot be implemented on platforms "
               "without low memory notifications");
           }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -999,6 +999,15 @@ namespace snmalloc
               (void*)((size_t)super + OS_PAGE_SIZE),
               SUPERSLAB_SIZE - OS_PAGE_SIZE);
           }
+          else if constexpr (decommit_strategy == DecommitSuperLazy)
+          {
+            static_assert(
+              std::remove_reference_t<decltype(
+                large_allocator
+                  .memory_provider)>::supports_low_memory_notification,
+              "A lazy decommit strategy cannot be implemented on platforms "
+              "without low memory notifications");
+          }
 
           pagemap().clear_slab(super);
           large_allocator.dealloc(super, 0);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1003,8 +1003,8 @@ namespace snmalloc
           {
             static_assert(
               std::remove_reference_t<decltype(
-                large_allocator
-                  .memory_provider)>::template pal_supports<LowMemoryNotification>(),
+                large_allocator.memory_provider)>::
+                template pal_supports<LowMemoryNotification>(),
               "A lazy decommit strategy cannot be implemented on platforms "
               "without low memory notifications");
           }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1004,7 +1004,7 @@ namespace snmalloc
             static_assert(
               std::remove_reference_t<decltype(
                 large_allocator
-                  .memory_provider)>::pal_supports<LowMemoryNotification>(),
+                  .memory_provider)>::template pal_supports<LowMemoryNotification>(),
               "A lazy decommit strategy cannot be implemented on platforms "
               "without low memory notifications");
           }

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -60,14 +60,30 @@ namespace snmalloc
 
   enum DecommitStrategy
   {
+    /**
+     * Never decommit memory.
+     */
     DecommitNone,
+    /**
+     * Decommit superslabs when they are no entirely empty.
+     */
     DecommitSuper,
-    DecommitAll
+    /**
+     * Decommit all slabs once they are empty.
+     */
+    DecommitAll,
+    /**
+     * Decommit superslabs only when we are informed of memory pressure by the
+     * OS, do not decommit anything in normal operation.
+     */
+    DecommitSuperLazy
   };
 
   static constexpr DecommitStrategy decommit_strategy =
 #ifdef USE_DECOMMIT_STRATEGY
     USE_DECOMMIT_STRATEGY
+#elif defined(_WIN32)
+    DecommitSuperLazy
 #else
     DecommitSuper
 #endif

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -82,7 +82,7 @@ namespace snmalloc
   static constexpr DecommitStrategy decommit_strategy =
 #ifdef USE_DECOMMIT_STRATEGY
     USE_DECOMMIT_STRATEGY
-#elif defined(_WIN32)
+#elif defined(_WIN32) && !defined(OPEN_ENCLAVE)
     DecommitSuperLazy
 #else
     DecommitSuper

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -65,7 +65,7 @@ namespace snmalloc
      */
     DecommitNone,
     /**
-     * Decommit superslabs when they are no entirely empty.
+     * Decommit superslabs when they are entirely empty.
      */
     DecommitSuper,
     /**

--- a/src/mem/baseslab.h
+++ b/src/mem/baseslab.h
@@ -10,7 +10,12 @@ namespace snmalloc
     Fresh = 0,
     Large,
     Medium,
-    Super
+    Super,
+    /**
+     * If the decommit policy is lazy, slabs are moved to this state when all
+     * pages other than the first one have been decommitted.
+     */
+    Decommitted
   };
 
   class Baseslab

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -174,13 +174,15 @@ namespace snmalloc
     ALWAYSINLINE void lazy_decommit_if_needed()
     {
 #ifdef TEST_LAZY_DECOMMIT
-		static_assert(TEST_LAZY_DECOMMIT > 0, "TEST_LAZY_DECOMMIT must be a positive integer value.");
-		static std::atomic<uint64_t> counter;
-		auto c = counter++;
-		if (c % TEST_LAZY_DECOMMIT == 0)
-		{
-          lazy_decommit();
-		}
+      static_assert(
+        TEST_LAZY_DECOMMIT > 0,
+        "TEST_LAZY_DECOMMIT must be a positive integer value.");
+      static std::atomic<uint64_t> counter;
+      auto c = counter++;
+      if (c % TEST_LAZY_DECOMMIT == 0)
+      {
+        lazy_decommit();
+      }
 #else
       if constexpr (decommit_strategy == DecommitSuperLazy)
       {

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -171,7 +171,6 @@ namespace snmalloc
       return p;
     }
 
-#define TEST_LAZY_DECOMMIT 4
     ALWAYSINLINE void lazy_decommit_if_needed()
     {
 #ifdef TEST_LAZY_DECOMMIT

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -104,7 +104,8 @@ namespace snmalloc
           // the stack.
           if (slab->get_kind() != Decommitted)
           {
-            notify_not_using(((char*)slab) + OS_PAGE_SIZE, decommit_size);
+            MemoryProviderState::notify_not_using(
+              ((char*)slab) + OS_PAGE_SIZE, decommit_size);
           }
           // Once we've removed these from the stack, there will be no
           // concurrent accesses and removal should have established a

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -19,7 +19,6 @@ namespace snmalloc
      */
     LowMemoryNotification = (1 << 0)
   };
-
 }
 
 // If simultating OE, then we need the underlying platform

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -3,6 +3,23 @@
 namespace snmalloc
 {
   void error(const char* const str);
+
+  /**
+   * Flags in a bitfield of optional features that a PAL may support.  These
+   * should be set in the PAL's `pal_features` static constexpr field.
+   */
+  enum PalFeatures : uint64_t
+  {
+    /**
+     * This PAL supports low memory notifications.  It must implement a
+     * `low_memory_epoch` method that returns a `uint64_t` of the number of
+     * times that a low-memory notification has been raised and an
+     * `expensive_low_memory_check()` method that returns a `bool` indicating
+     * whether low memory conditions are still in effect.
+     */
+    LowMemoryNotification = (1 << 0)
+  };
+
 }
 
 // If simultating OE, then we need the underlying platform

--- a/src/pal/pal_free_bsd_kernel.h
+++ b/src/pal/pal_free_bsd_kernel.h
@@ -25,10 +25,10 @@ namespace snmalloc
 
   public:
     /**
-     * Flag indicating that this PAL does not support low pressure
-     * notifications.
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
      */
-    static constexpr bool supports_low_memory_notification = false;
+    static constexpr uint64_t pal_features = 0;
     void error(const char* const str)
     {
       panic("snmalloc error: %s", str);

--- a/src/pal/pal_free_bsd_kernel.h
+++ b/src/pal/pal_free_bsd_kernel.h
@@ -24,6 +24,11 @@ namespace snmalloc
     }
 
   public:
+    /**
+     * Flag indicating that this PAL does not support low pressure
+     * notifications.
+     */
+    static constexpr bool supports_low_memory_notification = false;
     void error(const char* const str)
     {
       panic("snmalloc error: %s", str);

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -14,6 +14,11 @@ namespace snmalloc
   class PALFBSD
   {
   public:
+    /**
+     * Flag indicating that this PAL does not support low pressure
+     * notifications.
+     */
+    static constexpr bool supports_low_memory_notification = false;
     static void error(const char* const str)
     {
       puts(str);

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -15,10 +15,10 @@ namespace snmalloc
   {
   public:
     /**
-     * Flag indicating that this PAL does not support low pressure
-     * notifications.
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
      */
-    static constexpr bool supports_low_memory_notification = false;
+    static constexpr uint64_t pal_features = 0;
     static void error(const char* const str)
     {
       puts(str);

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -14,10 +14,10 @@ namespace snmalloc
   {
   public:
     /**
-     * Flag indicating that this PAL does not support low pressure
-     * notifications.
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
      */
-    static constexpr bool supports_low_memory_notification = false;
+    static constexpr uint64_t pal_features = 0;
     static void error(const char* const str)
     {
       puts(str);

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -13,6 +13,11 @@ namespace snmalloc
   class PALLinux
   {
   public:
+    /**
+     * Flag indicating that this PAL does not support low pressure
+     * notifications.
+     */
+    static constexpr bool supports_low_memory_notification = false;
     static void error(const char* const str)
     {
       puts(str);

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -14,6 +14,11 @@ namespace snmalloc
     std::atomic<uintptr_t> oe_base;
 
   public:
+    /**
+     * Flag indicating that this PAL does not support low pressure
+     * notifications.
+     */
+    static constexpr bool supports_low_memory_notification = false;
     static void error(const char* const str)
     {
       UNUSED(str);

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -15,10 +15,10 @@ namespace snmalloc
 
   public:
     /**
-     * Flag indicating that this PAL does not support low pressure
-     * notifications.
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
      */
-    static constexpr bool supports_low_memory_notification = false;
+    static constexpr uint64_t pal_features = 0;
     static void error(const char* const str)
     {
       UNUSED(str);

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -65,9 +65,10 @@ namespace snmalloc
       }
     }
     /**
-     * Flag indicating that this PAL supports the low pressure notification.
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.  This PAL supports low-memory notifications.
      */
-    static constexpr bool supports_low_memory_notification = true;
+    static constexpr uint64_t pal_features = LowMemoryNotification;
     /**
      * Counter values for the number of times that a low-pressure notification
      * has been delivered.  Callers should compare this with a previous value


### PR DESCRIPTION
This does not deallocate memory until the OS tells us that we are short
on memory, then tries to decommit all of the cached chunks (except for
the first page, used for the linked lists).

Nowhere near enough testing to commit to master yet!

PR submitted to push it through CI and see what I broke.