### PR TITLE
Update the macOS image, since 10.13 is going out of support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ jobs:
 - job: 
   displayName: macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Debug:


### PR DESCRIPTION
I picked 10.15, since that's the newest, I don't know if 10.14 should also be covered.