### PR TITLE
Pagemap access refactor

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,10 +204,10 @@ phases:
   steps:
   - script: |
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7.0 main"
       sudo apt-get update
-      sudo apt-get install -y clang-format-6.0
-      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
+      sudo apt-get install -y clang-format-7.0
+      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7.0 100
 
       bash check-format.sh
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,10 +204,10 @@ phases:
   steps:
   - script: |
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7.0 main"
+      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
       sudo apt-get update
-      sudo apt-get install -y clang-format-7.0
-      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7.0 100
+      sudo apt-get install -y clang-format-6.0
+      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
 
       bash check-format.sh
 

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -101,7 +101,7 @@ namespace snmalloc
 
   public:
     /**
-     * Construtor.  Accesses the pagemap via the C ABI accessor and casts it to
+     * Constructor.  Accesses the pagemap via the C ABI accessor and casts it to
      * the expected type, failing in cases of ABI mismatch.
      */
     ExternalGlobalPagemap()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -70,7 +70,15 @@ namespace snmalloc
    */
   struct SuperslabMap
   {
+    /**
+     * Reference to the pagemap that we're using, allowing it to not be the
+     * default pagemap.
+     */
     SuperslabPagemap& pagemap;
+    /**
+     * Constructor.  Uses the global pagemap by default, but can use a
+     * different one if required.
+     */
     SuperslabMap(SuperslabPagemap& pm = global_pagemap) : pagemap(pm) {}
     /**
      * Get the pagemap entry corresponding to a specific address.

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -138,7 +138,7 @@ namespace snmalloc
     {
       const snmalloc::PagemapConfig* c;
       external_pagemap =
-        SuperslabPagemap::cast_to_pagemap(snmalloc_get_global_pagemap(&c), c);
+        SuperslabPagemap::cast_to_pagemap(snmalloc_pagemap_global_get(&c), c);
       // FIXME: Report an error somehow in non-debug builds.
       assert(external_pagemap);
     }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -80,36 +80,6 @@ namespace snmalloc
   };
 
   /**
-   * Mixin used by `SuperslabMap` to access a pagemap provided by the user.
-   * This should be used by code that needs to access the canonical pagemap via
-   * some custom mechanism.
-   */
-  class CustomPagemap
-  {
-    /**
-     * Reference to the pagemap that we're using, allowing it to not be the
-     * default pagemap.
-     */
-    SuperslabPagemap& custom_pagemap;
-
-  public:
-    /**
-     * Constructor.  Takes the pagemap to use as an argument.  This constructor
-     * will be inherited by `SuperslabMap` if this mixin is used and so should
-     * be called as a constructor there, rather than directly.
-     */
-    CustomPagemap(SuperslabPagemap& pm) : custom_pagemap(pm) {}
-
-    /**
-     * Returns the provided pagemap.
-     */
-    SuperslabPagemap& pagemap()
-    {
-      return custom_pagemap;
-    }
-  };
-
-  /**
    * Optionally exported function that accesses the global pagemap provided by
    * a shared library.
    */

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -70,8 +70,8 @@ namespace snmalloc
    */
   struct SuperslabMap
   {
-	SuperslabPagemap &pagemap;
-	SuperslabMap(SuperslabPagemap &pm=global_pagemap) : pagemap(pm) {}
+    SuperslabPagemap& pagemap;
+    SuperslabMap(SuperslabPagemap& pm = global_pagemap) : pagemap(pm) {}
     /**
      * Get the pagemap entry corresponding to a specific address.
      */
@@ -123,8 +123,7 @@ namespace snmalloc
       for (size_t i = 0; i < size_bits - SUPERSLAB_BITS; i++)
       {
         size_t run = 1ULL << i;
-        pagemap.set_range(
-          (void*)ss, (uint8_t)(64 + i + SUPERSLAB_BITS), run);
+        pagemap.set_range((void*)ss, (uint8_t)(64 + i + SUPERSLAB_BITS), run);
         ss = (uintptr_t)ss + SUPERSLAB_SIZE * run;
       }
       pagemap.set(p, (uint8_t)size_bits);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -70,12 +70,14 @@ namespace snmalloc
    */
   struct SuperslabMap
   {
+	SuperslabPagemap &pagemap;
+	SuperslabMap(SuperslabPagemap &pm=global_pagemap) : pagemap(pm) {}
     /**
      * Get the pagemap entry corresponding to a specific address.
      */
     uint8_t get(void* p)
     {
-      return global_pagemap.get(p);
+      return pagemap.get(p);
     }
     /**
      * Set a pagemap entry indicating that there is a superslab at the
@@ -121,11 +123,11 @@ namespace snmalloc
       for (size_t i = 0; i < size_bits - SUPERSLAB_BITS; i++)
       {
         size_t run = 1ULL << i;
-        global_pagemap.set_range(
+        pagemap.set_range(
           (void*)ss, (uint8_t)(64 + i + SUPERSLAB_BITS), run);
         ss = (uintptr_t)ss + SUPERSLAB_SIZE * run;
       }
-      global_pagemap.set(p, (uint8_t)size_bits);
+      pagemap.set(p, (uint8_t)size_bits);
     }
     /**
      * Update the pagemap to remove a large allocation, of `size` bytes from
@@ -136,7 +138,7 @@ namespace snmalloc
       size_t rounded_size = bits::next_pow2(size);
       assert(get(p) == bits::next_pow2_bits(size));
       auto count = rounded_size >> SUPERSLAB_BITS;
-      global_pagemap.set_range((void*)p, PMNotOurs, count);
+      pagemap.set_range((void*)p, PMNotOurs, count);
     }
 
   private:
@@ -147,7 +149,7 @@ namespace snmalloc
      */
     void set(void* p, uint8_t x)
     {
-      global_pagemap.set(p, x);
+      pagemap.set(p, x);
     }
   };
 

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -4,12 +4,6 @@
 
 namespace snmalloc
 {
-  enum ZeroMem
-  {
-    NoZero,
-    YesZero
-  };
-
   // 0 intermediate bits results in power of 2 small allocs. 1 intermediate
   // bit gives additional sizeclasses at the midpoint between each power of 2.
   // 2 intermediate bits gives 3 intermediate sizeclasses, etc.

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -348,5 +348,4 @@ namespace snmalloc
       } while (length > 0);
     }
   };
-
 }

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -220,7 +220,7 @@ namespace snmalloc
     {
       if (
         (c->version != 1) || (c->is_flat_pagemap) ||
-        (c->sizeof_pointer == sizeof(void*)) ||
+        (c->sizeof_pointer != sizeof(void*)) ||
         (c->pagemap_bits != GRANULARITY_BITS) ||
         (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
       {
@@ -325,7 +325,7 @@ namespace snmalloc
     {
       if (
         (c->version != 1) || (!c->is_flat_pagemap) ||
-        (c->sizeof_pointer == sizeof(void*)) ||
+        (c->sizeof_pointer != sizeof(void*)) ||
         (c->pagemap_bits != GRANULARITY_BITS) ||
         (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
       {

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -10,6 +10,36 @@ namespace snmalloc
   static constexpr size_t PAGEMAP_NODE_BITS = 16;
   static constexpr size_t PAGEMAP_NODE_SIZE = 1ULL << PAGEMAP_NODE_BITS;
 
+  /**
+   * Structure describing the configuration of a pagemap.  When querying a
+   * pagemap from a different instantiation of snmalloc, the pagemap is exposed
+   * as a `void*`.  This structure allows the caller to check whether the
+   * pagemap is of the format that they expect.
+   */
+  struct PagemapConfig
+  {
+    /**
+     * The version of the pagemap structure.  This is always 1 in existing
+     * versions of snmalloc.  This will be incremented every time the format
+     * changes in an incompatible way.  Changes to the format may add fields to
+     * the end of this structure.
+     */
+    uint32_t version;
+    /**
+     * Is this a flat pagemap?  If this field is false, the pagemap is the
+     * hierarchical structure.
+     */
+    bool is_flat_pagemap;
+    /**
+     * The number of bits of the address used to index into the pagemap.
+     */
+    uint64_t pagemap_bits;
+    /**
+     * The size (in bytes) of a pagemap entry.
+     */
+    size_t size_of_entry;
+  };
+
   template<size_t GRANULARITY_BITS, typename T, T default_content>
   class Pagemap
   {
@@ -168,6 +198,19 @@ namespace snmalloc
     }
 
   public:
+    static constexpr PagemapConfig config = {
+      1, false, GRANULARITY_BITS, sizeof(T)};
+    static Pagemap* cast_to_pagemap(void* pm, const PagemapConfig* c)
+    {
+      if (
+        (c->version != 1) || (c->is_flat_pagemap) ||
+        (c->pagemap_bits != GRANULARITY_BITS) ||
+        (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
+      {
+        return nullptr;
+      }
+      return static_cast<Pagemap*>(pm);
+    }
     /**
      * Returns the index of a pagemap entry within a given page.  This is used
      * in code that propagates changes to the pagemap elsewhere.
@@ -247,6 +290,20 @@ namespace snmalloc
     std::atomic<T> top[ENTRIES];
 
   public:
+    static constexpr PagemapConfig config = {
+      1, true, GRANULARITY_BITS, sizeof(T)};
+
+    static FlatPagemap* cast_to_pagemap(void* pm, PagemapConfig* c)
+    {
+      if (
+        (c->version != 1) || (!c->is_flat_pagemap) ||
+        (c->pagemap_bits != GRANULARITY_BITS) ||
+        (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
+      {
+        return nullptr;
+      }
+      return static_cast<FlatPagemap*>(pm);
+    }
     T get(void* p)
     {
       return top[(size_t)p >> SHIFT].load(std::memory_order_relaxed);
@@ -268,4 +325,5 @@ namespace snmalloc
       } while (length > 0);
     }
   };
+
 }

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -316,7 +316,7 @@ namespace snmalloc
      * This intended to allow code that depends on the pagemap having a
      * specific representation to fail gracefully.
      */
-    static FlatPagemap* cast_to_pagemap(void* pm, PagemapConfig* c)
+    static FlatPagemap* cast_to_pagemap(void* pm, const PagemapConfig* c)
     {
       if (
         (c->version != 1) || (!c->is_flat_pagemap) ||

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -31,6 +31,10 @@ namespace snmalloc
      */
     bool is_flat_pagemap;
     /**
+     * Number of bytes in a pointer.
+     */
+    uint8_t sizeof_pointer;
+    /**
      * The number of bits of the address used to index into the pagemap.
      */
     uint64_t pagemap_bits;
@@ -202,7 +206,7 @@ namespace snmalloc
      * The pagemap configuration describing this instantiation of the template.
      */
     static constexpr PagemapConfig config = {
-      1, false, GRANULARITY_BITS, sizeof(T)};
+      1, false, sizeof(void*), GRANULARITY_BITS, sizeof(T)};
 
     /**
      * Cast a `void*` to a pointer to this template instantiation, given a
@@ -216,6 +220,7 @@ namespace snmalloc
     {
       if (
         (c->version != 1) || (c->is_flat_pagemap) ||
+        (c->sizeof_pointer == sizeof(void*)) ||
         (c->pagemap_bits != GRANULARITY_BITS) ||
         (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
       {
@@ -306,7 +311,7 @@ namespace snmalloc
      * The pagemap configuration describing this instantiation of the template.
      */
     static constexpr PagemapConfig config = {
-      1, true, GRANULARITY_BITS, sizeof(T)};
+      1, true, sizeof(void*), GRANULARITY_BITS, sizeof(T)};
 
     /**
      * Cast a `void*` to a pointer to this template instantiation, given a
@@ -320,6 +325,7 @@ namespace snmalloc
     {
       if (
         (c->version != 1) || (!c->is_flat_pagemap) ||
+        (c->sizeof_pointer == sizeof(void*)) ||
         (c->pagemap_bits != GRANULARITY_BITS) ||
         (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
       {

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -198,8 +198,20 @@ namespace snmalloc
     }
 
   public:
+    /**
+     * The pagemap configuration describing this instantiation of the template.
+     */
     static constexpr PagemapConfig config = {
       1, false, GRANULARITY_BITS, sizeof(T)};
+
+    /**
+     * Cast a `void*` to a pointer to this template instantiation, given a
+     * config describing the configuration.  Return null if the configuration
+     * passed does not correspond to this template instantiation.
+     *
+     * This intended to allow code that depends on the pagemap having a
+     * specific representation to fail gracefully.
+     */
     static Pagemap* cast_to_pagemap(void* pm, const PagemapConfig* c)
     {
       if (
@@ -290,9 +302,20 @@ namespace snmalloc
     std::atomic<T> top[ENTRIES];
 
   public:
+    /**
+     * The pagemap configuration describing this instantiation of the template.
+     */
     static constexpr PagemapConfig config = {
       1, true, GRANULARITY_BITS, sizeof(T)};
 
+    /**
+     * Cast a `void*` to a pointer to this template instantiation, given a
+     * config describing the configuration.  Return null if the configuration
+     * passed does not correspond to this template instantiation.
+     *
+     * This intended to allow code that depends on the pagemap having a
+     * specific representation to fail gracefully.
+     */
     static FlatPagemap* cast_to_pagemap(void* pm, PagemapConfig* c)
     {
       if (

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -214,7 +214,7 @@ extern "C"
    * this function to the correct type.  This allows us to preserve some
    * semblance of ABI safety via a pure C API.
    */
-  SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_get_global_pagemap)(
+  SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_pagemap_global_get)(
     PagemapConfig const** config)
   {
     if (config)

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -206,8 +206,16 @@ extern "C"
   }
 
 #ifdef SNMALLOC_EXPOSE_PAGEMAP
-  SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_get_global_pagemap)(void)
+  SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_get_global_pagemap)(
+    PagemapConfig const** config)
   {
+    if (config)
+    {
+      *config = &decltype(snmalloc::global_pagemap)::config;
+      assert(
+        decltype(snmalloc::global_pagemap)::cast_to_pagemap(
+          &snmalloc::global_pagemap, *config) == &snmalloc::global_pagemap);
+    }
     return &snmalloc::global_pagemap;
   }
 #endif

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -206,6 +206,14 @@ extern "C"
   }
 
 #ifdef SNMALLOC_EXPOSE_PAGEMAP
+  /**
+   * Export the pagemap.  The return value is a pointer to the pagemap
+   * structure.  The argument is used to return a pointer to a `PagemapConfig`
+   * structure describing the type of the pagemap.  Static methods on the
+   * concrete pagemap templates can then be used to safely cast the return from
+   * this function to the correct type.  This allows us to preserve some
+   * semblance of ABI safety via a pure C API.
+   */
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_get_global_pagemap)(
     PagemapConfig const** config)
   {

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -1,3 +1,5 @@
+#pragma once
+
 namespace snmalloc
 {
   /**

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -27,4 +27,19 @@ namespace snmalloc
      */
     AlignedAllocation = (1 << 1)
   };
+  /**
+   * Flag indicating whether requested memory should be zeroed.
+   */
+  enum ZeroMem
+  {
+    /**
+     * Memory should not be zeroed, contents are undefined.
+     */
+    NoZero,
+    /**
+     * Memory must be zeroed.  This can be lazily allocated via a copy-on-write
+     * mechanism as long as any load from the memory returns zero.
+     */
+    YesZero
+  };
 }

--- a/src/test/func/two_alloc_types/alloc1.cc
+++ b/src/test/func/two_alloc_types/alloc1.cc
@@ -4,6 +4,7 @@
 #define USE_RESERVE_MULTIPLE 1
 #define NO_BOOTSTRAP_ALLOCATOR
 #define IS_ADDRESS_SPACE_CONSTRAINED
+#define SNMALLOC_EXPOSE_PAGEMAP
 #define SNMALLOC_NAME_MANGLE(a) enclave_##a
 // Redefine the namespace, so we can have two versions.
 #define snmalloc snmalloc_enclave

--- a/src/test/func/two_alloc_types/alloc2.cc
+++ b/src/test/func/two_alloc_types/alloc2.cc
@@ -1,6 +1,7 @@
 #undef IS_ADDRESS_SPACE_CONSTRAINED
 #define SNMALLOC_NAME_MANGLE(a) host_##a
 #define NO_BOOTSTRAP_ALLOCATOR
+#define SNMALLOC_EXPOSE_PAGEMAP
 // Redefine the namespace, so we can have two versions.
 #define snmalloc snmalloc_host
 #include "../../../override/malloc.cc"

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -48,7 +48,7 @@ int main()
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.
-  PagemapConfig *c;
+  const PagemapConfig *c;
   enclave_snmalloc_pagemap_global_get(&c);
   host_snmalloc_pagemap_global_get(&c);
 

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -32,6 +32,11 @@ extern "C" void host_free(void*);
 extern "C" void* enclave_malloc(size_t);
 extern "C" void enclave_free(void*);
 
+extern "C" void*
+enclave_snmalloc_get_global_pagemap(snmalloc::PagemapConfig const**);
+extern "C" void*
+host_snmalloc_get_global_pagemap(snmalloc::PagemapConfig const**);
+
 using namespace snmalloc;
 int main()
 {
@@ -41,6 +46,10 @@ int main()
   oe_base = mp.reserve<true>(&size, 1);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
+
+  // Call these functions to trigger asserts if the cast-to-self doesn't work.
+  enclave_snmalloc_get_global_pagemap(nullptr);
+  host_snmalloc_get_global_pagemap(nullptr);
 
   auto a = host_malloc(128);
   auto b = enclave_malloc(128);

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -48,7 +48,7 @@ int main()
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.
-  const PagemapConfig *c;
+  const PagemapConfig* c;
   enclave_snmalloc_pagemap_global_get(&c);
   host_snmalloc_pagemap_global_get(&c);
 

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -48,8 +48,9 @@ int main()
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.
-  enclave_snmalloc_pagemap_global_get(nullptr);
-  host_snmalloc_pagemap_global_get(nullptr);
+  PagemapConfig *c;
+  enclave_snmalloc_pagemap_global_get(&c);
+  host_snmalloc_pagemap_global_get(&c);
 
   auto a = host_malloc(128);
   auto b = enclave_malloc(128);

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -33,9 +33,9 @@ extern "C" void* enclave_malloc(size_t);
 extern "C" void enclave_free(void*);
 
 extern "C" void*
-enclave_snmalloc_get_global_pagemap(snmalloc::PagemapConfig const**);
+enclave_snmalloc_pagemap_global_get(snmalloc::PagemapConfig const**);
 extern "C" void*
-host_snmalloc_get_global_pagemap(snmalloc::PagemapConfig const**);
+host_snmalloc_pagemap_global_get(snmalloc::PagemapConfig const**);
 
 using namespace snmalloc;
 int main()
@@ -48,8 +48,8 @@ int main()
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.
-  enclave_snmalloc_get_global_pagemap(nullptr);
-  host_snmalloc_get_global_pagemap(nullptr);
+  enclave_snmalloc_pagemap_global_get(nullptr);
+  host_snmalloc_pagemap_global_get(nullptr);
 
   auto a = host_malloc(128);
   auto b = enclave_malloc(128);


### PR DESCRIPTION
Now that we have a function for finding the pagemap that we can use across shared libraries, modify it to do some type checking and make some of the other code more resilient to importing a pagemap from a library without pulling in the symbol.