### PR TITLE
Modified pass through

### DIFF
--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -125,11 +125,15 @@ namespace snmalloc
      */
     static SNMALLOC_FAST_PATH Alloc* get()
     {
+#ifdef USE_MALLOC
+      return get_reference();
+#else
       auto alloc = get_reference();
       auto new_alloc = lazy_replacement(alloc);
       return (likely(new_alloc == nullptr)) ?
         alloc :
         reinterpret_cast<Alloc*>(new_alloc);
+#endif
     }
   };
 


### PR DESCRIPTION
If we are using USE_MALLOC pass through, then ThreadAlloc::get() can
cause an allocation inside snmalloc still, as it builds the thread
local allocator, which allocs a single stub allocation, using
the underlying allocator. This means that ASAN would detect a
leak in a client, even though the client program has none.

This change stops us ever allocating allocators, if we are passing
through calls to an underlying allocator.