### PR TITLE
Make Large allocations naturally aligned

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(EXPOSE_EXTERNAL_RESERVE "Expose an interface to reserve memory using the 
 option(SNMALLOC_RUST_SUPPORT "Build static library for rust" OFF)
 set(CACHE_FRIENDLY_OFFSET OFF CACHE STRING "Base offset to place linked-list nodes.")
 
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
+if ((CMAKE_BUILD_TYPE STREQUAL "Release") AND (NOT SNMALLOC_CI_BUILD))
   option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." Off)
 else ()
   option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." On)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ option(EXPOSE_EXTERNAL_RESERVE "Expose an interface to reserve memory using the 
 option(SNMALLOC_RUST_SUPPORT "Build static library for rust" OFF)
 set(CACHE_FRIENDLY_OFFSET OFF CACHE STRING "Base offset to place linked-list nodes.")
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." Off)
+else ()
+  option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." On)
+endif ()
+
 # Provide as macro so other projects can reuse
 macro(warnings_high)
   if(MSVC)
@@ -110,6 +116,11 @@ endif()
 if(CACHE_FRIENDLY_OFFSET)
   target_compile_definitions(snmalloc_lib INTERFACE -DCACHE_FRIENDLY_OFFSET=${CACHE_FRIENDLY_OFFSET})
 endif()
+
+if(USE_POSIX_COMMIT_CHECKS)
+  target_compile_definitions(snmalloc_lib INTERFACE -DUSE_POSIX_COMMIT_CHECKS)
+endif()
+
 
 # To build with just the header library target define SNMALLOC_ONLY_HEADER_LIBRARY
 # in containing Cmake file.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ template<bool committed>
 void* reserve(const size_t* size) noexcept;
 ```
 Only one of these needs to be implemented, depending on whether the underlying
-system can provide strongly (e.g. 16MiB) aligned memory regions.
+system can provide strongly aligned memory regions.
 If the system guarantees only page alignment, implement the second and snmalloc
 will over-allocate and then trim the requested region.
 If the system provides strong alignment, implement the first to return memory

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ pages, rather than zeroing them synchronously in this call
 
 ```c++
 template<bool committed>
-void* reserve(size_t* size, size_t align);
+void* reserve(size_t size, size_t align);
 template<bool committed>
-void* reserve(const size_t* size) noexcept;
+void* reserve(size_t size) noexcept;
 ```
 Only one of these needs to be implemented, depending on whether the underlying
 system can provide strongly aligned memory regions.

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1070,8 +1070,7 @@ namespace snmalloc
       bool was_full = super->is_full();
       SlabList* sl = &small_classes[sizeclass];
       Slab* slab = Metaslab::get_slab(p);
-      Superslab::Action a =
-        slab->dealloc_slow(sl, super, p);
+      Superslab::Action a = slab->dealloc_slow(sl, super, p);
       if (likely(a == Superslab::NoSlabReturn))
         return;
       stats().sizeclass_dealloc_slab(sizeclass);

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -273,7 +273,7 @@ namespace snmalloc
 
         // printf("Alloc %zx (size = %zx)\n", start, size);
 
-        void* result = pointer_cast<void>(start);  
+        void* result = pointer_cast<void>(start);
         if (committed)
           PAL::template notify_using<NoZero>(result, size);
 

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -124,7 +124,7 @@ namespace snmalloc
 
     void push_space(address_t start, size_t large_class)
     {
-      void * p = pointer_cast<void>(start);
+      void* p = pointer_cast<void>(start);
       if (large_class > 0)
         PAL::template notify_using<YesZero>(p, OS_PAGE_SIZE);
       else
@@ -249,7 +249,7 @@ namespace snmalloc
           PAL::notify_not_using(pointer_cast<void>(end), p1 - end);
         }
 
-        for (; end < bits::align_down(p1,align); end += size)
+        for (; end < bits::align_down(p1, align); end += size)
         {
           push_space(end, large_class);
         }
@@ -409,13 +409,14 @@ namespace snmalloc
       }
 
       // Cross-reference largealloc's alloc() decommitted condition.
-      if ((decommit_strategy != DecommitNone) 
-          && (large_class != 0 || decommit_strategy == DecommitSuper))
+      if (
+        (decommit_strategy != DecommitNone) &&
+        (large_class != 0 || decommit_strategy == DecommitSuper))
       {
         size_t rsize = bits::one_at_bit(SUPERSLAB_BITS) << large_class;
 
         memory_provider.notify_not_using(
-        pointer_offset(p, OS_PAGE_SIZE), rsize - OS_PAGE_SIZE);
+          pointer_offset(p, OS_PAGE_SIZE), rsize - OS_PAGE_SIZE);
       }
 
       stats.superslab_push();

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -179,8 +179,6 @@ namespace snmalloc
   {
     // Client responsible for checking alignment is not zero
     assert(alignment != 0);
-    // Client responsible for checking alignment is not above SUPERSLAB_SIZE
-    assert(alignment <= SUPERSLAB_SIZE);
     // Client responsible for checking alignment is a power of two
     assert(bits::next_pow2(alignment) == alignment);
 

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -178,8 +178,8 @@ namespace snmalloc
     // This does not need to remove the "use" as done by the fast path.
     // Returns a complex return code for managing the superslab meta data.
     // i.e. This deallocation could make an entire superslab free.
-    SNMALLOC_SLOW_PATH typename Superslab::Action dealloc_slow(
-      SlabList* sl, Superslab* super, void* p)
+    SNMALLOC_SLOW_PATH typename Superslab::Action
+    dealloc_slow(SlabList* sl, Superslab* super, void* p)
     {
       Metaslab& meta = super->get_meta(this);
 

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -84,7 +84,7 @@ namespace snmalloc
       {
         if (kind != Fresh)
         {
-        // If this wasn't previously Fresh, we need to zero some things.
+          // If this wasn't previously Fresh, we need to zero some things.
           used = 0;
           for (size_t i = 0; i < SLAB_COUNT; i++)
           {
@@ -105,7 +105,8 @@ namespace snmalloc
       {
         curr = (curr + meta[curr].next + 1) & (SLAB_COUNT - 1);
       }
-      if (curr != 0) abort();
+      if (curr != 0)
+        abort();
 
       for (size_t i = 0; i < SLAB_COUNT; i++)
       {

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -107,8 +107,7 @@ extern "C"
   SNMALLOC_EXPORT void*
     SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
   {
-    if (
-      (alignment == 0) || (alignment == size_t(-1)))
+    if ((alignment == 0) || (alignment == size_t(-1)))
     {
       errno = EINVAL;
       return nullptr;

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -108,8 +108,7 @@ extern "C"
     SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
   {
     if (
-      (alignment == 0) || (alignment == size_t(-1)) ||
-      (alignment > SUPERSLAB_SIZE))
+      (alignment == 0) || (alignment == size_t(-1)))
     {
       errno = EINVAL;
       return nullptr;

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -56,11 +56,11 @@ namespace snmalloc
      * See comment below.
      */
     template<bool committed>
-    void* reserve(const size_t* size)
+    void* reserve(size_t size)
     {
       void* p = mmap(
         nullptr,
-        *size,
+        size,
         PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS,
         pal_anon_id,

--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -27,7 +27,7 @@ namespace snmalloc
      * Reserve memory at a specific alignment.
      */
     template<bool committed>
-    void* reserve(const size_t* size, size_t align) noexcept
+    void* reserve(size_t size, size_t align) noexcept
     {
       // Alignment must be a power of 2.
       assert(align == bits::next_pow2(align));
@@ -38,7 +38,7 @@ namespace snmalloc
 
       void* p = mmap(
         nullptr,
-        *size,
+        size,
         PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED(log2align),
         -1,

--- a/src/pal/pal_freebsd_kernel.h
+++ b/src/pal/pal_freebsd_kernel.h
@@ -63,11 +63,10 @@ namespace snmalloc
     template<bool committed>
     void* reserve(size_t size, size_t align)
     {
-      size_t request = size;
       vm_offset_t addr;
       if (vmem_xalloc(
             kernel_arena,
-            request,
+            size,
             align,
             0,
             0,
@@ -81,10 +80,10 @@ namespace snmalloc
       if (committed)
       {
         if (
-          kmem_back(kernel_object, addr, request, M_ZERO | M_WAITOK) !=
+          kmem_back(kernel_object, addr, size, M_ZERO | M_WAITOK) !=
           KERN_SUCCESS)
         {
-          vmem_xfree(kernel_arena, addr, request);
+          vmem_xfree(kernel_arena, addr, size);
           return nullptr;
         }
       }

--- a/src/pal/pal_freebsd_kernel.h
+++ b/src/pal/pal_freebsd_kernel.h
@@ -61,9 +61,9 @@ namespace snmalloc
     }
 
     template<bool committed>
-    void* reserve(size_t* size, size_t align)
+    void* reserve(size_t size, size_t align)
     {
-      size_t request = *size;
+      size_t request = size;
       vm_offset_t addr;
       if (vmem_xalloc(
             kernel_arena,

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -18,7 +18,7 @@ namespace snmalloc
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = AlignedAllocation;
+    static constexpr uint64_t pal_features = 0;
     static void error(const char* const str)
     {
       UNUSED(str);
@@ -26,7 +26,7 @@ namespace snmalloc
     }
 
     template<bool committed>
-    void* reserve(size_t* size, size_t align) noexcept
+    void* reserve(size_t size) noexcept
     {
       if (oe_base == 0)
       {
@@ -36,21 +36,18 @@ namespace snmalloc
       }
 
       void* old_base = oe_base;
-      void* old_base2 = old_base;
       void* next_base;
       auto end = __oe_get_heap_end();
       do
       {
-        old_base2 = old_base;
-        auto new_base = pointer_align_up(old_base, align);
-        next_base = pointer_offset(new_base, *size);
+        auto new_base = old_base;
+        next_base = pointer_offset(new_base, size);
 
         if (next_base > end)
           error("Out of memory");
 
       } while (oe_base.compare_exchange_strong(old_base, next_base));
 
-      *size = pointer_diff(old_base2, next_base);
       return old_base;
     }
 

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -54,8 +54,12 @@ namespace snmalloc
     void notify_not_using(void* p, size_t size) noexcept
     {
       assert(is_aligned_block<OS_PAGE_SIZE>(p, size));
+#ifndef NDEBUG
+      mprotect(p, size, PROT_NONE);
+#else
       UNUSED(p);
       UNUSED(size);
+#endif
     }
 
     /**
@@ -72,11 +76,14 @@ namespace snmalloc
 
       if constexpr (zero_mem == YesZero)
         static_cast<OS*>(this)->template zero<true>(p, size);
-      else
-      {
-        UNUSED(p);
-        UNUSED(size);
-      }
+
+#ifndef NDEBUG
+      mprotect(p, size, PROT_READ | PROT_WRITE);
+#else
+      UNUSED(p);
+      UNUSED(size);
+#endif
+
     }
 
     /**

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -121,11 +121,11 @@ namespace snmalloc
      * greater than a page.
      */
     template<bool committed>
-    void* reserve(const size_t* size) noexcept
+    void* reserve(size_t size) noexcept
     {
       void* p = mmap(
         nullptr,
-        *size,
+        size,
         PROT_READ | PROT_WRITE,
         MAP_PRIVATE | MAP_ANONYMOUS,
         -1,

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -54,7 +54,7 @@ namespace snmalloc
     void notify_not_using(void* p, size_t size) noexcept
     {
       assert(is_aligned_block<OS_PAGE_SIZE>(p, size));
-#ifndef NDEBUG
+#ifdef USE_POSIX_COMMIT_CHECKS
       mprotect(p, size, PROT_NONE);
 #else
       UNUSED(p);
@@ -77,7 +77,7 @@ namespace snmalloc
       if constexpr (zero_mem == YesZero)
         static_cast<OS*>(this)->template zero<true>(p, size);
 
-#ifndef NDEBUG
+#ifdef USE_POSIX_COMMIT_CHECKS
       mprotect(p, size, PROT_READ | PROT_WRITE);
 #else
       UNUSED(p);

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -83,7 +83,6 @@ namespace snmalloc
       UNUSED(p);
       UNUSED(size);
 #endif
-
     }
 
     /**

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -183,7 +183,7 @@ namespace snmalloc
     }
 #  elif defined(PLATFORM_HAS_VIRTUALALLOC2)
     template<bool committed>
-    void* reserve(size_t* size, size_t align) noexcept
+    void* reserve(size_t size, size_t align) noexcept
     {
       DWORD flags = MEM_RESERVE;
 
@@ -209,7 +209,7 @@ namespace snmalloc
       param.Pointer = &addressReqs;
 
       void* ret = VirtualAlloc2FromApp(
-        nullptr, nullptr, *size, flags, PAGE_READWRITE, &param, 1);
+        nullptr, nullptr, size, flags, PAGE_READWRITE, &param, 1);
       if (ret == nullptr)
       {
         error("Failed to allocate memory\n");
@@ -218,14 +218,14 @@ namespace snmalloc
     }
 #  else
     template<bool committed>
-    void* reserve(size_t* size) noexcept
+    void* reserve(size_t size) noexcept
     {
       DWORD flags = MEM_RESERVE;
 
       if (committed)
         flags |= MEM_COMMIT;
 
-      void* ret = VirtualAlloc(nullptr, *size, flags, PAGE_READWRITE);
+      void* ret = VirtualAlloc(nullptr, size, flags, PAGE_READWRITE);
       if (ret == nullptr)
       {
         error("Failed to allocate memory\n");

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -32,6 +32,9 @@ int main()
 {
   MemoryProviderStateMixin<DefaultPal> mp;
 
+  // 28 is large enough to produce a nested allocator.
+  // It is also large enough for the example to run in.
+  // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
   size_t large_class = 28 - SUPERSLAB_BITS;
   size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
   oe_base = mp.reserve<true>(large_class);

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -32,8 +32,9 @@ int main()
 {
   MemoryProviderStateMixin<DefaultPal> mp;
 
-  size_t size = 1ULL << 28;
-  oe_base = mp.reserve<true>(size, 1);
+  size_t large_class = 28 - SUPERSLAB_BITS;
+  size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
+  oe_base = mp.reserve<true>(large_class);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -33,7 +33,7 @@ int main()
   MemoryProviderStateMixin<DefaultPal> mp;
 
   size_t size = 1ULL << 28;
-  oe_base = mp.reserve<true>(&size, 0);
+  oe_base = mp.reserve<true>(size, 1);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
   test_posix_memalign((size_t)-1, 0, EINVAL, true);
   test_posix_memalign(OS_PAGE_SIZE, sizeof(uintptr_t) / 2, EINVAL, true);
 
-  for (size_t align = sizeof(uintptr_t); align <= SUPERSLAB_SIZE; align <<= 1)
+  for (size_t align = sizeof(uintptr_t); align <= SUPERSLAB_SIZE * 8; align <<= 1)
   {
     for (snmalloc::sizeclass_t sc = 0; sc < NUM_SIZECLASSES; sc++)
     {

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -108,7 +108,8 @@ int main(int argc, char** argv)
   test_posix_memalign((size_t)-1, 0, EINVAL, true);
   test_posix_memalign(OS_PAGE_SIZE, sizeof(uintptr_t) / 2, EINVAL, true);
 
-  for (size_t align = sizeof(uintptr_t); align <= SUPERSLAB_SIZE * 8; align <<= 1)
+  for (size_t align = sizeof(uintptr_t); align <= SUPERSLAB_SIZE * 8;
+       align <<= 1)
   {
     for (snmalloc::sizeclass_t sc = 0; sc < NUM_SIZECLASSES; sc++)
     {

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -46,7 +46,7 @@ int main()
   MemoryProviderStateMixin<DefaultPal> mp;
 
   size_t size = 1ULL << 26;
-  oe_base = mp.reserve<true>(&size, 1);
+  oe_base = mp.reserve<true>(size, 1);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -45,6 +45,9 @@ int main()
 
   MemoryProviderStateMixin<DefaultPal> mp;
 
+  // 26 is large enough to produce a nested allocator.
+  // It is also large enough for the example to run in.
+  // For 1MiB superslabs, SUPERSLAB_BITS + 2 is not big enough for the example.
   size_t large_class = 26 - SUPERSLAB_BITS;
   size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
   oe_base = mp.reserve<true>(large_class);

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -45,8 +45,9 @@ int main()
 
   MemoryProviderStateMixin<DefaultPal> mp;
 
-  size_t size = 1ULL << 26;
-  oe_base = mp.reserve<true>(size, 1);
+  size_t large_class = 26 - SUPERSLAB_BITS;
+  size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
+  oe_base = mp.reserve<true>(large_class);
   oe_end = (uint8_t*)oe_base + size;
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 


### PR DESCRIPTION
This makes all large allocations aligned to their size next power of two size.

This introduces a new strategy for aligning blocks on platforms without a way to fetched aligned virtual memory (e.g. VirtualAlloc2, or mmap with MAP_ALIGNED).

To aid in debugging also uses mprotect to switch off unused pages in debug on posix platforms. This enables better testing of the Commit/Decommit code from Posix platforms.

  