### PR TITLE
DNM WIP: CHERIfy via PAL

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -46,7 +46,7 @@ namespace snmalloc
      */
     static inline uint64_t tick()
     {
-#if __has_builtin(__builtin_readcyclecounter) && \
+#if __has_builtin(__builtin_readcyclecounter) && !defined(__CHERI__) && \
   !defined(SNMALLOC_NO_AAL_BUILTINS)
       return __builtin_readcyclecounter();
 #else
@@ -59,6 +59,8 @@ namespace snmalloc
 
 #ifdef PLATFORM_IS_X86
 #  include "aal_x86.h"
+#elif defined(__CHERI__) && defined(__mips__)
+#  include "aal_cheri_mips.h"
 #endif
 
 namespace snmalloc

--- a/src/aal/aal_cheri_mips.h
+++ b/src/aal/aal_cheri_mips.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#define SNMALLOC_VA_BITS_64
+
+extern "C"
+{
+#include <machine/cheri.h>
+}
+
+namespace snmalloc
+{
+  /**
+   * CHERI-MIPS specific architecture abstraction layer.
+   */
+  class AAL_CHERI_MIPS
+  {
+    static inline void halt_out_of_order()
+    {
+      static unsigned st;
+      __sync_swap(&st, 0); // XXX: Overkill!
+    }
+
+    static inline uint64_t tickp()
+    {
+      static unsigned st;
+      __sync_swap(&st, 0); // XXX: Overkill!
+      return cheri_get_cyclecount();
+    }
+
+  public:
+    static inline void pause()
+    {
+      ;
+      /*
+       * XXX the PAUSE instruction could be correct or not, depending on the
+       * implementation details of std::atomic_flag and other callers.
+       *
+       * For PAUSE to be
+       * correct, .test_and_set must exit with the LL flag still set and
+       * .clear must store to the same word probed by test_and_set.  It
+       * seems like these will be true, but they are doubtless not required
+       * to be so.
+       */
+    }
+
+    static inline void prefetch(void* p)
+    {
+      __builtin_prefetch(p, 0, 3);
+    }
+
+    static inline uint64_t tick()
+    {
+      return cheri_get_cyclecount();
+    }
+
+    static inline uint64_t benchmark_time_start()
+    {
+      halt_out_of_order();
+      return AAL_Generic<AAL_CHERI_MIPS>::tick();
+    }
+
+    static inline uint64_t benchmark_time_end()
+    {
+      uint64_t t = AAL_Generic<AAL_CHERI_MIPS>::tickp();
+      halt_out_of_order();
+      return t;
+    }
+  };
+
+  using AAL_Arch = AAL_CHERI_MIPS;
+}

--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -52,8 +52,6 @@ namespace snmalloc
       return (static_cast<T>(1)) << shift;
     }
 
-    static constexpr size_t ADDRESS_BITS = is64() ? 48 : 32;
-
     inline size_t clz(size_t x)
     {
 #if defined(_MSC_VER)

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -203,6 +203,7 @@ namespace snmalloc
 #else
 
       constexpr sizeclass_t sizeclass = size_to_sizeclass_const(size);
+      p = chunkmap().getp(p);
 
       handle_message_queue();
 
@@ -246,6 +247,7 @@ namespace snmalloc
       handle_message_queue();
 
       sizeclass_t sizeclass = size_to_sizeclass(size);
+      p = chunkmap().getp(p);
 
       if (sizeclass < NUM_SMALL_CLASSES)
       {
@@ -285,6 +287,7 @@ namespace snmalloc
 #else
 
       uint8_t size = chunkmap().get(address_cast(p));
+      p = chunkmap().getp(p);
 
       Superslab* super = Superslab::get(p);
 

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -110,8 +110,9 @@ namespace snmalloc
 #endif
 
   // Minimum allocation size is space for two pointers.
-  static constexpr size_t MIN_ALLOC_BITS = bits::is64() ? 4 : 3;
-  static constexpr size_t MIN_ALLOC_SIZE = 1 << MIN_ALLOC_BITS;
+  static_assert(bits::next_pow2_const(sizeof(void*)) == sizeof(void*));
+  static constexpr size_t MIN_ALLOC_SIZE = 2 * sizeof(void*);
+  static constexpr size_t MIN_ALLOC_BITS = bits::ctz_const(MIN_ALLOC_SIZE);
 
   // Slabs are 64 KiB unless constrained to 16 KiB.
   static constexpr size_t SLAB_BITS = ADDRESS_SPACE_CONSTRAINED ? 14 : 16;

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -122,7 +122,7 @@ namespace snmalloc
     static constexpr size_t BUCKETS = 1 << BUCKETS_BITS;
     static constexpr size_t TOTAL_BUCKETS =
       bits::to_exp_mant_const<BUCKETS_BITS>(
-        bits::one_at_bit(bits::ADDRESS_BITS - 1));
+        bits::one_at_bit(Pal::ADDRESS_BITS - 1));
 
     Stats sizeclass[N];
     Stats large[LARGE_N];

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -141,7 +141,7 @@ namespace snmalloc
    * implementation (for example, to move pagemap updates to a different
    * protection domain).
    */
-  template<typename PagemapProvider = GlobalPagemap>
+  template<typename PagemapProvider>
   struct DefaultChunkMap
   {
     /**
@@ -238,7 +238,7 @@ namespace snmalloc
   };
 
 #ifndef SNMALLOC_DEFAULT_CHUNKMAP
-#  define SNMALLOC_DEFAULT_CHUNKMAP snmalloc::DefaultChunkMap<>
+#  define SNMALLOC_DEFAULT_CHUNKMAP snmalloc::Pal::PalChunkMap<GlobalPagemap>
 #endif
 
 } // namespace snmalloc

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -142,12 +142,12 @@ namespace snmalloc
 
     static Slab* get_slab(void* p)
     {
-      return pointer_cast<Slab>(address_cast(p) & SLAB_MASK);
+      return pointer_align_down<SLAB_SIZE, Slab>(p);
     }
 
     static bool is_short(Slab* p)
     {
-      return (address_cast(p) & SUPERSLAB_MASK) == address_cast(p);
+      return pointer_align_down<SUPERSLAB_SIZE>(p) == p;
     }
 
     /**

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -109,7 +109,7 @@ namespace snmalloc
     /// simple corruptions.
     static SNMALLOC_FAST_PATH void store_next(void* p, void* head)
     {
-#ifndef CHECK_CLIENT
+#if !defined(CHECK_CLIENT) || defined(__CHERI_PURE_CAPABILITY__)
       *static_cast<void**>(p) = head;
 #else
       *static_cast<void**>(p) = head;
@@ -121,7 +121,7 @@ namespace snmalloc
     /// In Debug checks for simple corruptions.
     static SNMALLOC_FAST_PATH void* follow_next(void* node)
     {
-#ifdef CHECK_CLIENT
+#if defined(CHECK_CLIENT) && !defined(__CHERI_PURE_CAPABILITY__)
       uintptr_t next = *static_cast<uintptr_t*>(node);
       uintptr_t chk = *(static_cast<uintptr_t*>(node) + 1);
       if ((next ^ chk) != POISON)

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -387,7 +387,7 @@ namespace snmalloc
      */
     size_t index_for_address(uintptr_t p)
     {
-      return reinterpret_cast<size_t>((p >> SHIFT) & (OS_PAGE_SIZE - 1));
+      return bits::align_down(static_cast<size_t>(p) >> SHIFT, OS_PAGE_SIZE);
     }
 
     /**

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -191,7 +191,7 @@ namespace snmalloc
           return std::pair(nullptr, 0);
 
         shift -= BITS_PER_INDEX_LEVEL;
-        ix = (addr >> shift) & ENTRIES_MASK;
+        ix = (static_cast<size_t>(addr) >> shift) & ENTRIES_MASK;
         e = &value->entries[ix];
 
         if constexpr (INDEX_LEVELS == 1)
@@ -211,7 +211,7 @@ namespace snmalloc
         return std::pair(nullptr, 0);
 
       shift -= BITS_FOR_LEAF;
-      ix = (addr >> shift) & LEAF_MASK;
+      ix = (static_cast<size_t>(addr) >> shift) & LEAF_MASK;
       return std::pair(leaf, ix);
     }
 

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -58,7 +58,7 @@ namespace snmalloc
   {
   private:
     static constexpr size_t COVERED_BITS =
-      bits::ADDRESS_BITS - GRANULARITY_BITS;
+      Pal::ADDRESS_BITS - GRANULARITY_BITS;
     static constexpr size_t CONTENT_BITS =
       bits::next_pow2_bits_const(sizeof(T));
 
@@ -325,7 +325,7 @@ namespace snmalloc
   {
   private:
     static constexpr size_t COVERED_BITS =
-      bits::ADDRESS_BITS - GRANULARITY_BITS;
+      Pal::ADDRESS_BITS - GRANULARITY_BITS;
     static constexpr size_t CONTENT_BITS =
       bits::next_pow2_bits_const(sizeof(T));
     static constexpr size_t ENTRIES = 1ULL << (COVERED_BITS + CONTENT_BITS);

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "allocconfig.h"
+#include "../pal/pal.h"
 
 namespace snmalloc
 {
@@ -50,7 +51,7 @@ namespace snmalloc
 
   // Large classes range from [SUPERSLAB, ADDRESS_SPACE).
   static constexpr size_t NUM_LARGE_CLASSES =
-    bits::ADDRESS_BITS - SUPERSLAB_BITS;
+    Pal::ADDRESS_BITS - SUPERSLAB_BITS;
 
   inline static size_t round_by_sizeclass(size_t rsize, size_t offset)
   {

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -210,10 +210,10 @@ extern "C"
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(snmalloc_pagemap_global_get)(
     PagemapConfig const** config)
   {
-    auto& pm = GlobalPagemap::pagemap();
+    auto& pm = SNMALLOC_DEFAULT_CHUNKMAP::expose_pagemap();
     if (config)
     {
-      *config = &ChunkmapPagemap::config;
+      *config = &pm.config;
       assert(ChunkmapPagemap::cast_to_pagemap(&pm, *config) == &pm);
     }
     return &pm;

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -17,6 +17,7 @@ namespace snmalloc
 // If simultating OE, then we need the underlying platform
 #if !defined(OPEN_ENCLAVE) || defined(OPEN_ENCLAVE_SIMULATION)
 #  include "pal_apple.h"
+#  include "pal_cheribsd.h"
 #  include "pal_freebsd.h"
 #  include "pal_freebsd_kernel.h"
 #  include "pal_linux.h"
@@ -40,7 +41,11 @@ namespace snmalloc
 #  elif defined(FreeBSD_KERNEL)
     PALFreeBSDKernel;
 #  elif defined(__FreeBSD__)
-    PALFreeBSD;
+#    if defined(__CHERI_PURE_CAPABILITY__)
+    PALCHERIBSD;
+#    else
+    PALFBSD;
+#    endif
 #  elif defined(__NetBSD__)
     PALNetBSD;
 #  elif defined(__OpenBSD__)

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -5,6 +5,9 @@
 namespace snmalloc
 {
   void error(const char* const str);
+
+  template<typename PagemapProvder>
+  class DefaultChunkMap;
 } // namespace snmalloc
 
 // If simultating OE, then we need the underlying platform

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -6,8 +6,12 @@ namespace snmalloc
 {
   void error(const char* const str);
 
-  template<typename PagemapProvder>
-  class DefaultChunkMap;
+  template<
+    template<typename>
+    typename PagemapProvderTemplate,
+    template<auto>
+    typename ChunkmapPagemapTemplate>
+  struct DefaultChunkMap;
 } // namespace snmalloc
 
 // If simultating OE, then we need the underlying platform

--- a/src/pal/pal_cheribsd.h
+++ b/src/pal/pal_cheribsd.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#if defined(__FreeBSD__) && !defined(_KERNEL)
+#  include "../ds/address.h"
+#  include "../ds/bits.h"
+#  include "../mem/allocconfig.h"
+
+#  include <errno.h>
+#  include <pthread.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <strings.h>
+#  include <sys/mman.h>
+
+namespace snmalloc
+{
+  class PALCHERIBSD
+  {
+    /*
+     * In CHERI, we have to be able to rederive pointers to headers and
+     * metadata given the address of the allocation, since the capabilities we
+     * give out have bounds narrowed to the allocation itself.  Since snmalloc
+     * already holds a map of the address space, here's a great place to do
+     * that.  Rather than store sizes per each SUPERSLAB_SIZE sized piece of
+     * memory, we store a capability.
+     *
+     * We have a lot of "metadata" bits at the least-significant end of the
+     * address of a capability in this map, since its bounds must, at least,
+     * cover a SUPERSLAB_SIZE sized object (or a large allocation).  To
+     * minimize churn, we stash the existing enum PageMapSuperslabKind values
+     * in the bottom 8 bits of the address.
+     *
+     * We could cut that down to 6 bits by reclaiming all values above 64; we
+     * can test that the capability given to us to free is has address equal
+     * to the base of the capability stored here in the page map.
+     */
+    static constexpr int PAGEMAP_PTR_ALIGN = 0x100;
+
+  public:
+    
+    static constexpr size_t ADDRESS_BITS = 39; /* XXX CheriBSD MIPS specific */
+
+    template<template<typename> typename PagemapProviderTemplate,
+             template<auto> typename ChunkmapPagemapTemplate>
+    struct PalChunkMap : snmalloc::DefaultChunkMap<PagemapProviderTemplate, ChunkmapPagemapTemplate>
+    {
+      using ChunkmapPagemap = ChunkmapPagemapTemplate<static_cast<void*>(nullptr)>;
+      using PagemapProvider = PagemapProviderTemplate<ChunkmapPagemap>;
+
+      static uint8_t get(address_t p)
+      {
+        return static_cast<uint8_t>(address_cast(PagemapProvider::pagemap().get(p)));
+      }
+
+      template<bool offset = true> SNMALLOC_FAST_PATH
+      static void* getp(void *p)
+      {
+        void* pmp = pointer_align_down<PAGEMAP_PTR_ALIGN, void>(
+          PagemapProvider::pagemap().get(address_cast(p)));
+        if constexpr (offset)
+        {
+          return pointer_offset(pmp, pointer_diff(pmp, p));
+        }
+        else
+        {
+          return pmp;
+        }
+      }
+    };
+
+    /**
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
+     */
+    static constexpr uint64_t pal_features = LazyCommit | AlignedAllocation;
+    static void error(const char* const str)
+    {
+      puts(str);
+      abort();
+    }
+
+    /// Notify platform that we will not be using these pages
+    void notify_not_using(void* p, size_t size) noexcept
+    {
+      assert(is_aligned_block<OS_PAGE_SIZE>(p, size));
+      madvise(p, size, MADV_FREE);
+    }
+
+    /// Notify platform that we will be using these pages
+    template<ZeroMem zero_mem>
+    void notify_using(void* p, size_t size) noexcept
+    {
+      assert(is_aligned_block<OS_PAGE_SIZE>(p, size) || (zero_mem == NoZero));
+      if constexpr (zero_mem == YesZero)
+        zero(p, size);
+    }
+
+    /// OS specific function for zeroing memory
+    template<bool page_aligned = false>
+    void zero(void* p, size_t size) noexcept
+    {
+      if (page_aligned || is_aligned_block<OS_PAGE_SIZE>(p, size))
+      {
+        assert(is_aligned_block<OS_PAGE_SIZE>(p, size));
+        void* r = mmap(
+          p,
+          size,
+          PROT_READ | PROT_WRITE,
+          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+          -1,
+          0);
+
+        if (r != MAP_FAILED)
+          return;
+
+        /*
+         * We're going to fall back to zeroing the memory ourselves, which
+         * is not great.  But we also need to zero errno, lest it propagate
+         * out to our caller!
+         */
+        errno = 0;
+      }
+
+      bzero(p, size);
+    }
+
+    template<bool committed>
+    void* reserve(size_t* size, size_t align) noexcept
+    {
+      size_t request = *size;
+      // Alignment must be a power of 2.
+      assert(align == bits::next_pow2(align));
+
+      if (align == 0)
+      {
+        align = 1;
+      }
+
+      size_t log2align = bits::next_pow2_bits(align);
+
+      void* p = mmap(
+        NULL,
+        request,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED(log2align),
+        -1,
+        0);
+
+      if (p == MAP_FAILED)
+        error("Out of memory");
+
+      return p;
+    }
+  };
+}
+#endif

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -16,8 +16,13 @@ namespace snmalloc
   public:
     static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
 
-    template<typename PagemapProvider>
-    using PalChunkMap = DefaultChunkMap<PagemapProvider>;
+    template<
+      template<typename>
+      typename PagemapProviderTemplate,
+      template<auto>
+      typename ChunkmapPagemapTemplate>
+    using PalChunkMap =
+      DefaultChunkMap<PagemapProviderTemplate, ChunkmapPagemapTemplate>;
 
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -16,6 +16,9 @@ namespace snmalloc
   public:
     static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
 
+    template<typename PagemapProvider>
+    using PalChunkMap = DefaultChunkMap<PagemapProvider>;
+
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -14,6 +14,8 @@ namespace snmalloc
     std::atomic<void*> oe_base;
 
   public:
+    static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
+
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -28,8 +28,13 @@ namespace snmalloc
   public:
     static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
 
-    template<typename PagemapProvider>
-    using PalChunkMap = snmalloc::DefaultChunkMap<PagemapProvider>;
+    template<
+      template<typename>
+      typename PagemapProviderTemplate,
+      template<auto>
+      typename ChunkmapPagemapTemplate>
+    using PalChunkMap = snmalloc::
+      DefaultChunkMap<PagemapProviderTemplate, ChunkmapPagemapTemplate>;
 
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -28,6 +28,9 @@ namespace snmalloc
   public:
     static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
 
+    template<typename PagemapProvider>
+    using PalChunkMap = snmalloc::DefaultChunkMap<PagemapProvider>;
+
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -26,6 +26,8 @@ namespace snmalloc
   class PALPOSIX
   {
   public:
+    static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
+
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -40,6 +40,8 @@ namespace snmalloc
     }
 
   public:
+    static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
+
     PALWindows()
     {
       // No error handling here - if this doesn't work, then we will just

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -42,6 +42,14 @@ namespace snmalloc
   public:
     static constexpr size_t ADDRESS_BITS = bits::is64() ? 48 : 32;
 
+    template<
+      template<typename>
+      typename PagemapProviderTemplate,
+      template<auto>
+      typename ChunkmapPagemapTemplate>
+    using PalChunkMap = snmalloc::
+      DefaultChunkMap<PagemapProviderTemplate, ChunkmapPagemapTemplate>;
+
     PALWindows()
     {
       // No error handling here - if this doesn't work, then we will just


### PR DESCRIPTION
This is not yet ready for merge, but I would like to solicit feedback on the general idea.  Specifically, while the previous attempt at CHERIfication of `snmalloc` relied on a pile of `ifdefs` everywhere (including `SNMALLOC_PAGEMAP_POINTERS`), this attempt vectors everything through the platform abstraction layer.  There are some caveats:

* The PAL is very early in the toposorting of dependencies, and so almost everything pagemap related needs to be passed in as template parameters.
* It uses higher-order templates, which is... somewhat exciting.
* While this compiles for CHERI, it should not be expected to actually work; at the very least, the `set` method of the CHERI chunkmap is wrong and, besides, most of the calls to the requisite hooks are not actually in place, just enough to ensure that we generate some code to test compilation.

This builds on #104, sorry for the duplicate commits at the moment.