### PR TITLE
Fix GCC 9 error.

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -974,7 +974,7 @@ namespace snmalloc
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_inner(sizeclass_t sizeclass)
     {
-      assert(sizeclass < NUM_SMALL_CLASSES);
+      SNMALLOC_ASSUME(sizeclass < NUM_SMALL_CLASSES);
       auto& fl = small_fast_free_lists[sizeclass];
       void* head = fl.value;
       if (likely(head != nullptr))


### PR DESCRIPTION
GCC has some aggressive warnings that can be imprecise for checking array bounds access.  This commit converts an assert to an assume to remove the warning.

I do not have GCC 9 to test this, but it follows a similar pattern to we have seen with other versions of GCC.  Should address #108.