### PR TITLE
Small refactoring of code for finding a sizeclass for an alignment

### DIFF
--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -104,14 +104,6 @@ extern "C"
   }
 #endif
 
-  SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
-  {
-    assert((size % alignment) == 0);
-    (void)alignment;
-    return SNMALLOC_NAME_MANGLE(malloc)(size);
-  }
-
   inline size_t aligned_size(size_t alignment, size_t size)
   {
     // Client responsible for checking alignment is not zero
@@ -157,6 +149,13 @@ extern "C"
     }
 
     return SNMALLOC_NAME_MANGLE(malloc)(aligned_size(alignment, size));
+  }
+
+  SNMALLOC_EXPORT void*
+    SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
+  {
+    assert((size % alignment) == 0);
+    return SNMALLOC_NAME_MANGLE(memalign)(alignment, size);
   }
 
   SNMALLOC_EXPORT int SNMALLOC_NAME_MANGLE(posix_memalign)(

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -112,6 +112,34 @@ extern "C"
     return SNMALLOC_NAME_MANGLE(malloc)(size);
   }
 
+  inline size_t aligned_size(size_t alignment, size_t size)
+  {
+    // Client responsible for checking alignment is not zero
+    assert(alignment != 0);
+    // Client responsible for checking alignment is not above SUPERSLAB_SIZE
+    assert(alignment <= SUPERSLAB_SIZE);
+    // Client responsible for checking alignment is a power of two
+    assert(bits::next_pow2(alignment) == alignment);
+
+    size = bits::max(size, alignment);
+    snmalloc::sizeclass_t sc = size_to_sizeclass(size);
+    if (sc >= NUM_SIZECLASSES)
+    {
+      // large allocs are 16M aligned, which is maximum we guarantee
+      return size;
+    }
+    for (; sc < NUM_SIZECLASSES; sc++)
+    {
+      size = sizeclass_to_size(sc);
+      if ((size & (~size + 1)) >= alignment)
+      {
+        return size;
+      }
+    }
+    // Give max alignment.
+    return SUPERSLAB_SIZE;
+  }
+
   SNMALLOC_EXPORT void*
     SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
   {
@@ -128,22 +156,7 @@ extern "C"
       return nullptr;
     }
 
-    size = bits::max(size, alignment);
-    snmalloc::sizeclass_t sc = size_to_sizeclass(size);
-    if (sc >= NUM_SIZECLASSES)
-    {
-      // large allocs are 16M aligned.
-      return SNMALLOC_NAME_MANGLE(malloc)(size);
-    }
-    for (; sc < NUM_SIZECLASSES; sc++)
-    {
-      size = sizeclass_to_size(sc);
-      if ((size & (~size + 1)) >= alignment)
-      {
-        return SNMALLOC_NAME_MANGLE(aligned_alloc)(alignment, size);
-      }
-    }
-    return SNMALLOC_NAME_MANGLE(malloc)(SUPERSLAB_SIZE);
+    return SNMALLOC_NAME_MANGLE(malloc)(aligned_size(alignment, size));
   }
 
   SNMALLOC_EXPORT int SNMALLOC_NAME_MANGLE(posix_memalign)(


### PR DESCRIPTION
snmalloc has natural alignment for each sizeclass, this means that we can search for a sizeclass larger then the requested sizeclass whose natural alignment meets that specified by the call.

This is currently used in a single place, so was directly written into `memalign`. With #109 there is a wish to make a larger API surface that supports alignment.  This PR is intended to make that easier.  