### PR TITLE
Improvements to Decommit Strategies

### DIFF
--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -56,7 +56,7 @@ namespace snmalloc
       length == bits::next_pow2_const(length), "Must be a power of two.");
 
   private:
-    T value;
+    T value = 0;
 
   public:
     operator T()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -930,8 +930,7 @@ namespace snmalloc
 
         if (super != nullptr)
         {
-          Slab* slab =
-            super->alloc_short_slab(sizeclass, large_allocator.memory_provider);
+          Slab* slab = super->alloc_short_slab(sizeclass);
           assert(super->is_full());
           return slab;
         }
@@ -941,8 +940,7 @@ namespace snmalloc
         if ((allow_reserve == NoReserve) && (super == nullptr))
           return nullptr;
 
-        Slab* slab =
-          super->alloc_short_slab(sizeclass, large_allocator.memory_provider);
+        Slab* slab = super->alloc_short_slab(sizeclass);
         reposition_superslab(super);
         return slab;
       }
@@ -952,8 +950,7 @@ namespace snmalloc
       if ((allow_reserve == NoReserve) && (super == nullptr))
         return nullptr;
 
-      Slab* slab =
-        super->alloc_slab(sizeclass, large_allocator.memory_provider);
+      Slab* slab = super->alloc_slab(sizeclass);
       reposition_superslab(super);
       return slab;
     }
@@ -1074,7 +1071,7 @@ namespace snmalloc
       SlabList* sl = &small_classes[sizeclass];
       Slab* slab = Metaslab::get_slab(p);
       Superslab::Action a =
-        slab->dealloc_slow(sl, super, p, large_allocator.memory_provider);
+        slab->dealloc_slow(sl, super, p);
       if (likely(a == Superslab::NoSlabReturn))
         return;
       stats().sizeclass_dealloc_slab(sizeclass);
@@ -1191,7 +1188,7 @@ namespace snmalloc
     {
       MEASURE_TIME(medium_dealloc, 4, 16);
       stats().sizeclass_dealloc(sizeclass);
-      bool was_full = slab->dealloc(p, large_allocator.memory_provider);
+      bool was_full = slab->dealloc(p);
 
 #ifdef CHECK_CLIENT
       if (!is_multiple_of_sizeclass(

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -69,10 +69,6 @@ namespace snmalloc
      */
     DecommitSuper,
     /**
-     * Decommit all slabs once they are empty.
-     */
-    DecommitAll,
-    /**
      * Decommit superslabs only when we are informed of memory pressure by the
      * OS, do not decommit anything in normal operation.
      */

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -87,16 +87,13 @@ namespace snmalloc
       assert(is_aligned_block<OS_PAGE_SIZE>(p, OS_PAGE_SIZE));
       size = bits::align_up(size, OS_PAGE_SIZE);
 
-      if constexpr (decommit_strategy == DecommitAll)
-        memory_provider.template notify_using<zero_mem>(p, size);
-      else if constexpr (zero_mem == YesZero)
+      if constexpr (zero_mem == YesZero)
         memory_provider.template zero<true>(p, size);
 
       return p;
     }
 
-    template<typename MemoryProvider>
-    bool dealloc(void* p, MemoryProvider& memory_provider)
+    bool dealloc(void* p)
     {
       assert(head > 0);
 
@@ -104,9 +101,6 @@ namespace snmalloc
       bool was_full = full();
       free++;
       stack[--head] = pointer_to_index(p);
-
-      if constexpr (decommit_strategy == DecommitAll)
-        memory_provider.notify_not_using(p, sizeclass_to_size(sizeclass));
 
       return was_full;
     }

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -36,7 +36,7 @@ namespace snmalloc
      *  The list will be (allocated - needed - 1) long. The -1 is
      *  for the `link` element which is not in the free list.
      */
-    void* head;
+    void* head = nullptr;
 
     /**
      *  How many entries are not in the free list of slab, i.e.
@@ -51,7 +51,7 @@ namespace snmalloc
     /**
      *  How many entries have been allocated from this slab.
      */
-    uint16_t allocated;
+    uint16_t allocated = 0;
 
     // When a slab has free space it will be on the has space list for
     // that size class.  We use an empty block in this slab to be the

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -178,9 +178,8 @@ namespace snmalloc
     // This does not need to remove the "use" as done by the fast path.
     // Returns a complex return code for managing the superslab meta data.
     // i.e. This deallocation could make an entire superslab free.
-    template<typename MemoryProvider>
     SNMALLOC_SLOW_PATH typename Superslab::Action dealloc_slow(
-      SlabList* sl, Superslab* super, void* p, MemoryProvider& memory_provider)
+      SlabList* sl, Superslab* super, void* p)
     {
       Metaslab& meta = super->get_meta(this);
 
@@ -191,9 +190,9 @@ namespace snmalloc
         {
           // Dealloc on the superslab.
           if (is_short())
-            return super->dealloc_short_slab(memory_provider);
+            return super->dealloc_short_slab();
 
-          return super->dealloc_slab(this, memory_provider);
+          return super->dealloc_slab(this);
         }
         // Update the head and the sizeclass link.
         uint16_t index = pointer_to_index(p);
@@ -212,10 +211,11 @@ namespace snmalloc
       sl->remove(meta.get_link(this));
 
       if (is_short())
-        return super->dealloc_short_slab(memory_provider);
+        return super->dealloc_short_slab();
 
-      return super->dealloc_slab(this, memory_provider);
+      return super->dealloc_slab(this);
     }
+
     bool is_short()
     {
       return Metaslab::is_short(this);

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -84,7 +84,7 @@ namespace snmalloc
       {
         if (kind != Fresh)
         {
-          // If this wasn't previously Fresh, we need to zero some things.
+        // If this wasn't previously Fresh, we need to zero some things.
           used = 0;
           for (size_t i = 0; i < SLAB_COUNT; i++)
           {
@@ -97,21 +97,21 @@ namespace snmalloc
         kind = Super;
         // Point head at the first non-short slab.
         head = 1;
+      }
 
 #ifndef NDEBUG
-        auto curr = head;
-        for (size_t i = 0; i < SLAB_COUNT - used - 1; i++)
-        {
-          curr = (curr + meta[curr].next + 1) & (SLAB_COUNT - 1);
-        }
-        assert(curr == 0);
-
-        for (size_t i = 0; i < SLAB_COUNT; i++)
-        {
-          assert(meta[i].is_unused());
-        }
-#endif
+      auto curr = head;
+      for (size_t i = 0; i < SLAB_COUNT - used - 1; i++)
+      {
+        curr = (curr + meta[curr].next + 1) & (SLAB_COUNT - 1);
       }
+      if (curr != 0) abort();
+
+      for (size_t i = 0; i < SLAB_COUNT; i++)
+      {
+        assert(meta[i].is_unused());
+      }
+#endif
     }
 
     bool is_empty()
@@ -165,7 +165,7 @@ namespace snmalloc
       meta[0].link = get_initial_offset(sizeclass, true);
 
       used++;
-      return (Slab*)this;
+      return reinterpret_cast<Slab*>(this);
     }
 
     Slab* alloc_slab(sizeclass_t sizeclass)


### PR DESCRIPTION
This PR primarily fixes a performance issue on Windows where Commit (NotifyUsing) was called too often. 

The other commits tidy the decommit code to remove an unused poorly performing strategy, and refactor the code.