### PR TITLE
Address GCC8 warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,16 +25,16 @@ jobs:
         SelfHost: false
         CMakeArgs: ''
 
-      GCC-7 Debug:
-        CC: gcc-7
-        CXX: g++-7
+      GCC-8 Debug:
+        CC: gcc-8
+        CXX: g++-8
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
 
-      GCC-7 Release:
-        CC: gcc-7
-        CXX: g++-7
+      GCC-8 Release:
+        CC: gcc-8
+        CXX: g++-8
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
@@ -57,7 +57,7 @@ jobs:
   - script: |
       sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       sudo apt-get update
-      sudo apt-get install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-7 g++-7
+      sudo apt-get install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8
       # sudo apt-get install clang-6.0 clang++-6.0
 
       sudo update-alternatives --install /usr/bin/cc cc /usr/bin/$(CC) 100

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -18,6 +18,12 @@
 #  define SNMALLOC_PURE __attribute__((const))
 #endif
 
+#if !defined(__clang__) && defined(__GNUC__)
+#  if __GNUC__ >= 8
+#    define GCC_VERSION_EIGHT_PLUS
+#  endif
+#endif
+
 #ifndef __has_builtin
 #  define __has_builtin(x) 0
 #endif

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -102,9 +102,18 @@ namespace snmalloc
       MemoryProviderStateMixin<PAL>* allocated =
         local.alloc_chunk<MemoryProviderStateMixin<PAL>, 1>();
 
+#ifdef GCC_VERSION_EIGHT_PLUS
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
       // Put temporary allocator we have used, into the permanent storage.
-      // memcpy is safe as this is entirely single threaded.
+      // memcpy is safe as this is entirely single threaded: the move
+      // constructors were removed as unsafe to move std::atomic in a
+      // concurrent setting.
       memcpy(allocated, &local, sizeof(MemoryProviderStateMixin<PAL>));
+#ifdef GCC_VERSION_EIGHT_PLUS
+#  pragma GCC diagnostic pop
+#endif
 
       return allocated;
     }


### PR DESCRIPTION
The bootstrapping allocator needs to perform a memcpy to bypass the
removed move constructors on std::atomic.  This is safe as there is no
concurrency at this point, but GCC is unhappy with this.

This commit moves CI to GCC8 and disables this warning for that line.