### PR TITLE
Make the pagemap global typed.

### DIFF
--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -210,14 +210,13 @@ extern "C"
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_pagemap_global_get)(
     PagemapConfig const** config)
   {
+    auto& pm = GlobalPagemap::pagemap();
     if (config)
     {
-      *config = &decltype(snmalloc::global_pagemap)::config;
-      assert(
-        decltype(snmalloc::global_pagemap)::cast_to_pagemap(
-          &snmalloc::global_pagemap, *config) == &snmalloc::global_pagemap);
+      *config = &SuperslabPagemap::config;
+      assert(SuperslabPagemap::cast_to_pagemap(&pm, *config) == &pm);
     }
-    return &snmalloc::global_pagemap;
+    return &pm;
   }
 #endif
 


### PR DESCRIPTION
The pagemap global is now an inline static of a template class, so that
we will see different symbols for the different types.

Issue #84 showed that it's possible to compile two compilation units
with different pagemaps, link them together, and have them attempt to
interpret the global pagemap as two different types.  This change should
make that impossible.

Also make the `pagemap()` function static so that it can be used from
static functions, avoiding other things that directly reference the
global pagemap.