### PR TITLE
Adding support for shared allocators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build*/
 CMakeFiles/
 .vscode/
+.vs/
 *~
 *.sw?

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -4,6 +4,34 @@
 
 namespace snmalloc
 {
+  void error(const char* const str);
+
+  /**
+   * Flags in a bitfield of optional features that a PAL may support.  These
+   * should be set in the PAL's `pal_features` static constexpr field.
+   */
+  enum PalFeatures : uint64_t
+  {
+    /**
+     * This PAL supports low memory notifications.  It must implement a
+     * `low_memory_epoch` method that returns a `uint64_t` of the number of
+     * times that a low-memory notification has been raised and an
+     * `expensive_low_memory_check()` method that returns a `bool` indicating
+     * whether low memory conditions are still in effect.
+     */
+    LowMemoryNotification = (1 << 0),
+    /**
+     * This PAL natively supports allocation with a guaranteed alignment.  If
+     * this is not supported, then we will over-allocate and round the
+     * allocation.
+     *
+     * A PAL that does supports this must expose a `request()` method that takes
+     * a size and alignment.  A PAL that does *not* support it must expose a
+     * `request()` method that takes only a size.
+     */
+    AlignedAllocation = (1 << 1)
+  };
+
   enum ZeroMem
   {
     NoZero,

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -205,6 +205,17 @@ extern "C"
     return ENOENT;
   }
 
+  SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(get_global_pagemap)(void)
+  {
+    return &snmalloc::global_pagemap;
+  }
+
+  SNMALLOC_EXPORT void*
+    SNMALLOC_NAME_MANGLE(reserve_shared)(size_t* size, size_t align)
+  {
+    return snmalloc::default_memory_provider.reserve<true>(size, align);
+  }
+
 #if !defined(__PIC__) && !defined(NO_BOOTSTRAP_ALLOCATOR)
   // The following functions are required to work before TLS is set up, in
   // statically-linked programs.  These temporarily grab an allocator from the

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -1,36 +1,5 @@
 #pragma once
 
-namespace snmalloc
-{
-  void error(const char* const str);
-
-  /**
-   * Flags in a bitfield of optional features that a PAL may support.  These
-   * should be set in the PAL's `pal_features` static constexpr field.
-   */
-  enum PalFeatures : uint64_t
-  {
-    /**
-     * This PAL supports low memory notifications.  It must implement a
-     * `low_memory_epoch` method that returns a `uint64_t` of the number of
-     * times that a low-memory notification has been raised and an
-     * `expensive_low_memory_check()` method that returns a `bool` indicating
-     * whether low memory conditions are still in effect.
-     */
-    LowMemoryNotification = (1 << 0),
-    /**
-     * This PAL natively supports allocation with a guaranteed alignment.  If
-     * this is not supported, then we will over-allocate and round the
-     * allocation.
-     *
-     * A PAL that does supports this must expose a `request()` method that takes
-     * a size and alignment.  A PAL that does *not* support it must expose a
-     * `request()` method that takes only a size.
-     */
-    AlignedAllocation = (1 << 1)
-  };
-}
-
 // If simultating OE, then we need the underlying platform
 #if !defined(OPEN_ENCLAVE) || defined(OPEN_ENCLAVE_SIMULATION)
 #  include "pal_apple.h"
@@ -56,14 +25,16 @@ namespace snmalloc
     PALFreeBSDKernel;
 #  elif defined(__FreeBSD__)
     PALFBSD;
+#  else
+#    error Unsupported platform
 #  endif
 #endif
 
   using Pal =
-#ifdef OPEN_ENCLAVE
-    PALPlainMixin<PALOpenEnclave>;
-#elif defined(SNMALLOC_MEMORY_PROVIDER)
+#if defined(SNMALLOC_MEMORY_PROVIDER)
     PALPlainMixin<SNMALLOC_MEMORY_PROVIDER>;
+#elif defined(OPEN_ENCLAVE)
+    PALPlainMixin<PALOpenEnclave>;
 #else
     DefaultPal;
 #endif


### PR DESCRIPTION
Exporting the global pagemap and the default memory provider's reserve function in order to support shared allocators