### PR TITLE
Code quality for `free`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,6 +203,7 @@ jobs:
 
   - script: |
       make clangformat
+      git diff
       if [ "$(git diff $(Build.SourceVersion))" != "" ]; then exit 1; fi
 
     workingDirectory: build

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -484,7 +484,7 @@ namespace snmalloc
       if (likely(size == PMSuperslab))
       {
         RemoteAllocator* target = super->get_allocator();
-        Slab* slab = Slab::get(p);
+        Slab* slab = Metaslab::get_slab(p);
         Metaslab& meta = super->get_meta(slab);
 
         // Reading a remote sizeclass won't fail, since the other allocator
@@ -552,7 +552,7 @@ namespace snmalloc
       Superslab* super = Superslab::get(p);
       if (size == PMSuperslab)
       {
-        Slab* slab = Slab::get(p);
+        Slab* slab = Metaslab::get_slab(p);
         Metaslab& meta = super->get_meta(slab);
 
         sizeclass_t sc = meta.sizeclass;
@@ -621,7 +621,7 @@ namespace snmalloc
 
         // Reading a remote sizeclass won't fail, since the other allocator
         // can't reuse the slab, as we have no yet deallocated this pointer.
-        Slab* slab = Slab::get(p);
+        Slab* slab = Metaslab::get_slab(p);
         Metaslab& meta = super->get_meta(slab);
 
         return sizeclass_to_size(meta.sizeclass);
@@ -968,7 +968,7 @@ namespace snmalloc
 #endif
       if (likely(super->get_kind() == Super))
       {
-        Slab* slab = Slab::get(p);
+        Slab* slab = Metaslab::get_slab(p);
         Metaslab& meta = super->get_meta(slab);
         if (likely(p->target_id() == id()))
         {
@@ -1000,7 +1000,7 @@ namespace snmalloc
       else
       {
         assert(likely(p->target_id() != id()));
-        Slab* slab = Slab::get(p);
+        Slab* slab = Metaslab::get_slab(p);
         Metaslab& meta = super->get_meta(slab);
         // Queue for remote dealloc elsewhere.
         remote.dealloc(p->target_id(), p, meta.sizeclass);
@@ -1210,7 +1210,7 @@ namespace snmalloc
     small_dealloc(Superslab* super, void* p, sizeclass_t sizeclass)
     {
 #ifdef CHECK_CLIENT
-      Slab* slab = Slab::get(p);
+      Slab* slab = Metaslab::get_slab(p);
       if (!slab->is_start_of_object(super, p))
       {
         error("Not deallocating start of an object");
@@ -1233,7 +1233,7 @@ namespace snmalloc
     SNMALLOC_FAST_PATH void small_dealloc_offseted_inner(
       Superslab* super, void* p, sizeclass_t sizeclass)
     {
-      Slab* slab = Slab::get(p);
+      Slab* slab = Metaslab::get_slab(p);
       if (likely(slab->dealloc_fast(super, p)))
         return;
 
@@ -1245,7 +1245,7 @@ namespace snmalloc
     {
       bool was_full = super->is_full();
       SlabList* sl = &small_classes[sizeclass];
-      Slab* slab = Slab::get(p);
+      Slab* slab = Metaslab::get_slab(p);
       Superslab::Action a =
         slab->dealloc_slow(sl, super, p, large_allocator.memory_provider);
       if (likely(a == Superslab::NoSlabReturn))

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -33,7 +33,7 @@ namespace snmalloc
     /**
      *  Pointer to first free entry in this slab
      *
-     *  The list will (allocated - needed - 1) long. The -1 is
+     *  The list will be (allocated - needed - 1) long. The -1 is
      *  for the `link` element which is not in the free list.
      */
     void* head;
@@ -145,6 +145,11 @@ namespace snmalloc
       return pointer_cast<Slab>(address_cast(p) & SLAB_MASK);
     }
 
+    static bool is_short(Slab* p)
+    {
+      return (address_cast(p) & SUPERSLAB_MASK) == address_cast(p);
+    }
+
     /**
      * Check bump-free-list-segment for cycles
      *
@@ -187,9 +192,11 @@ namespace snmalloc
 #endif
     }
 
-    void debug_slab_invariant(bool is_short, Slab* slab)
+    void debug_slab_invariant(Slab* slab)
     {
 #if !defined(NDEBUG) && !defined(SNMALLOC_CHEAP_CHECKS)
+      bool is_short = Metaslab::is_short(slab);
+
       if (is_full())
       {
         // There is no free list to validate
@@ -252,7 +259,6 @@ namespace snmalloc
       assert(SLAB_SIZE == accounted_for);
 #else
       UNUSED(slab);
-      UNUSED(is_short);
 #endif
     }
   };

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -61,14 +61,15 @@ namespace snmalloc
       used++;
     }
 
-    void sub_use()
+    /**
+     * Removes a use, if the slab is either
+     *  - empty after removing the use, or
+     *  - was full before the substraction
+     * this returns true, otherwise returns false.
+     **/
+    bool sub_use()
     {
-      used--;
-    }
-
-    void set_unused()
-    {
-      used = 0;
+      return (--used) == 0;
     }
 
     bool is_unused()
@@ -78,7 +79,9 @@ namespace snmalloc
 
     bool is_full()
     {
-      return link == 1;
+      auto result = link == 1;
+      assert(!result || head == 1);
+      return result;
     }
 
     void set_full()
@@ -86,6 +89,9 @@ namespace snmalloc
       assert(head == 1);
       assert(link != 1);
       link = 1;
+      // Set used to 1, so that "sub_use" will return true after calling
+      // set_full
+      used = 1;
     }
 
     SlabLink* get_link(Slab* slab)
@@ -175,22 +181,20 @@ namespace snmalloc
     void debug_slab_invariant(bool is_short, Slab* slab)
     {
 #if !defined(NDEBUG) && !defined(SNMALLOC_CHEAP_CHECKS)
-      size_t size = sizeclass_to_size(sizeclass);
-      size_t offset = get_initial_offset(sizeclass, is_short);
-
-      if (is_unused())
-        return;
-
-      size_t accounted_for = used * size + offset;
-
       if (is_full())
       {
-        // All the blocks must be used.
-        assert(SLAB_SIZE == accounted_for);
         // There is no free list to validate
         // 'link' value is not important if full.
         return;
       }
+
+      if (is_unused())
+        return;
+
+      size_t size = sizeclass_to_size(sizeclass);
+      size_t offset = get_initial_offset(sizeclass, is_short);
+      size_t accounted_for = used * size + offset;
+
 
       // Block is not full
       assert(SLAB_SIZE > accounted_for);

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -8,6 +8,7 @@ namespace snmalloc
   // We use size_t as it generates better code.
   using sizeclass_t = size_t;
   //  using sizeclass_t = uint8_t;
+  using sizeclass_compress_t = uint8_t;
 
   constexpr static uint16_t get_initial_offset(sizeclass_t sc, bool is_short);
   constexpr static size_t sizeclass_to_size(sizeclass_t sizeclass);

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -153,8 +153,8 @@ namespace snmalloc
     return p = (void*)((uintptr_t)p & mask);
   }
 
-  SNMALLOC_FAST_PATH static uint16_t
-  remove_cache_friendly_offset(uint16_t relative, sizeclass_t sizeclass)
+  SNMALLOC_FAST_PATH static uintptr_t
+  remove_cache_friendly_offset(uintptr_t relative, sizeclass_t sizeclass)
   {
     size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
     return relative & mask;
@@ -167,8 +167,8 @@ namespace snmalloc
     return p;
   }
 
-  SNMALLOC_FAST_PATH static uint16_t
-  remove_cache_friendly_offset(uint16_t relative, sizeclass_t sizeclass)
+  SNMALLOC_FAST_PATH static uintptr_t
+  remove_cache_friendly_offset(uintptr_t relative, sizeclass_t sizeclass)
   {
     UNUSED(sizeclass);
     return relative;

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -43,7 +43,7 @@ namespace snmalloc
       void* head = meta.head;
 
       assert(rsize == sizeclass_to_size(meta.sizeclass));
-      meta.debug_slab_invariant(is_short(), this);
+      meta.debug_slab_invariant(this);
       assert(sl.get_head() == (SlabLink*)((size_t)this + meta.link));
       assert(!meta.is_full());
 
@@ -127,7 +127,7 @@ namespace snmalloc
 
       assert(is_start_of_object(Superslab::get(p), p));
 
-      meta.debug_slab_invariant(is_short(), this);
+      meta.debug_slab_invariant(this);
 
       if constexpr (zero_mem == YesZero)
       {
@@ -158,7 +158,7 @@ namespace snmalloc
       if (meta.is_unused())
         error("Detected potential double free.");
 #endif
-      meta.debug_slab_invariant(is_short(), this);
+      meta.debug_slab_invariant(this);
 
       if (unlikely(meta.return_object()))
         return false;
@@ -172,7 +172,7 @@ namespace snmalloc
 
       // Set the next pointer to the previous head.
       Metaslab::store_next(p, head);
-      meta.debug_slab_invariant(is_short(), this);
+      meta.debug_slab_invariant(this);
       return true;
     }
 
@@ -206,7 +206,7 @@ namespace snmalloc
 
         // Push on the list of slabs for this sizeclass.
         sl->insert_back(meta.get_link(this));
-        meta.debug_slab_invariant(is_short(), this);
+        meta.debug_slab_invariant(this);
         return Superslab::NoSlabReturn;
       }
 
@@ -218,10 +218,9 @@ namespace snmalloc
 
       return super->dealloc_slab(this, memory_provider);
     }
-
     bool is_short()
     {
-      return (address_cast(this) & SUPERSLAB_MASK) == address_cast(this);
+      return Metaslab::is_short(this);
     }
   };
 } // namespace snmalloc

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -161,7 +161,7 @@ namespace snmalloc
         return alloc_slab(sizeclass, memory_provider);
 
       meta[0].allocated = 1;
-      meta[0].head = 1;
+      meta[0].head = nullptr;
       meta[0].sizeclass = static_cast<uint8_t>(sizeclass);
       meta[0].link = get_initial_offset(sizeclass, true);
 
@@ -183,7 +183,7 @@ namespace snmalloc
 
       uint8_t n = meta[h].next;
 
-      meta[h].head = 1;
+      meta[h].head = nullptr;
       meta[h].allocated = 1;
       meta[h].sizeclass = static_cast<uint8_t>(sizeclass);
       meta[h].link = get_initial_offset(sizeclass, false);


### PR DESCRIPTION
These two changes reduce the fast path for deallocation from 34 instructions on Linux with Clang to 25 instructions.  There are two key changes
* When a slab is full, set its 'used' count to 1.  This allows the detecting leaving full, and entering empty to be the same check.
* Expand the meta-data to contain a full pointer to the free list, not a relative 16 bit pointer.  This reduces the arithmetic required on the fast path. 