### PR TITLE
Add an explicit invalid pointer type.

### DIFF
--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -19,7 +19,7 @@ namespace snmalloc
     }
   };
 
-  using SlabList = DLList<SlabLink, UINTPTR_MAX>;
+  using SlabList = DLList<SlabLink, InvalidPointer<UINTPTR_MAX>>;
 
   static_assert(
     sizeof(SlabLink) <= MIN_ALLOC_SIZE,


### PR DESCRIPTION
This is a generalisation of `std::nullptr_t` that allows non-0 values of
pointer-sized-but-not-a-pointer thing.  `DLList` now takes an
`InvalidPointer`, `nullptr_t`, or some other compatible class as a
sentinel value instead of a `uintptr_t`.