### PR TITLE
Combination of the refactor align and add Apple changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,6 +129,30 @@ phases:
     workingDirectory: build
     displayName: 'Run Ctest'
 
+- phase: macOS
+  queue:
+    name: 'Hosted macOS'
+    parallel: 2
+    matrix:
+      Debug:
+        BuildType: Debug
+      Release:
+        BuildType: Release
+
+  steps:
+  - task: CMake@1
+    displayName: 'CMake .. -DCMAKE_BUILD_TYPE=$(BuildType)'
+    inputs:
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=$(BuildType)'
+
+  - script: |
+      make -j 4
+      ctest -j 4 --output-on-failure
+
+    workingDirectory: build
+    failOnStderr: true
+    displayName: 'Compile & Test'
+
 - phase: Format
   queue:
     name: 'Hosted Ubuntu 1604'

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -33,8 +33,18 @@ namespace snmalloc
     }
   };
 
+  /**
+   * A slab that has been decommitted.  The first page remains committed and
+   * the only fields that are guaranteed to exist are the kind and next
+   * pointer from the superclass.
+   */
   struct Decommittedslab : public Largeslab
   {
+    /**
+     * Constructor.  Expected to be called via placement new into some memory
+     * that was formerly a superslab or large allocation and is now just some
+     * spare address space.
+     */
     Decommittedslab()
     {
       kind = Decommitted;

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -17,7 +17,17 @@ namespace snmalloc
      * `expensive_low_memory_check()` method that returns a `bool` indicating
      * whether low memory conditions are still in effect.
      */
-    LowMemoryNotification = (1 << 0)
+    LowMemoryNotification = (1 << 0),
+    /**
+     * This PAL natively supports allocation with a guaranteed alignment.  If
+     * this is not supported, then we will over-allocate and round the
+     * allocation.
+     *
+     * A PAL that does supports this must expose a `request()` method that takes
+     * a size and alignment.  A PAL that does *not* support it must expose a
+     * `request()` method that takes only a size.
+     */
+    AlignedAllocation = (1 << 1)
   };
 }
 

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -33,6 +33,7 @@ namespace snmalloc
 
 // If simultating OE, then we need the underlying platform
 #if !defined(OPEN_ENCLAVE) || defined(OPEN_ENCLAVE_SIMULATION)
+#  include "pal_apple.h"
 #  include "pal_free_bsd_kernel.h"
 #  include "pal_freebsd.h"
 #  include "pal_linux.h"
@@ -47,6 +48,8 @@ namespace snmalloc
   using DefaultPal =
 #  if defined(_WIN32)
     PALWindows;
+#  elif defined(__APPLE__)
+    PALApple;
 #  elif defined(__linux__)
     PALLinux;
 #  elif defined(FreeBSD_KERNEL)

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#ifdef __APPLE__
+#  include "../ds/bits.h"
+#  include "../mem/allocconfig.h"
+
+#  include <pthread.h>
+#  include <stdio.h>
+#  include <strings.h>
+#  include <sys/mman.h>
+
+namespace snmalloc
+{
+  /**
+   * PAL implementation for Apple systems (macOS, iOS, watchOS, tvOS...).
+   */
+  class PALApple
+  {
+  public:
+    /**
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
+     */
+    static constexpr uint64_t pal_features = 0;
+    static void error(const char* const str)
+    {
+      puts(str);
+      abort();
+    }
+
+    /// Notify platform that we will not be using these pages
+    void notify_not_using(void* p, size_t size) noexcept
+    {
+      assert(bits::is_aligned_block<OS_PAGE_SIZE>(p, size));
+      madvise(p, size, MADV_FREE);
+    }
+
+    /// Notify platform that we will be using these pages
+    template<ZeroMem zero_mem>
+    void notify_using(void* p, size_t size) noexcept
+    {
+      assert(
+        bits::is_aligned_block<OS_PAGE_SIZE>(p, size) || (zero_mem == NoZero));
+      if constexpr (zero_mem == YesZero)
+        zero(p, size);
+    }
+
+    /// OS specific function for zeroing memory
+    template<bool page_aligned = false>
+    void zero(void* p, size_t size) noexcept
+    {
+      if (page_aligned || bits::is_aligned_block<OS_PAGE_SIZE>(p, size))
+      {
+        assert(bits::is_aligned_block<OS_PAGE_SIZE>(p, size));
+        void* r = mmap(
+          p,
+          size,
+          PROT_READ | PROT_WRITE,
+          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+          -1,
+          0);
+
+        if (r != MAP_FAILED)
+          return;
+      }
+
+      bzero(p, size);
+    }
+
+    template<bool committed>
+    void* reserve(size_t* size) noexcept
+    {
+      void* p = mmap(
+        NULL,
+        *size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0);
+
+      if (p == MAP_FAILED)
+        error("Out of memory");
+
+      return p;
+    }
+  };
+}
+#endif

--- a/src/pal/pal_free_bsd_kernel.h
+++ b/src/pal/pal_free_bsd_kernel.h
@@ -28,7 +28,7 @@ namespace snmalloc
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = 0;
+    static constexpr uint64_t pal_features = AlignedAllocation;
     void error(const char* const str)
     {
       panic("snmalloc error: %s", str);

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -18,7 +18,7 @@ namespace snmalloc
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = 0;
+    static constexpr uint64_t pal_features = AlignedAllocation;
     static void error(const char* const str)
     {
       puts(str);

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -61,17 +61,11 @@ namespace snmalloc
     }
 
     template<bool committed>
-    void* reserve(size_t* size, size_t align) noexcept
+    void* reserve(size_t* size) noexcept
     {
-      size_t request = *size;
-      // Add align, so we can guarantee to provide at least size.
-      request += align;
-      // Alignment must be a power of 2.
-      assert(align == bits::next_pow2(align));
-
       void* p = mmap(
         NULL,
-        request,
+        *size,
         PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS,
         -1,
@@ -79,18 +73,7 @@ namespace snmalloc
 
       if (p == MAP_FAILED)
         error("Out of memory");
-      *size = request;
-      uintptr_t p0 = (uintptr_t)p;
-      uintptr_t start = bits::align_up(p0, align);
 
-      if (start > (uintptr_t)p0)
-      {
-        uintptr_t end = bits::align_down(p0 + request, align);
-        *size = end - start;
-        munmap(p, start - p0);
-        munmap((void*)end, (p0 + request) - end);
-        p = (void*)start;
-      }
       return p;
     }
   };

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -18,7 +18,7 @@ namespace snmalloc
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = 0;
+    static constexpr uint64_t pal_features = AlignedAllocation;
     static void error(const char* const str)
     {
       UNUSED(str);

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -30,10 +30,10 @@ extern "C" void oe_abort()
 using namespace snmalloc;
 int main()
 {
-  DefaultPal pal;
+  MemoryProviderStateMixin<DefaultPal> mp;
 
   size_t size = 1ULL << 28;
-  oe_base = pal.reserve<true>(&size, 0);
+  oe_base = mp.reserve<true>(&size, 0);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -35,10 +35,10 @@ extern "C" void enclave_free(void*);
 using namespace snmalloc;
 int main()
 {
-  DefaultPal pal;
+  MemoryProviderStateMixin<DefaultPal> mp;
 
   size_t size = 1ULL << 28;
-  oe_base = pal.reserve<true>(&size, 0);
+  oe_base = mp.reserve<true>(&size, 1);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 


### PR DESCRIPTION
This PR (which depends on #29) factors out the code for dealing with a PAL that doesn't know how to give you strongly aligned memory.  That then makes the Apple PAL simpler to write, so the next commit adds one and integrates it with the CI:

https://dev.azure.com/snmalloc/snmalloc/_build/results?buildId=190