### PR TITLE
Introduce AAL feature flags

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -12,6 +12,19 @@
 namespace snmalloc
 {
   /**
+   * Flags in a bitfield of attributes of this architecture, much like
+   * PalFeatures.
+   */
+  enum AalFeatures : uint64_t
+  {
+    /**
+     * This architecture does not discriminate between integers and pointers,
+     * and so may use bit operations on pointer values.
+     */
+    IntegerPointers = (1 << 0),
+  };
+
+  /**
    * Architecture Abstraction Layer. Includes default implementations of some
    * functions using compiler builtins.  Falls back to the definitions in the
    * platform's AAL if the builtin does not exist.
@@ -64,6 +77,9 @@ namespace snmalloc
 namespace snmalloc
 {
   using Aal = AAL_Generic<AAL_Arch>;
+
+  template<AalFeatures F, typename AAL = Aal>
+  constexpr static bool aal_supports = (AAL::aal_features & F) == F;
 } // namespace snmalloc
 
 #if defined(_MSC_VER) && defined(SNMALLOC_VA_BITS_32)

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -63,7 +63,7 @@ namespace snmalloc
 
 namespace snmalloc
 {
-  using AAL = AAL_Generic<AAL_Arch>;
+  using Aal = AAL_Generic<AAL_Arch>;
 } // namespace snmalloc
 
 #if defined(_MSC_VER) && defined(SNMALLOC_VA_BITS_32)

--- a/src/aal/aal_x86.h
+++ b/src/aal/aal_x86.h
@@ -56,6 +56,11 @@ namespace snmalloc
 
   public:
     /**
+     * Bitmap of AalFeature flags
+     */
+    static constexpr uint64_t aal_features = IntegerPointers;
+
+    /**
      * On pipelined processors, notify the core that we are in a spin loop and
      * that speculative execution past this point may not be a performance gain.
      */

--- a/src/ds/flaglock.h
+++ b/src/ds/flaglock.h
@@ -13,7 +13,7 @@ namespace snmalloc
     FlagLock(std::atomic_flag& lock) : lock(lock)
     {
       while (lock.test_and_set(std::memory_order_acquire))
-        AAL::pause();
+        Aal::pause();
     }
 
     ~FlagLock()

--- a/src/ds/mpscq.h
+++ b/src/ds/mpscq.h
@@ -70,7 +70,7 @@ namespace snmalloc
       if (next != nullptr)
       {
         front = next;
-        AAL::prefetch(&(next->next));
+        Aal::prefetch(&(next->next));
         assert(front);
         std::atomic_thread_fence(std::memory_order_acquire);
         invariant();

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1120,7 +1120,7 @@ namespace snmalloc
           else if constexpr (decommit_strategy == DecommitSuperLazy)
           {
             static_assert(
-              pal_supports<LowMemoryNotification, MemoryProvider>(),
+              pal_supports<LowMemoryNotification, MemoryProvider>,
               "A lazy decommit strategy cannot be implemented on platforms "
               "without low memory notifications");
           }

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -66,7 +66,7 @@ namespace snmalloc
     {
       CurrentMaxPair count;
       CurrentMaxPair slab_count;
-      uint64_t time = AAL::tick();
+      uint64_t time = Aal::tick();
       uint64_t ticks = 0;
       double online_average = 0;
 
@@ -83,7 +83,7 @@ namespace snmalloc
 
       void addToRunningAverage()
       {
-        uint64_t now = AAL::tick();
+        uint64_t now = Aal::tick();
 
         if (slab_count.current != 0)
         {

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -47,7 +47,7 @@ namespace snmalloc
 // Use flat map is under a single node.
 #  define SNMALLOC_MAX_FLATPAGEMAP_SIZE PAGEMAP_NODE_SIZE
 #endif
-  static constexpr bool USE_FLATPAGEMAP = pal_supports<LazyCommit>() ||
+  static constexpr bool USE_FLATPAGEMAP = pal_supports<LazyCommit> ||
     (SNMALLOC_MAX_FLATPAGEMAP_SIZE >=
      sizeof(FlatPagemap<SUPERSLAB_BITS, uint8_t>));
 

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -190,7 +190,7 @@ namespace snmalloc
     SNMALLOC_FAST_PATH
     uint64_t low_memory_epoch()
     {
-      if constexpr (pal_supports<LowMemoryNotification, PAL>())
+      if constexpr (pal_supports<LowMemoryNotification, PAL>)
       {
         return PAL::low_memory_epoch();
       }
@@ -203,7 +203,7 @@ namespace snmalloc
     template<bool committed>
     void* reserve(size_t* size, size_t align) noexcept
     {
-      if constexpr (pal_supports<AlignedAllocation, PAL>())
+      if constexpr (pal_supports<AlignedAllocation, PAL>)
       {
         return PAL::template reserve<committed>(size, align);
       }

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -162,7 +162,7 @@ namespace snmalloc
           while (address_cast(e->load(std::memory_order_relaxed)) ==
                  LOCKED_ENTRY)
           {
-            AAL::pause();
+            Aal::pause();
           }
           value = e->load(std::memory_order_acquire);
         }

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -61,8 +61,5 @@ namespace snmalloc
    * Query whether the PAL supports a specific feature.
    */
   template<PalFeatures F, typename PAL = Pal>
-  constexpr static bool pal_supports()
-  {
-    return (PAL::pal_features & F) == F;
-  }
+  constexpr static bool pal_supports = (PAL::pal_features & F) == F;
 } // namespace snmalloc

--- a/src/test/perf/contention/contention.cc
+++ b/src/test/perf/contention/contention.cc
@@ -31,18 +31,18 @@ private:
     auto prev = ready.fetch_add(1);
     if (prev + 1 == cores)
     {
-      start = AAL::tick();
+      start = Aal::tick();
       flag = true;
     }
     while (!flag)
-      AAL::pause();
+      Aal::pause();
 
     f(id);
 
     prev = complete.fetch_add(1);
     if (prev + 1 == cores)
     {
-      end = AAL::tick();
+      end = Aal::tick();
     }
   }
 


### PR DESCRIPTION
And use them to gate `POISON`-ing pointers when `CHECK_CLIENT` is defined.  The bulk of the change is just stylistic to normalize case and the use of templated vardecls.

This extracts some small part of conversations had in #105 for incremental review.