### PR TITLE
Make Lazy Decomit asynchronous

### DIFF
--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -10,8 +10,8 @@ namespace snmalloc
   {
     /**
      * This PAL supports low memory notifications.  It must implement a
-     * `low_memory_epoch` method that returns a `uint64_t` of the number of
-     * times that a low-memory notification has been raised and an
+     * `register_for_low_memory_callback` method that allows callbacks to be
+     * registered when the platform detects low-memory and an
      * `expensive_low_memory_check()` method that returns a `bool` indicating
      * whether low memory conditions are still in effect.
      */
@@ -53,4 +53,63 @@ namespace snmalloc
    * Default Tag ID for the Apple class
    */
   static const int PALAnonDefaultID = 241;
+
+  /**
+   * This struct is used to represent callbacks for notification from the
+   * platform. It contains a next pointer as client is responsible for
+   * allocation as we cannot assume an allocator at this point.
+   **/
+  struct PalNotificationObject
+  {
+    std::atomic<PalNotificationObject*> pal_next;
+
+    void (*pal_notify)(PalNotificationObject* self);
+  };
+
+  /***
+   * Wrapper for managing notifications for PAL events
+   **/
+  class PalNotifier
+  {
+    /**
+     * List of callbacks to notify
+     **/
+    std::atomic<PalNotificationObject*> callbacks = nullptr;
+
+  public:
+    /**
+     * Register a callback object to be notified
+     *
+     * The object should never be deallocated by the client after calling
+     * this.
+     **/
+    void register_notification(PalNotificationObject* callback)
+    {
+      callback->pal_next = nullptr;
+
+      auto prev = &callbacks;
+      auto curr = prev->load();
+      do
+      {
+        while (curr != nullptr)
+        {
+          prev = &(curr->pal_next);
+          curr = prev->load();
+        }
+      } while (!prev->compare_exchange_weak(curr, callback));
+    }
+
+    /**
+     * Calls the pal_notify of all the registered objects.
+     **/
+    void notify_all()
+    {
+      PalNotificationObject* curr = callbacks;
+      while (curr != nullptr)
+      {
+        curr->pal_notify(curr);
+        curr = curr->pal_next;
+      }
+    }
+  };
 } // namespace snmalloc


### PR DESCRIPTION
On platforms that support low-memory notifications register callbacks
that perform lazy decommit. This allows idle processes to return memory
to the OS. Without incurring the cost of constantly committing and
decommitting memory.