### PR TITLE
Memory leak

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -911,7 +911,7 @@ namespace snmalloc
         while (prev != nullptr)
         {
           auto n = Metaslab::follow_next(prev);
-          dealloc(prev);
+          dealloc(remove_cache_friendly_offset(prev, i));
           prev = n;
         }
 

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -917,9 +917,9 @@ namespace snmalloc
         test(small_classes[i].is_empty());
       }
 
-      for (size_t i = 0; i < NUM_MEDIUM_CLASSES; i++)
+      for (auto & medium_class : medium_classes)
       {
-        test(medium_classes[i].is_empty());
+        test(medium_class.is_empty());
       }
 
       test(super_available.is_empty());

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -918,7 +918,7 @@ namespace snmalloc
         test(small_classes[i]);
       }
 
-      for (auto & medium_class : medium_classes)
+      for (auto& medium_class : medium_classes)
       {
         test(medium_class);
       }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -876,15 +876,16 @@ namespace snmalloc
     }
 
     /**
-     * If result parameter is non-null, then is_empty is passsed into the
-     * the location pointed to by result.
+     * If result parameter is non-null, then false is assigned into the
+     * the location pointed to by result if this allocator is non-empty.
      *
-     * Otherwise, asserts that it is empty.
+     * If result pointer is null, then this code raises a Pal::error on the
+     * particular check that fails, if any do fail.
      **/
     void debug_is_empty(bool* result)
     {
-      auto test = [&result](bool value) {
-        if (!value)
+      auto test = [&result](auto& queue) {
+        if (!queue.is_empty())
         {
           if (result != nullptr)
             *result = false;
@@ -914,16 +915,16 @@ namespace snmalloc
           prev = n;
         }
 
-        test(small_classes[i].is_empty());
+        test(small_classes[i]);
       }
 
       for (auto & medium_class : medium_classes)
       {
-        test(medium_class.is_empty());
+        test(medium_class);
       }
 
-      test(super_available.is_empty());
-      test(super_only_short_available.is_empty());
+      test(super_available);
+      test(super_only_short_available);
 
       // Place the static stub message on the queue.
       init_message_queue();

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1084,7 +1084,12 @@ namespace snmalloc
 
       SNMALLOC_ASSUME(size <= SLAB_SIZE);
       sizeclass_t sizeclass = size_to_sizeclass(size);
+      return small_alloc_inner<zero_mem, allow_reserve>(sizeclass);
+    }
 
+    template<ZeroMem zero_mem, AllowReserve allow_reserve>
+    SNMALLOC_FAST_PATH void* small_alloc_inner(sizeclass_t sizeclass)
+    {
       assert(sizeclass < NUM_SMALL_CLASSES);
       auto& fl = small_fast_free_lists[sizeclass];
       void* head = fl.value;
@@ -1097,7 +1102,7 @@ namespace snmalloc
         void* p = remove_cache_friendly_offset(head, sizeclass);
         if constexpr (zero_mem == YesZero)
         {
-          large_allocator.memory_provider.zero(p, size);
+          large_allocator.memory_provider.zero(p, sizeclass_to_size(sizeclass));
         }
         return p;
       }


### PR DESCRIPTION
This PR does
* Fix a memory leak during allocator creation, if the first allocation is the same size as the message queue stub;
* Provides a more resilient debug_check_empty, that does not depend on statistics being enabled. 