### PR TITLE
Use get_noncachable in malloc/new overrides.

### DIFF
--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -23,12 +23,12 @@ extern "C"
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(malloc)(size_t size)
   {
-    return ThreadAlloc::get()->alloc(size);
+    return ThreadAlloc::get_noncachable()->alloc(size);
   }
 
   SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free)(void* ptr)
   {
-    ThreadAlloc::get()->dealloc(ptr);
+    ThreadAlloc::get_noncachable()->dealloc(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(calloc)(size_t nmemb, size_t size)
@@ -40,7 +40,7 @@ extern "C"
       errno = ENOMEM;
       return nullptr;
     }
-    return ThreadAlloc::get()->alloc<ZeroMem::YesZero>(sz);
+    return ThreadAlloc::get_noncachable()->alloc<ZeroMem::YesZero>(sz);
   }
 
   SNMALLOC_EXPORT size_t SNMALLOC_NAME_MANGLE(malloc_usable_size)(void* ptr)

--- a/src/override/new.cc
+++ b/src/override/new.cc
@@ -18,50 +18,50 @@ using namespace snmalloc;
 
 void* operator new(size_t size)
 {
-  return ThreadAlloc::get()->alloc(size);
+  return ThreadAlloc::get_noncachable()->alloc(size);
 }
 
 void* operator new[](size_t size)
 {
-  return ThreadAlloc::get()->alloc(size);
+  return ThreadAlloc::get_noncachable()->alloc(size);
 }
 
 void* operator new(size_t size, std::nothrow_t&)
 {
-  return ThreadAlloc::get()->alloc(size);
+  return ThreadAlloc::get_noncachable()->alloc(size);
 }
 
 void* operator new[](size_t size, std::nothrow_t&)
 {
-  return ThreadAlloc::get()->alloc(size);
+  return ThreadAlloc::get_noncachable()->alloc(size);
 }
 
 void operator delete(void* p)EXCEPTSPEC
 {
-  ThreadAlloc::get()->dealloc(p);
+  ThreadAlloc::get_noncachable()->dealloc(p);
 }
 
 void operator delete(void* p, size_t size)EXCEPTSPEC
 {
-  ThreadAlloc::get()->dealloc(p, size);
+  ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 
 void operator delete(void* p, std::nothrow_t&)
 {
-  ThreadAlloc::get()->dealloc(p);
+  ThreadAlloc::get_noncachable()->dealloc(p);
 }
 
 void operator delete[](void* p) EXCEPTSPEC
 {
-  ThreadAlloc::get()->dealloc(p);
+  ThreadAlloc::get_noncachable()->dealloc(p);
 }
 
 void operator delete[](void* p, size_t size) EXCEPTSPEC
 {
-  ThreadAlloc::get()->dealloc(p, size);
+  ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 
 void operator delete[](void* p, std::nothrow_t&)
 {
-  ThreadAlloc::get()->dealloc(p);
+  ThreadAlloc::get_noncachable()->dealloc(p);
 }


### PR DESCRIPTION
This may return the GlobalPlaceholder, in which case the slow path will
be used, initializing the real thread local allocator.