### PR TITLE
Update to use clangformat9

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,6 +21,7 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:
+  AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,12 @@ endmacro()
 
 macro(clangformat_targets)
   # The clang-format tool is installed under a variety of different names.  Try
-  # to find a sensible one.  Only look for versions 6 to 8 explicitly - we don't
+  # to find a sensible one.  Only look for versions 9 explicitly - we don't
   # know whether our clang-format file will work with newer versions of the
-  # tool
+  # tool.  It does not work with older versions as AfterCaseLabel is not supported
+  # in earlier versions.
   find_program(CLANG_FORMAT NAMES
-    clang-format-8
-    clang-format-7.0
-    clang-format-6.0
-    clang-format70
-    clang-format60
+    clang-format-9
     clang-format)
 
   # If we've found a clang-format tool, generate a target for it, otherwise emit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,7 +232,7 @@ jobs:
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
       sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
       sudo apt-get update
-      sudo apt-get install -y clang-format-9
+      sudo apt-get install -y clang-format-9 clang-tidy-9
       sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
 
     displayName: 'Install clang'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,15 +225,15 @@ jobs:
 - job: 
   displayName: Format
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - script: |
       set -eo pipefail
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+      sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
       sudo apt-get update
-      sudo apt-get install -y clang-format-8 clang-tidy-8
-      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
+      sudo apt-get install -y clang-format-9
+      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
 
     displayName: 'Install clang'
 
@@ -245,7 +245,6 @@ jobs:
   - script: |
       set -eo pipefail
       make clangformat
-      git diff
       git diff --exit-code $(Build.SourceVersion)
 
     workingDirectory: build
@@ -254,7 +253,6 @@ jobs:
 
   - script: |
       set -eo pipefail
-      clang-tidy-8  src/override/malloc.cc  -header-filter="`pwd`/*" -export-fixes=tidy.fail -- -std=c++17 -mcx16
-      if [ -f tidy.fail ] ; then exit 1 ; fi
+      clang-tidy-9  src/override/malloc.cc  -header-filter="`pwd`/*" -warnings-as-errors='*' -export-fixes=tidy.fail -- -std=c++17 -mcx16
 
     displayName: 'Clang-Tidy'

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -61,7 +61,7 @@ namespace snmalloc
    * power of two.
    */
   template<size_t alignment, typename T = void>
-  inline T* pointer_align_down(void* p)
+  SNMALLOC_FAST_PATH T* pointer_align_down(void* p)
   {
     static_assert(alignment > 0);
     static_assert(bits::next_pow2_const(alignment) == alignment);

--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -54,7 +54,7 @@ namespace snmalloc
 
     static constexpr size_t ADDRESS_BITS = is64() ? 48 : 32;
 
-    inline size_t clz(size_t x)
+    SNMALLOC_FAST_PATH size_t clz(size_t x)
     {
 #if defined(_MSC_VER)
 #  ifdef USE_LZCNT
@@ -193,7 +193,7 @@ namespace snmalloc
 #endif
     }
 
-    inline size_t next_pow2(size_t x)
+    SNMALLOC_FAST_PATH size_t next_pow2(size_t x)
     {
       // Correct for numbers [0..MAX_SIZE >> 1).
       // Returns 1 for x > (MAX_SIZE >> 1).
@@ -223,7 +223,7 @@ namespace snmalloc
       return BITS - clz_const(x - 1);
     }
 
-    static inline size_t align_down(size_t value, size_t alignment)
+    static SNMALLOC_FAST_PATH size_t align_down(size_t value, size_t alignment)
     {
       assert(next_pow2(alignment) == alignment);
 

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -45,6 +45,7 @@ namespace snmalloc
       assert(rsize == sizeclass_to_size(meta.sizeclass));
       assert(sl.get_head() == (SlabLink*)pointer_offset(this, meta.link));
       assert(!meta.is_full());
+      meta.debug_slab_invariant(this);
 
       void* p = nullptr;
       bool p_has_value = false;
@@ -156,7 +157,6 @@ namespace snmalloc
       if (meta.is_unused())
         error("Detected potential double free.");
 #endif
-      meta.debug_slab_invariant(this);
 
       if (unlikely(meta.return_object()))
         return false;
@@ -170,7 +170,7 @@ namespace snmalloc
 
       // Set the next pointer to the previous head.
       Metaslab::store_next(p, head);
-      meta.debug_slab_invariant(this);
+
       return true;
     }
 
@@ -182,6 +182,7 @@ namespace snmalloc
     dealloc_slow(SlabList* sl, Superslab* super, void* p)
     {
       Metaslab& meta = super->get_meta(this);
+      meta.debug_slab_invariant(this);
 
       if (meta.is_full())
       {


### PR DESCRIPTION
With clangformat9 the AfterCaseLabel is introduced.
And this defaults to false, but our code is formatted
implicitly with this set to true.

PRs to Verona and Snmalloc are being formatted with clangformat9,
and this is causing complexity. Let's move forward to clangformat9
in CI.