### PR TITLE
Removing some calls into the C++ runtime

### DIFF
--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -38,7 +38,7 @@ namespace snmalloc
 
     static AllocPool* make() noexcept
     {
-      return make(default_memory_provider);
+      return make(default_memory_provider());
     }
 
     Alloc* acquire()

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -58,7 +58,7 @@ namespace snmalloc
   class MemoryProviderStateMixin : public PAL
   {
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
-    void* bump = 0;
+    void* bump = nullptr;
     size_t remaining = 0;
 
   public:
@@ -67,30 +67,28 @@ namespace snmalloc
      */
     ModArray<NUM_LARGE_CLASSES, MPMCStack<Largeslab, RequiresInit>> large_stack;
 
-  static MemoryProviderStateMixin<PAL>* make() noexcept
-  {
-    // Temporary storage to start the allocator in.
-    MemoryProviderStateMixin<PAL> local;
+    static MemoryProviderStateMixin<PAL>* make() noexcept
+    {
+      // Temporary storage to start the allocator in.
+      MemoryProviderStateMixin<PAL> local;
 
-    // Allocate permanent storage for the allocator usung temporary allocator
-    MemoryProviderStateMixin<PAL>* allocated 
-      = local.alloc_chunk<MemoryProviderStateMixin<PAL>, 1>();
+      // Allocate permanent storage for the allocator usung temporary allocator
+      MemoryProviderStateMixin<PAL>* allocated =
+        local.alloc_chunk<MemoryProviderStateMixin<PAL>, 1>();
 
-    // Put temporary allocator we have used, into the permanent storage.
-    // memcpy is safe as this is entirely single threaded.
-    memcpy(allocated, &local, sizeof(MemoryProviderStateMixin<PAL>));
+      // Put temporary allocator we have used, into the permanent storage.
+      // memcpy is safe as this is entirely single threaded.
+      memcpy(allocated, &local, sizeof(MemoryProviderStateMixin<PAL>));
 
-    return allocated;
-  }
+      return allocated;
+    }
 
   private:
-
     /**
      * The last time we saw a low memory notification.
      */
     std::atomic<uint64_t> last_low_memory_epoch = 0;
     std::atomic_flag lazy_decommit_guard = {};
-
 
     void new_block()
     {

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -57,9 +57,31 @@ namespace snmalloc
   template<class PAL>
   class MemoryProviderStateMixin : public PAL
   {
+    /**
+     * Flag to protect the bump allocator
+     **/
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
+
+    /**
+     * Pointer to block being bump allocated
+     **/
     void* bump = nullptr;
+
+    /**
+     * Space remaining in this block being bump allocated
+     **/
     size_t remaining = 0;
+
+    /**
+     * The last time we saw a low memory notification.
+     */
+    std::atomic<uint64_t> last_low_memory_epoch = 0;
+
+    /**
+     * Simple flag for checking if another instance of lazy-decommit is
+     * running
+     **/
+    std::atomic_flag lazy_decommit_guard = {};
 
   public:
     /**
@@ -67,9 +89,12 @@ namespace snmalloc
      */
     ModArray<NUM_LARGE_CLASSES, MPMCStack<Largeslab, RequiresInit>> large_stack;
 
+    /**
+     * Make a new memory provide for this PAL.
+     **/
     static MemoryProviderStateMixin<PAL>* make() noexcept
     {
-      // Temporary storage to start the allocator in.
+      // Temporary stack-based storage to start the allocator in.
       MemoryProviderStateMixin<PAL> local;
 
       // Allocate permanent storage for the allocator usung temporary allocator
@@ -84,12 +109,6 @@ namespace snmalloc
     }
 
   private:
-    /**
-     * The last time we saw a low memory notification.
-     */
-    std::atomic<uint64_t> last_low_memory_epoch = 0;
-    std::atomic_flag lazy_decommit_guard = {};
-
     void new_block()
     {
       // Reserve the smallest large_class which is SUPERSLAB_SIZE
@@ -289,8 +308,6 @@ namespace snmalloc
             offcut_start = offcut_end;
           }
         }
-
-        // printf("Alloc %zx (size = %zx)\n", start, size);
 
         void* result = pointer_cast<void>(start);
         if (committed)

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -153,7 +153,7 @@ namespace snmalloc
         if (e->compare_exchange_strong(
               value, LOCKED_ENTRY, std::memory_order_relaxed))
         {
-          auto& v = default_memory_provider;
+          auto& v = default_memory_provider();
           value = v.alloc_chunk<PagemapEntry, OS_PAGE_SIZE>();
           e->store(value, std::memory_order_release);
         }

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -41,7 +41,7 @@ namespace snmalloc
 
     static Pool* make() noexcept
     {
-      return Pool::make(default_memory_provider);
+      return Pool::make(default_memory_provider());
     }
 
     template<typename... Args>

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -87,12 +87,12 @@ namespace snmalloc
      **/
     static void register_cleanup()
     {
-#ifdef USE_SNMALLOC_STATS
+#  ifdef USE_SNMALLOC_STATS
       Singleton<int, atexit_print_stats>::get();
-#endif
+#  endif
     }
 
-#ifdef USE_SNMALLOC_STATS
+#  ifdef USE_SNMALLOC_STATS
     static void print_stats()
     {
       Stats s;
@@ -104,7 +104,7 @@ namespace snmalloc
     {
       return atexit(print_stats);
     }
-#endif
+#  endif
 
   public:
     /**
@@ -143,15 +143,15 @@ namespace snmalloc
      */
     static SNMALLOC_FAST_PATH Alloc* get()
     {
-#ifdef USE_MALLOC
+#  ifdef USE_MALLOC
       return get_reference();
-#else
+#  else
       auto alloc = get_reference();
       auto new_alloc = lazy_replacement(alloc);
       return (likely(new_alloc == nullptr)) ?
         alloc :
         reinterpret_cast<Alloc*>(new_alloc);
-#endif
+#  endif
     }
   };
 
@@ -200,7 +200,7 @@ namespace snmalloc
     }
   };
 
-#ifdef SNMALLOC_USE_THREAD_CLEANUP
+#  ifdef SNMALLOC_USE_THREAD_CLEANUP
   /**
    * Entry point that allows libc to call into the allocator for per-thread
    * cleanup.
@@ -210,9 +210,9 @@ namespace snmalloc
     ThreadAllocLibcCleanup::inner_release();
   }
   using ThreadAlloc = ThreadAllocLibcCleanup;
-#else
+#  else
   using ThreadAlloc = ThreadAllocThreadDestructor;
-#endif
+#  endif
 
   /**
    * Slow path for the placeholder replacement.  The simple check that this is

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -208,7 +208,7 @@ extern "C"
   SNMALLOC_EXPORT void*
     SNMALLOC_NAME_MANGLE(snmalloc_reserve_shared)(size_t* size, size_t align)
   {
-    return snmalloc::default_memory_provider.reserve<true>(size, align);
+    return snmalloc::default_memory_provider().reserve<true>(size, align);
   }
 #endif
 

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -11,7 +11,7 @@ namespace snmalloc
 {
   class PALOpenEnclave
   {
-    std::atomic<void*> oe_base;
+    std::atomic<void*> oe_base = nullptr;
 
   public:
     /**

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -19,6 +19,8 @@ extern "C" const void* __oe_get_heap_end()
 
 extern "C" void* oe_memset(void* p, int c, size_t size)
 {
+  std::cout << "Memset " << p << " - " << size << std::endl;
+
   return memset(p, c, size);
 }
 
@@ -30,7 +32,7 @@ extern "C" void oe_abort()
 using namespace snmalloc;
 int main()
 {
-  MemoryProviderStateMixin<DefaultPal> mp;
+  auto& mp = *MemoryProviderStateMixin<DefaultPal>::make();
 
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.

--- a/src/test/func/thread_alloc_external/thread_alloc_external.cc
+++ b/src/test/func/thread_alloc_external/thread_alloc_external.cc
@@ -1,0 +1,40 @@
+
+#define SNMALLOC_EXTERNAL_THREAD_ALLOC
+#include <mem/globalalloc.h>
+using namespace snmalloc;
+
+class ThreadAllocUntyped
+{
+public:
+  static void* get()
+  {
+    static thread_local void* alloc = nullptr;
+    if (alloc != nullptr)
+    {
+      return alloc;
+    }
+ 
+    alloc = current_alloc_pool()->acquire();
+    return alloc;
+  }
+};
+
+#include <override/malloc.cc>
+
+int main()
+{
+  MemoryProviderStateMixin<DefaultPal> mp;
+
+  // 28 is large enough to produce a nested allocator.
+  // It is also large enough for the example to run in.
+  // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
+ 
+  auto a = ThreadAlloc::get();
+
+  for (size_t i = 0; i < 1000; i++)
+  {
+    auto r1 = a->alloc(100);
+ 
+    free(r1);
+  }
+}

--- a/src/test/func/thread_alloc_external/thread_alloc_external.cc
+++ b/src/test/func/thread_alloc_external/thread_alloc_external.cc
@@ -26,17 +26,11 @@ int main()
 {
   setup();
 
-  MemoryProviderStateMixin<DefaultPal> mp;
-
-  // 28 is large enough to produce a nested allocator.
-  // It is also large enough for the example to run in.
-  // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
-
   auto a = ThreadAlloc::get();
 
   for (size_t i = 0; i < 1000; i++)
   {
-    auto r1 = a->alloc(100);
+    auto r1 = a->alloc(i);
 
     a->dealloc(r1);
   }

--- a/src/test/func/thread_alloc_external/thread_alloc_external.cc
+++ b/src/test/func/thread_alloc_external/thread_alloc_external.cc
@@ -14,7 +14,7 @@ public:
     {
       return alloc;
     }
- 
+
     alloc = current_alloc_pool()->acquire();
     return alloc;
   }
@@ -31,13 +31,13 @@ int main()
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.
   // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
- 
+
   auto a = ThreadAlloc::get();
 
   for (size_t i = 0; i < 1000; i++)
   {
     auto r1 = a->alloc(100);
- 
+
     a->dealloc(r1);
   }
 }

--- a/src/test/func/thread_alloc_external/thread_alloc_external.cc
+++ b/src/test/func/thread_alloc_external/thread_alloc_external.cc
@@ -1,3 +1,4 @@
+#include <test/setup.h>
 
 #define SNMALLOC_EXTERNAL_THREAD_ALLOC
 #include <mem/globalalloc.h>
@@ -19,10 +20,12 @@ public:
   }
 };
 
-#include <override/malloc.cc>
+#include <snmalloc.h>
 
 int main()
 {
+  setup();
+
   MemoryProviderStateMixin<DefaultPal> mp;
 
   // 28 is large enough to produce a nested allocator.
@@ -35,6 +38,6 @@ int main()
   {
     auto r1 = a->alloc(100);
  
-    free(r1);
+    a->dealloc(r1);
   }
 }

--- a/src/test/perf/low_memory/low-memory.cc
+++ b/src/test/perf/low_memory/low-memory.cc
@@ -57,7 +57,7 @@ bool has_pressure()
     return false;
   }
 
-  uint64_t current_epoch = default_memory_provider.low_memory_epoch();
+  uint64_t current_epoch = default_memory_provider().low_memory_epoch();
   bool result = epoch != current_epoch;
   epoch = current_epoch;
   return result;


### PR DESCRIPTION
These changes are to reduce the C++ runtime calls when the TLS state is managed externally.
This enables the code to be included in really restricted build environments such as Open Enclave where the allocator is needed before any of the C++ library is available.

The primary changes are to remove
```
GlobalPlaceHolder
```
as a global if not needed, and to convert 
```
default_memory_provider
```
from a C++ global with initialisation, into a pointer with our custom `Singleton` constructor.  This removes calls to 
```
__cxa_guard_acquire
```
and 
```
__cxa_guard_release
```