### PR TITLE
Improve slow path performance for allocation

### DIFF
--- a/difference.md
+++ b/difference.md
@@ -33,7 +33,10 @@ This document outlines the changes that have diverged from
   4.  We now store a direct pointer to the next element in each slabs free list
       rather than a relative offset into the slab.  This enables list
       calculation on the fast path.
-
+ 
+  5.  There is a single bump-ptr per size class that is part of the
+      allocator structure.  The per size class slab list now only contains slabs
+      with free list, and not if it only has a bump ptr.
 
 [2-4]  Are changes that are directly inspired by
 (mimalloc)[http://github.com/microsoft/mimalloc].

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -25,6 +25,15 @@ namespace snmalloc
   }
 
   /**
+   * Perform pointer arithmetic and return the adjusted pointer.
+   */
+  template<typename T>
+  inline T* pointer_offset_signed(T* base, ptrdiff_t diff)
+  {
+    return reinterpret_cast<T*>(reinterpret_cast<char*>(base) + diff);
+  }
+
+  /**
    * Cast from a pointer type to an address.
    */
   template<typename T>
@@ -115,4 +124,15 @@ namespace snmalloc
     return static_cast<size_t>(
       static_cast<char*>(cursor) - static_cast<char*>(base));
   }
+
+  /**
+   * Compute the difference in pointers in units of char. This can be used
+   * across allocations.
+   */
+  inline ptrdiff_t pointer_diff_signed(void* base, void* cursor)
+  {
+    return static_cast<ptrdiff_t>(
+      static_cast<char*>(cursor) - static_cast<char*>(base));
+  }
+
 } // namespace snmalloc

--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -328,7 +328,7 @@ namespace snmalloc
      *
      * `std::min` is in `<algorithm>`, so pulls in a lot of unneccessary code
      * We write our own to reduce the code that potentially needs reviewing.
-     */
+     **/
     template<typename T>
     constexpr inline T min(T t1, T t2)
     {
@@ -340,7 +340,7 @@ namespace snmalloc
      *
      * `std::max` is in `<algorithm>`, so pulls in a lot of unneccessary code
      * We write our own to reduce the code that potentially needs reviewing.
-     */
+     **/
     template<typename T>
     constexpr inline T max(T t1, T t2)
     {

--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -328,7 +328,7 @@ namespace snmalloc
      *
      * `std::min` is in `<algorithm>`, so pulls in a lot of unneccessary code
      * We write our own to reduce the code that potentially needs reviewing.
-     **/
+     */
     template<typename T>
     constexpr inline T min(T t1, T t2)
     {
@@ -340,7 +340,7 @@ namespace snmalloc
      *
      * `std::max` is in `<algorithm>`, so pulls in a lot of unneccessary code
      * We write our own to reduce the code that potentially needs reviewing.
-     **/
+     */
     template<typename T>
     constexpr inline T max(T t1, T t2)
     {

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "defines.h"
+
 #include <cstdint>
 #include <type_traits>
-#include "defines.h"
 
 namespace snmalloc
 {
@@ -44,7 +45,7 @@ namespace snmalloc
       // As this is no longer in the list, check invariant for
       // neighbouring element.
       next->debug_check();
-      
+
 #ifndef NDEBUG
       next = nullptr;
       prev = nullptr;

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -18,6 +18,9 @@ namespace snmalloc
     CDLLNode* prev;
 
   public:
+    /**
+     * Single element cyclic list.  This is the empty case.
+     **/
     CDLLNode()
     {
       next = this;
@@ -29,12 +32,17 @@ namespace snmalloc
       return next == this;
     }
 
+    /**
+     * Removes this element from the cyclic list is it part of.
+     **/
     SNMALLOC_FAST_PATH void remove()
     {
       SNMALLOC_ASSERT(!is_empty());
       debug_check();
       next->prev = prev;
       prev->next = next;
+      // As this is no longer in the list, check invariant for
+      // neighbouring element.
       next->debug_check();
       
 #ifndef NDEBUG
@@ -73,6 +81,11 @@ namespace snmalloc
       debug_check();
     }
 
+    /**
+     * Checks the lists invariants
+     *   x->next->prev = x
+     * for all x in the list.
+     **/
     void debug_check()
     {
 #ifndef NDEBUG

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -11,7 +11,7 @@ namespace snmalloc
    * Special class for cyclic doubly linked non-empty linked list
    *
    * This code assumes there is always one element in the list. The client
-   * must ensure there is a sentinal element.
+   */ust ensure there is a sentinal element.
    **/
   class CDLLNode
   {
@@ -20,7 +20,7 @@ namespace snmalloc
 
   public:
     /**
-     * Single element cyclic list.  This is the empty case.
+     */ingle element cyclic list.  This is the empty case.
      **/
     CDLLNode()
     {
@@ -34,7 +34,7 @@ namespace snmalloc
     }
 
     /**
-     * Removes this element from the cyclic list is it part of.
+     */emoves this element from the cyclic list is it part of.
      **/
     SNMALLOC_FAST_PATH void remove()
     {
@@ -85,7 +85,7 @@ namespace snmalloc
     /**
      * Checks the lists invariants
      *   x->next->prev = x
-     * for all x in the list.
+     */or all x in the list.
      **/
     void debug_check()
     {

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include "defines.h"
+
+namespace snmalloc
+{
+  /**
+   * Special class for cyclic doubly linked non-empty linked list
+   *
+   * This code assumes there is always one element in the list. The client
+   * must ensure there is a sentinal element.
+   **/
+  class CDLLNode
+  {
+    CDLLNode* next;
+    CDLLNode* prev;
+
+  public:
+    CDLLNode()
+    {
+      next = this;
+      prev = this;
+    }
+
+    SNMALLOC_FAST_PATH bool is_empty()
+    {
+      return next == this;
+    }
+
+    SNMALLOC_FAST_PATH void remove()
+    {
+      SNMALLOC_ASSERT(!is_empty());
+      debug_check();
+      next->prev = prev;
+      prev->next = next;
+      next->debug_check();
+      
+#ifndef NDEBUG
+      next = nullptr;
+      prev = nullptr;
+#endif
+    }
+
+    SNMALLOC_FAST_PATH CDLLNode* get_next()
+    {
+      return next;
+    }
+
+    SNMALLOC_FAST_PATH CDLLNode* get_prev()
+    {
+      return prev;
+    }
+
+    SNMALLOC_FAST_PATH void insert_next(CDLLNode* item)
+    {
+      debug_check();
+      item->next = next;
+      next->prev = item;
+      item->prev = this;
+      next = item;
+      debug_check();
+    }
+
+    SNMALLOC_FAST_PATH void insert_prev(CDLLNode* item)
+    {
+      debug_check();
+      item->prev = prev;
+      prev->next = item;
+      item->next = this;
+      prev = item;
+      debug_check();
+    }
+
+    void debug_check()
+    {
+#ifndef NDEBUG
+      CDLLNode* item = this->next;
+      CDLLNode* p = this;
+
+      do
+      {
+        SNMALLOC_ASSERT(item->prev == p);
+        p = item;
+        item = item->next;
+      } while (item != this);
+#endif
+    }
+  };
+} // namespace snmalloc

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -12,7 +12,7 @@ namespace snmalloc
    *
    * This code assumes there is always one element in the list. The client
    * must ensure there is a sentinal element.
-   **/
+   */
   class CDLLNode
   {
     CDLLNode* next;
@@ -21,7 +21,7 @@ namespace snmalloc
   public:
     /**
      * Single element cyclic list.  This is the empty case.
-     **/
+     */
     CDLLNode()
     {
       next = this;
@@ -35,7 +35,7 @@ namespace snmalloc
 
     /**
      * Removes this element from the cyclic list is it part of.
-     **/
+     */
     SNMALLOC_FAST_PATH void remove()
     {
       SNMALLOC_ASSERT(!is_empty());
@@ -86,7 +86,7 @@ namespace snmalloc
      * Checks the lists invariants
      *   x->next->prev = x
      * for all x in the list.
-     **/
+     */
     void debug_check()
     {
 #ifndef NDEBUG

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -22,14 +22,14 @@ namespace snmalloc
      */
     ptrdiff_t to_next = 0;
 
-// TODO: CHERI will need a real pointer too
-//    CDLLNode* next = nullptr;
+    // TODO: CHERI will need a real pointer too
+    //    CDLLNode* next = nullptr;
     CDLLNode* prev = nullptr;
 
     void set_next(CDLLNode* c)
     {
-// TODO: CHERI will need a real pointer too
-//      next = c;
+      // TODO: CHERI will need a real pointer too
+      //      next = c;
       to_next = pointer_diff_signed(this, c);
     }
 
@@ -69,8 +69,8 @@ namespace snmalloc
 
     SNMALLOC_FAST_PATH CDLLNode* get_next()
     {
-// TODO: CHERI will require a real pointer
-//    return next;
+      // TODO: CHERI will require a real pointer
+      //    return next;
       return pointer_offset_signed(this, to_next);
     }
 

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -30,7 +30,7 @@ namespace snmalloc
     {
 // TODO: CHERI will need a real pointer too
 //      next = c;
-      to_next = pointer_diff(c, this);
+      to_next = pointer_diff_signed(this, c);
     }
 
   public:
@@ -71,7 +71,7 @@ namespace snmalloc
     {
 // TODO: CHERI will require a real pointer
 //    return next;
-      return pointer_offset(this, to_next);
+      return pointer_offset_signed(this, to_next);
     }
 
     SNMALLOC_FAST_PATH CDLLNode* get_prev()

--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -11,7 +11,7 @@ namespace snmalloc
    * Special class for cyclic doubly linked non-empty linked list
    *
    * This code assumes there is always one element in the list. The client
-   */ust ensure there is a sentinal element.
+   * must ensure there is a sentinal element.
    **/
   class CDLLNode
   {
@@ -20,7 +20,7 @@ namespace snmalloc
 
   public:
     /**
-     */ingle element cyclic list.  This is the empty case.
+     * Single element cyclic list.  This is the empty case.
      **/
     CDLLNode()
     {
@@ -34,7 +34,7 @@ namespace snmalloc
     }
 
     /**
-     */emoves this element from the cyclic list is it part of.
+     * Removes this element from the cyclic list is it part of.
      **/
     SNMALLOC_FAST_PATH void remove()
     {
@@ -85,7 +85,7 @@ namespace snmalloc
     /**
      * Checks the lists invariants
      *   x->next->prev = x
-     */or all x in the list.
+     * for all x in the list.
      **/
     void debug_check()
     {

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -94,12 +94,12 @@ namespace snmalloc
       return *this;
     }
 
-    bool is_empty()
+    SNMALLOC_FAST_PATH bool is_empty()
     {
       return head == Terminator();
     }
 
-    T* get_head()
+    SNMALLOC_FAST_PATH T* get_head()
     {
       return head;
     }
@@ -109,7 +109,7 @@ namespace snmalloc
       return tail;
     }
 
-    T* pop()
+    SNMALLOC_FAST_PATH T* pop()
     {
       T* item = head;
 
@@ -169,7 +169,7 @@ namespace snmalloc
 #endif
     }
 
-    void remove(T* item)
+    SNMALLOC_FAST_PATH void remove(T* item)
     {
 #ifndef NDEBUG
       debug_check_contains(item);

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -48,7 +48,7 @@ namespace snmalloc
    *
    * Wraps on read. This allows code to trust the value is in range, even when
    * there is a memory corruption.
-   **/
+   */
   template<size_t length, typename T>
   class Mod
   {

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -48,7 +48,7 @@ namespace snmalloc
    *
    * Wraps on read. This allows code to trust the value is in range, even when
    * there is a memory corruption.
-   */
+   **/
   template<size_t length, typename T>
   class Mod
   {

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -98,7 +98,7 @@ namespace snmalloc
      * If aligned to a SLAB start, then it is empty, and a new
      * slab is required.
      */
-    void* bump_ptrs[NUM_SMALL_CLASSES] = {0};
+    void* bump_ptrs[NUM_SMALL_CLASSES] = {nullptr};
 
   public:
     Stats& stats()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1281,7 +1281,8 @@ namespace snmalloc
     }
 
     SNMALLOC_SLOW_PATH
-    void remote_dealloc_slow(RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
+    void remote_dealloc_slow(
+      RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
     {
       MEASURE_TIME(remote_dealloc, 4, 16);
       SNMALLOC_ASSERT(target->id() != id());

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1277,12 +1277,13 @@ namespace snmalloc
         return;
       }
 
-      remote_dealloc_slow(target, p, sizeclass);
+      remote_dealloc_slow(target, p , sizeclass);
     }
 
-    SNMALLOC_SLOW_PATH void
-    remote_dealloc_slow(RemoteAllocator* target, void* p, sizeclass_t sizeclass)
+    SNMALLOC_SLOW_PATH
+    void remote_dealloc_slow(RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
     {
+      MEASURE_TIME(remote_dealloc, 4, 16);
       SNMALLOC_ASSERT(target->id() != id());
 
       // Now that we've established that we're in the slow path (if we're a
@@ -1290,6 +1291,7 @@ namespace snmalloc
       // a real allocator and construct one if we aren't.
       if (void* replacement = Replacement(this))
       {
+        void* p = remove_cache_friendly_offset(offseted, sizeclass);
         // We have to do a dealloc, not a remote_dealloc here because this may
         // have been allocated with the allocator that we've just had returned.
         reinterpret_cast<Allocator*>(replacement)->dealloc(p);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1012,7 +1012,8 @@ namespace snmalloc
     }
 
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
-    SNMALLOC_FAST_PATH void* small_alloc_inner(sizeclass_t sizeclass, size_t size)
+    SNMALLOC_FAST_PATH void*
+    small_alloc_inner(sizeclass_t sizeclass, size_t size)
     {
       SNMALLOC_ASSUME(sizeclass < NUM_SMALL_CLASSES);
       auto& fl = small_fast_free_lists[sizeclass];
@@ -1033,7 +1034,8 @@ namespace snmalloc
       }
 
       if (likely(!has_messages()))
-        return small_alloc_next_free_list<zero_mem, allow_reserve>(sizeclass, size);
+        return small_alloc_next_free_list<zero_mem, allow_reserve>(
+          sizeclass, size);
 
       return small_alloc_mq_slow<zero_mem, allow_reserve>(sizeclass, size);
     }
@@ -1043,18 +1045,21 @@ namespace snmalloc
      * allocation request.
      */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
-    SNMALLOC_SLOW_PATH void* small_alloc_mq_slow(sizeclass_t sizeclass, size_t size)
+    SNMALLOC_SLOW_PATH void*
+    small_alloc_mq_slow(sizeclass_t sizeclass, size_t size)
     {
       handle_message_queue_inner();
 
-      return small_alloc_next_free_list<zero_mem, allow_reserve>(sizeclass, size);
+      return small_alloc_next_free_list<zero_mem, allow_reserve>(
+        sizeclass, size);
     }
 
     /**
      * Attempt to find a new free list to allocate from
      */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
-    SNMALLOC_SLOW_PATH void* small_alloc_next_free_list(sizeclass_t sizeclass, size_t size)
+    SNMALLOC_SLOW_PATH void*
+    small_alloc_next_free_list(sizeclass_t sizeclass, size_t size)
     {
       size_t rsize = sizeclass_to_size(sizeclass);
       auto& sl = small_classes[sizeclass];
@@ -1081,7 +1086,8 @@ namespace snmalloc
      * new free list.
      */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
-    SNMALLOC_SLOW_PATH void* small_alloc_rare(sizeclass_t sizeclass, size_t size)
+    SNMALLOC_SLOW_PATH void*
+    small_alloc_rare(sizeclass_t sizeclass, size_t size)
     {
       if (likely(!NeedsInitialisation(this)))
       {
@@ -1097,7 +1103,8 @@ namespace snmalloc
      * then directs the allocation request to the newly created allocator.
      */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
-    SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(sizeclass_t sizeclass, size_t size)
+    SNMALLOC_SLOW_PATH void*
+    small_alloc_first_alloc(sizeclass_t sizeclass, size_t size)
     {
       auto replacement = InitThreadAllocator();
       return reinterpret_cast<Allocator*>(replacement)

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -996,8 +996,9 @@ namespace snmalloc
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_slow(sizeclass_t sizeclass)
     {
-      if (void* replacement = Replacement(this))
+      if (IsFirstAllocation(this))
       {
+        void* replacement = InitThreadAllocator();
         return reinterpret_cast<Allocator*>(replacement)
           ->template small_alloc_inner<zero_mem, allow_reserve>(sizeclass);
       }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1280,9 +1280,8 @@ namespace snmalloc
       remote_dealloc_slow(target, p, sizeclass);
     }
 
-    SNMALLOC_SLOW_PATH
-    void remote_dealloc_slow(
-      RemoteAllocator* target, void* p, sizeclass_t sizeclass)
+    SNMALLOC_SLOW_PATH void
+    remote_dealloc_slow(RemoteAllocator* target, void* p, sizeclass_t sizeclass)
     {
       SNMALLOC_ASSERT(target->id() != id());
 

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1277,16 +1277,15 @@ namespace snmalloc
         return;
       }
 
-      remote_dealloc_slow(target, p , sizeclass);
+      remote_dealloc_slow(target, p, sizeclass);
     }
 
     SNMALLOC_SLOW_PATH
     void remote_dealloc_slow(
       RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
     {
-      MEASURE_TIME(remote_dealloc, 4, 16);
       SNMALLOC_ASSERT(target->id() != id());
-
+      
       // Now that we've established that we're in the slow path (if we're a
       // real allocator, we will have to empty our cache now), check if we are
       // a real allocator and construct one if we aren't.

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1255,11 +1255,10 @@ namespace snmalloc
       large_allocator.dealloc(slab, large_class);
     }
 
-    // Note that this is on the slow path as it lead to better code.
-    // As it is tail, not inlining means that it is jumped to, so has no perf
-    // impact on the producer consumer scenarios, and doesn't require register
-    // spills in the fast path for local deallocation.
-    SNMALLOC_SLOW_PATH
+    // This is still considered the fast path as all the complex code is tail
+    // called in its slow path. This leads to one fewer unconditional jump in
+    // Clang.
+    SNMALLOC_FAST_PATH
     void remote_dealloc(RemoteAllocator* target, void* p, sizeclass_t sizeclass)
     {
       MEASURE_TIME(remote_dealloc, 4, 16);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1001,7 +1001,7 @@ namespace snmalloc
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_mq_slow(sizeclass_t sizeclass)
     {
-      handle_message_queue();
+      handle_message_queue_inner();
 
       return small_alloc_new_free_list<zero_mem, allow_reserve>(sizeclass);
     }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1285,7 +1285,7 @@ namespace snmalloc
       RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
     {
       SNMALLOC_ASSERT(target->id() != id());
-      
+
       // Now that we've established that we're in the slow path (if we're a
       // real allocator, we will have to empty our cache now), check if we are
       // a real allocator and construct one if we aren't.

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -714,7 +714,7 @@ namespace snmalloc
      *
      * If result pointer is null, then this code raises a Pal::error on the
      * particular check that fails, if any do fail.
-     */
+     **/
     void debug_is_empty(bool* result)
     {
       auto test = [&result](auto& queue) {
@@ -890,7 +890,7 @@ namespace snmalloc
     /**
      * Check if this allocator has messages to deallocate blocks from another
      * thread
-     */
+     **/
     SNMALLOC_FAST_PATH bool has_messages()
     {
       return !(message_queue().is_empty());
@@ -1042,7 +1042,7 @@ namespace snmalloc
     /**
      * Slow path for handling message queue, before dealing with small
      * allocation request.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_mq_slow(sizeclass_t sizeclass)
     {
@@ -1053,7 +1053,7 @@ namespace snmalloc
 
     /**
      * Attempt to find a new free list to allocate from
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_next_free_list(sizeclass_t sizeclass)
     {
@@ -1079,7 +1079,7 @@ namespace snmalloc
      * Called when there are no available free list to service this request
      * Could be due to using the dummy allocator, or needing to bump allocate a
      * new free list.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_rare(sizeclass_t sizeclass)
     {
@@ -1094,7 +1094,7 @@ namespace snmalloc
     /**
      * Called on first allocation to set up the thread local allocator,
      * then directs the allocation request to the newly created allocator.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(sizeclass_t sizeclass)
     {
@@ -1106,7 +1106,7 @@ namespace snmalloc
     /**
      * Called to create a new free list, and service the request from that new
      * list.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_new_free_list(sizeclass_t sizeclass)
     {
@@ -1122,7 +1122,7 @@ namespace snmalloc
     /**
      * Creates a new free list from the thread local bump allocator and service
      * the request from that new list.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_build_free_list(sizeclass_t sizeclass)
     {
@@ -1146,7 +1146,7 @@ namespace snmalloc
      * Allocates a new slab to allocate from, set it to be the bump allocator
      * for this size class, and then builds a new free list from the thread
      * local bump allocator and service the request from that new list.
-     */
+     **/
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_new_slab(sizeclass_t sizeclass)
     {

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1267,6 +1267,13 @@ namespace snmalloc
     {
       MEASURE_TIME(large_dealloc, 4, 16);
 
+      if (IsFirstAllocation(this))
+      {
+        void* replacement = InitThreadAllocator();
+        return reinterpret_cast<Allocator*>(replacement)
+          ->large_dealloc(p, size);
+      }
+
       size_t size_bits = bits::next_pow2_bits(size);
       SNMALLOC_ASSERT(bits::one_at_bit(size_bits) >= SUPERSLAB_SIZE);
       size_t large_class = size_bits - SUPERSLAB_BITS;

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -858,7 +858,7 @@ namespace snmalloc
     SNMALLOC_FAST_PATH void handle_message_queue()
     {
       // Inline the empty check, but not necessarily the full queue handling.
-      if (likely(message_queue().is_empty()))
+      if (likely(!has_messages()))
         return;
 
       handle_message_queue_inner();
@@ -1004,7 +1004,7 @@ namespace snmalloc
       handle_message_queue();
 
       return small_alloc_new_free_list<zero_mem, allow_reserve>(sizeclass);
-      }
+    }
 
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_new_free_list(sizeclass_t sizeclass)
@@ -1031,11 +1031,11 @@ namespace snmalloc
         return small_alloc_new_slab<zero_mem, allow_reserve>(sizeclass);
       }
       return small_alloc_first_alloc<zero_mem, allow_reserve>(sizeclass);
-      }
+    }
 
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(sizeclass_t sizeclass)
-      {
+    {
       auto replacement = InitThreadAllocator();
       return reinterpret_cast<Allocator*>(replacement)
         ->template small_alloc_inner<zero_mem, allow_reserve>(sizeclass);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -269,7 +269,7 @@ namespace snmalloc
     SNMALLOC_SLOW_PATH void dealloc_sized_slow(void* p, size_t size)
     {
       if (size == 0)
-        dealloc(p, 1);
+        return dealloc(p, 1);
 
       if (likely(size <= sizeclass_to_size(NUM_SIZECLASSES - 1)))
       {

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1282,7 +1282,7 @@ namespace snmalloc
 
     SNMALLOC_SLOW_PATH
     void remote_dealloc_slow(
-      RemoteAllocator* target, void* offseted, sizeclass_t sizeclass)
+      RemoteAllocator* target, void* p, sizeclass_t sizeclass)
     {
       SNMALLOC_ASSERT(target->id() != id());
 
@@ -1291,7 +1291,6 @@ namespace snmalloc
       // a real allocator and construct one if we aren't.
       if (void* replacement = Replacement(this))
       {
-        void* p = remove_cache_friendly_offset(offseted, sizeclass);
         // We have to do a dealloc, not a remote_dealloc here because this may
         // have been allocated with the allocator that we've just had returned.
         reinterpret_cast<Allocator*>(replacement)->dealloc(p);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1129,7 +1129,7 @@ namespace snmalloc
       auto& bp = bump_ptrs[sizeclass];
       auto rsize = sizeclass_to_size(sizeclass);
       auto& ffl = small_fast_free_lists[sizeclass];
-      assert(ffl.value == nullptr);
+      SNMALLOC_ASSERT(ffl.value == nullptr);
       Slab::alloc_new_list(bp, ffl, rsize);
 
       void* p = remove_cache_friendly_offset(ffl.value, sizeclass);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -714,7 +714,7 @@ namespace snmalloc
      *
      * If result pointer is null, then this code raises a Pal::error on the
      * particular check that fails, if any do fail.
-     **/
+     */
     void debug_is_empty(bool* result)
     {
       auto test = [&result](auto& queue) {
@@ -890,7 +890,7 @@ namespace snmalloc
     /**
      * Check if this allocator has messages to deallocate blocks from another
      * thread
-     **/
+     */
     SNMALLOC_FAST_PATH bool has_messages()
     {
       return !(message_queue().is_empty());
@@ -1042,7 +1042,7 @@ namespace snmalloc
     /**
      * Slow path for handling message queue, before dealing with small
      * allocation request.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_mq_slow(sizeclass_t sizeclass)
     {
@@ -1053,7 +1053,7 @@ namespace snmalloc
 
     /**
      * Attempt to find a new free list to allocate from
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_next_free_list(sizeclass_t sizeclass)
     {
@@ -1079,7 +1079,7 @@ namespace snmalloc
      * Called when there are no available free list to service this request
      * Could be due to using the dummy allocator, or needing to bump allocate a
      * new free list.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_rare(sizeclass_t sizeclass)
     {
@@ -1094,7 +1094,7 @@ namespace snmalloc
     /**
      * Called on first allocation to set up the thread local allocator,
      * then directs the allocation request to the newly created allocator.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(sizeclass_t sizeclass)
     {
@@ -1106,7 +1106,7 @@ namespace snmalloc
     /**
      * Called to create a new free list, and service the request from that new
      * list.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_new_free_list(sizeclass_t sizeclass)
     {
@@ -1122,7 +1122,7 @@ namespace snmalloc
     /**
      * Creates a new free list from the thread local bump allocator and service
      * the request from that new list.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_FAST_PATH void* small_alloc_build_free_list(sizeclass_t sizeclass)
     {
@@ -1146,7 +1146,7 @@ namespace snmalloc
      * Allocates a new slab to allocate from, set it to be the bump allocator
      * for this size class, and then builds a new free list from the thread
      * local bump allocator and service the request from that new list.
-     **/
+     */
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_new_slab(sizeclass_t sizeclass)
     {

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -199,17 +199,14 @@ namespace snmalloc
       UNUSED(size);
       return free(p);
 #else
-
       constexpr sizeclass_t sizeclass = size_to_sizeclass_const(size);
-
-      handle_message_queue();
 
       if (sizeclass < NUM_SMALL_CLASSES)
       {
         Superslab* super = Superslab::get(p);
         RemoteAllocator* target = super->get_allocator();
 
-        if (target == public_state())
+        if (likely(target == public_state()))
           small_dealloc(super, p, sizeclass);
         else
           remote_dealloc(target, p, sizeclass);
@@ -219,7 +216,7 @@ namespace snmalloc
         Mediumslab* slab = Mediumslab::get(p);
         RemoteAllocator* target = slab->get_allocator();
 
-        if (target == public_state())
+        if (likely(target == public_state()))
           medium_dealloc(slab, p, sizeclass);
         else
           remote_dealloc(target, p, sizeclass);

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -125,7 +125,7 @@ namespace snmalloc
         bits::one_at_bit(bits::ADDRESS_BITS - 1));
 
     Stats sizeclass[N];
-    
+
     size_t large_pop_count[LARGE_N] = {0};
     size_t large_push_count[LARGE_N] = {0};
 
@@ -354,8 +354,7 @@ namespace snmalloc
             << "Size group"
             << "Size"
             << "Push count"
-            << "Pop count"
-            << csv.endl;
+            << "Pop count" << csv.endl;
 
         csv << "AllocSizes"
             << "DumpID"

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -125,7 +125,9 @@ namespace snmalloc
         bits::one_at_bit(bits::ADDRESS_BITS - 1));
 
     Stats sizeclass[N];
-    Stats large[LARGE_N];
+    
+    size_t large_pop_count[LARGE_N] = {0};
+    size_t large_push_count[LARGE_N] = {0};
 
     size_t remote_freed = 0;
     size_t remote_posted = 0;
@@ -159,7 +161,7 @@ namespace snmalloc
 
       for (size_t i = 0; i < LARGE_N; i++)
       {
-        if (!large[i].is_empty())
+        if (large_push_count[i] != large_pop_count[i])
           return false;
       }
 
@@ -194,7 +196,7 @@ namespace snmalloc
       UNUSED(sc);
 
 #ifdef USE_SNMALLOC_STATS
-      large[sc].count.inc();
+      large_pop_count[sc]++;
 #endif
     }
 
@@ -223,7 +225,7 @@ namespace snmalloc
       UNUSED(sc);
 
 #ifdef USE_SNMALLOC_STATS
-      large[sc].count.dec();
+      large_push_count[sc]++;
 #endif
     }
 
@@ -289,7 +291,10 @@ namespace snmalloc
         sizeclass[i].add(that.sizeclass[i]);
 
       for (size_t i = 0; i < LARGE_N; i++)
-        large[i].add(that.large[i]);
+      {
+        large_push_count[i] += that.large_push_count[i];
+        large_pop_count[i] += that.large_pop_count[i];
+      }
 
       for (size_t i = 0; i < TOTAL_BUCKETS; i++)
         bucketed_requests[i] += that.bucketed_requests[i];
@@ -343,6 +348,15 @@ namespace snmalloc
             << "Average Slab Usage"
             << "Average wasted space" << csv.endl;
 
+        csv << "LargeBucketedStats"
+            << "DumpID"
+            << "AllocatorID"
+            << "Size group"
+            << "Size"
+            << "Push count"
+            << "Pop count"
+            << csv.endl;
+
         csv << "AllocSizes"
             << "DumpID"
             << "AllocatorID"
@@ -367,13 +381,12 @@ namespace snmalloc
 
       for (uint8_t i = 0; i < LARGE_N; i++)
       {
-        if (large[i].count.is_unused())
+        if ((large_push_count[i] == 0) && (large_pop_count[i] == 0))
           continue;
 
-        csv << "BucketedStats" << dumpid << allocatorid << (i + N)
-            << large_sizeclass_to_size(i);
-
-        large[i].print(csv, large_sizeclass_to_size(i));
+        csv << "LargeBucketedStats" << dumpid << allocatorid << (i + N)
+            << large_sizeclass_to_size(i) << large_push_count[i]
+            << large_pop_count[i] << csv.endl;
       }
 
       size_t low = 0;

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -6,24 +6,26 @@
 
 namespace snmalloc
 {
-  inline void* lazy_replacement(void*);
+  inline bool first_allocation(void*);
+  void* init_thread_allocator();
+
   using Alloc =
-    Allocator<GlobalVirtual, SNMALLOC_DEFAULT_CHUNKMAP, true, lazy_replacement>;
+    Allocator<first_allocation, init_thread_allocator, GlobalVirtual, SNMALLOC_DEFAULT_CHUNKMAP, true>;
 
   template<class MemoryProvider>
   class AllocPool : Pool<
                       Allocator<
+                        first_allocation, init_thread_allocator,
                         MemoryProvider,
                         SNMALLOC_DEFAULT_CHUNKMAP,
-                        true,
-                        lazy_replacement>,
+                        true>,
                       MemoryProvider>
   {
     using Alloc = Allocator<
-      MemoryProvider,
+      first_allocation, init_thread_allocator, MemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
-      true,
-      lazy_replacement>;
+      true
+      >;
     using Parent = Pool<Alloc, MemoryProvider>;
 
   public:

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -6,23 +6,23 @@
 
 namespace snmalloc
 {
-  inline bool first_allocation(void*);
+  inline bool needs_initialisation(void*);
   void* init_thread_allocator();
 
   using Alloc =
-    Allocator<first_allocation, init_thread_allocator, GlobalVirtual, SNMALLOC_DEFAULT_CHUNKMAP, true>;
+    Allocator<needs_initialisation, init_thread_allocator, GlobalVirtual, SNMALLOC_DEFAULT_CHUNKMAP, true>;
 
   template<class MemoryProvider>
   class AllocPool : Pool<
                       Allocator<
-                        first_allocation, init_thread_allocator,
+                        needs_initialisation, init_thread_allocator,
                         MemoryProvider,
                         SNMALLOC_DEFAULT_CHUNKMAP,
                         true>,
                       MemoryProvider>
   {
     using Alloc = Allocator<
-      first_allocation, init_thread_allocator, MemoryProvider,
+      needs_initialisation, init_thread_allocator, MemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
       true
       >;

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -9,23 +9,29 @@ namespace snmalloc
   inline bool needs_initialisation(void*);
   void* init_thread_allocator();
 
-  using Alloc =
-    Allocator<needs_initialisation, init_thread_allocator, GlobalVirtual, SNMALLOC_DEFAULT_CHUNKMAP, true>;
+  using Alloc = Allocator<
+    needs_initialisation,
+    init_thread_allocator,
+    GlobalVirtual,
+    SNMALLOC_DEFAULT_CHUNKMAP,
+    true>;
 
   template<class MemoryProvider>
   class AllocPool : Pool<
                       Allocator<
-                        needs_initialisation, init_thread_allocator,
+                        needs_initialisation,
+                        init_thread_allocator,
                         MemoryProvider,
                         SNMALLOC_DEFAULT_CHUNKMAP,
                         true>,
                       MemoryProvider>
   {
     using Alloc = Allocator<
-      needs_initialisation, init_thread_allocator, MemoryProvider,
+      needs_initialisation,
+      init_thread_allocator,
+      MemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
-      true
-      >;
+      true>;
     using Parent = Pool<Alloc, MemoryProvider>;
 
   public:

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -60,23 +60,23 @@ namespace snmalloc
   {
     /**
      * Flag to protect the bump allocator
-     */
+     **/
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
 
     /**
      * Pointer to block being bump allocated
-     */
+     **/
     void* bump = nullptr;
 
     /**
      * Space remaining in this block being bump allocated
-     */
+     **/
     size_t remaining = 0;
 
     /**
      * Simple flag for checking if another instance of lazy-decommit is
      * running
-     */
+     **/
     std::atomic_flag lazy_decommit_guard = {};
 
   public:
@@ -87,7 +87,7 @@ namespace snmalloc
 
     /**
      * Make a new memory provide for this PAL.
-     */
+     **/
     static MemoryProviderStateMixin<PAL>* make() noexcept
     {
       // Temporary stack-based storage to start the allocator in.
@@ -197,7 +197,7 @@ namespace snmalloc
 
     /***
      * Method for callback object to perform lazy decommit.
-     */
+     **/
     static void process(PalNotificationObject* p)
     {
       // Unsafe downcast here. Don't want vtable and RTTI.

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -60,23 +60,23 @@ namespace snmalloc
   {
     /**
      * Flag to protect the bump allocator
-     **/
+     */
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
 
     /**
      * Pointer to block being bump allocated
-     **/
+     */
     void* bump = nullptr;
 
     /**
      * Space remaining in this block being bump allocated
-     **/
+     */
     size_t remaining = 0;
 
     /**
      * Simple flag for checking if another instance of lazy-decommit is
      * running
-     **/
+     */
     std::atomic_flag lazy_decommit_guard = {};
 
   public:
@@ -87,7 +87,7 @@ namespace snmalloc
 
     /**
      * Make a new memory provide for this PAL.
-     **/
+     */
     static MemoryProviderStateMixin<PAL>* make() noexcept
     {
       // Temporary stack-based storage to start the allocator in.
@@ -197,7 +197,7 @@ namespace snmalloc
 
     /***
      * Method for callback object to perform lazy decommit.
-     **/
+     */
     static void process(PalNotificationObject* p)
     {
       // Unsafe downcast here. Don't want vtable and RTTI.

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../ds/dllist.h"
+#include "../ds/cdllist.h"
 #include "../ds/helpers.h"
 #include "sizeclass.h"
 
@@ -8,18 +9,14 @@ namespace snmalloc
 {
   class Slab;
 
-  struct SlabLink
+  using SlabList = CDLLNode;
+  using SlabLink = CDLLNode;
+
+  SNMALLOC_FAST_PATH Slab* get_slab(SlabLink* sl)
   {
-    SlabLink* prev;
-    SlabLink* next;
+    return pointer_align_down<SLAB_SIZE, Slab>(sl);
+  }
 
-    SNMALLOC_FAST_PATH Slab* get_slab()
-    {
-      return pointer_align_down<SLAB_SIZE, Slab>(this);
-    }
-  };
-
-  using SlabList = DLList<SlabLink>;
 
   static_assert(
     sizeof(SlabLink) <= MIN_ALLOC_SIZE,

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -65,7 +65,7 @@ namespace snmalloc
      *  - was full before the subtraction
      * this returns true, otherwise returns false.
      **/
-    bool return_object()
+    b*/ return_object()
     {
       return (--needed) == 0;
     }
@@ -158,7 +158,7 @@ namespace snmalloc
      * We don't expect a cycle, so worst case is only followed by a crash, so
      * slow doesn't mater.
      **/
-    size_t debug_slab_acyclic_free_list(Slab* slab)
+    s*/_t debug_slab_acyclic_free_list(Slab* slab)
     {
 #ifndef NDEBUG
       size_t length = 0;

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -64,7 +64,7 @@ namespace snmalloc
      *  - empty adding the entry to the free list, or
      *  - was full before the subtraction
      * this returns true, otherwise returns false.
-     **/
+     */
     bool return_object()
     {
       return (--needed) == 0;
@@ -157,7 +157,7 @@ namespace snmalloc
      * https://en.wikipedia.org/wiki/Cycle_detection#Floyd's_Tortoise_and_Hare
      * We don't expect a cycle, so worst case is only followed by a crash, so
      * slow doesn't mater.
-     **/
+     */
     size_t debug_slab_acyclic_free_list(Slab* slab)
     {
 #ifndef NDEBUG

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../ds/dllist.h"
 #include "../ds/cdllist.h"
+#include "../ds/dllist.h"
 #include "../ds/helpers.h"
 #include "sizeclass.h"
 
@@ -16,7 +16,6 @@ namespace snmalloc
   {
     return pointer_align_down<SLAB_SIZE, Slab>(sl);
   }
-
 
   static_assert(
     sizeof(SlabLink) <= MIN_ALLOC_SIZE,

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -65,7 +65,7 @@ namespace snmalloc
      *  - was full before the subtraction
      * this returns true, otherwise returns false.
      **/
-    b*/ return_object()
+    bool return_object()
     {
       return (--needed) == 0;
     }
@@ -158,7 +158,7 @@ namespace snmalloc
      * We don't expect a cycle, so worst case is only followed by a crash, so
      * slow doesn't mater.
      **/
-    s*/_t debug_slab_acyclic_free_list(Slab* slab)
+    size_t debug_slab_acyclic_free_list(Slab* slab)
     {
 #ifndef NDEBUG
       size_t length = 0;

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -13,7 +13,7 @@ namespace snmalloc
     SlabLink* prev;
     SlabLink* next;
 
-    Slab* get_slab()
+    SNMALLOC_FAST_PATH Slab* get_slab()
     {
       return pointer_align_down<SLAB_SIZE, Slab>(this);
     }
@@ -86,7 +86,7 @@ namespace snmalloc
       return result;
     }
 
-    void set_full()
+    SNMALLOC_FAST_PATH void set_full()
     {
       SNMALLOC_ASSERT(head == nullptr);
       SNMALLOC_ASSERT(link != 1);

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -319,7 +319,7 @@ namespace snmalloc
   /**
    * Simple pagemap that for each GRANULARITY_BITS of the address range
    * stores a T.
-   **/
+   */
   template<size_t GRANULARITY_BITS, typename T>
   class alignas(OS_PAGE_SIZE) FlatPagemap
   {

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -319,7 +319,7 @@ namespace snmalloc
   /**
    * Simple pagemap that for each GRANULARITY_BITS of the address range
    * stores a T.
-   */
+   **/
   template<size_t GRANULARITY_BITS, typename T>
   class alignas(OS_PAGE_SIZE) FlatPagemap
   {

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -15,7 +15,7 @@ namespace snmalloc
    * concurrency safe.
    *
    * This is used to bootstrap the allocation of allocators.
-   **/
+   */
   template<class T, class MemoryProvider = GlobalVirtual>
   class Pool
   {

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -15,7 +15,7 @@ namespace snmalloc
    * concurrency safe.
    *
    * This is used to bootstrap the allocation of allocators.
-   */
+   **/
   template<class T, class MemoryProvider = GlobalVirtual>
   class Pool
   {

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -35,7 +35,7 @@ namespace snmalloc
      * Takes a free list out of a slabs meta data.
      * Returns the link as the allocation, and places the free list into the
      * `fast_free_list` for further allocations.
-     **/
+     */
     template<ZeroMem zero_mem, typename MemoryProvider>
     SNMALLOC_FAST_PATH void* alloc(
       SlabList& sl,
@@ -90,7 +90,7 @@ namespace snmalloc
      * list, and stores it in the fast_free_list. It will only create a page
      * worth of allocations, or one if the allocation size is larger than a
      * page.
-     **/
+     */
     static SNMALLOC_FAST_PATH void
     alloc_new_list(void*& bumpptr, FreeListHead& fast_free_list, size_t rsize)
     {

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -33,9 +33,9 @@ namespace snmalloc
 
     /**
      * Takes a free list out of a slabs meta data.
-     * Returns the link as the allocation, and places the free list into the 
+     * Returns the link as the allocation, and places the free list into the
      * `fast_free_list` for further allocations.
-     **/  
+     **/
     template<ZeroMem zero_mem, typename MemoryProvider>
     SNMALLOC_FAST_PATH void* alloc(
       SlabList& sl,
@@ -89,13 +89,10 @@ namespace snmalloc
      * Given a bumpptr and a fast_free_list head reference, builds a new free
      * list, and stores it in the fast_free_list. It will only create a page
      * worth of allocations, or one if the allocation size is larger than a
-     * page. 
+     * page.
      **/
-    static
-    SNMALLOC_FAST_PATH void alloc_new_list(
-      void*& bumpptr,
-      FreeListHead& fast_free_list,
-      size_t rsize)
+    static SNMALLOC_FAST_PATH void
+    alloc_new_list(void*& bumpptr, FreeListHead& fast_free_list, size_t rsize)
     {
       // Allocate the last object on the current page if there is one,
       // and then thread the next free list worth of allocations.
@@ -104,8 +101,10 @@ namespace snmalloc
       while (true)
       {
         void* newbumpptr = pointer_offset(bumpptr, rsize);
-        auto alignedbumpptr = bits::align_up(address_cast(bumpptr) - 1, OS_PAGE_SIZE);
-        auto alignednewbumpptr = bits::align_up(address_cast(newbumpptr), OS_PAGE_SIZE);
+        auto alignedbumpptr =
+          bits::align_up(address_cast(bumpptr) - 1, OS_PAGE_SIZE);
+        auto alignednewbumpptr =
+          bits::align_up(address_cast(newbumpptr), OS_PAGE_SIZE);
 
         if (alignedbumpptr != alignednewbumpptr)
         {

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -156,6 +156,10 @@ namespace snmalloc
         else
           memory_provider.template zero<true>(p, rsize);
       }
+      else
+      {
+        UNUSED(rsize);
+      }
 
       return p;
     }

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -35,7 +35,7 @@ namespace snmalloc
      * Takes a free list out of a slabs meta data.
      * Returns the link as the allocation, and places the free list into the
      * `fast_free_list` for further allocations.
-     */
+     **/
     template<ZeroMem zero_mem, typename MemoryProvider>
     SNMALLOC_FAST_PATH void* alloc(
       SlabList& sl,
@@ -90,7 +90,7 @@ namespace snmalloc
      * list, and stores it in the fast_free_list. It will only create a page
      * worth of allocations, or one if the allocation size is larger than a
      * page.
-     */
+     **/
     static SNMALLOC_FAST_PATH void
     alloc_new_list(void*& bumpptr, FreeListHead& fast_free_list, size_t rsize)
     {

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -166,7 +166,7 @@ namespace snmalloc
       // returned all the elements, but this is a slab that is still being bump
       // allocated from. Hence, the bump allocator slab will never be returned
       // for use in another size class.
-      meta[0].allocated = (uint16_t)(
+      meta[0].allocated = static_cast<uint16_t>(
         (SLAB_SIZE - get_initial_offset(sizeclass, true)) /
         sizeclass_to_size(sizeclass));
       meta[0].link = 1;
@@ -191,7 +191,7 @@ namespace snmalloc
       // returned all the elements, but this is a slab that is still being bump
       // allocated from. Hence, the bump allocator slab will never be returned
       // for use in another size class.
-      meta[h].allocated = (uint16_t)(
+      meta[h].allocated = static_cast<uint16_t>(
         (SLAB_SIZE - get_initial_offset(sizeclass, false)) /
         sizeclass_to_size(sizeclass));
       meta[h].needed = 1;

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -161,7 +161,11 @@ namespace snmalloc
         return alloc_slab(sizeclass);
 
       meta[0].head = nullptr;
-      // Set up meta data as if the entire slab has been turned into a free list.
+      // Set up meta data as if the entire slab has been turned into a free
+      // list. This means we don't have to check for special cases where we have
+      // returned all the elements, but this is a slab that is still being bump
+      // allocated from. Hence, the bump allocator slab will never be returned
+      // for use in another size class.
       meta[0].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, true)) / sizeclass_to_size(sizeclass));
       meta[0].link = 1;
       meta[0].needed = 1;
@@ -180,7 +184,11 @@ namespace snmalloc
       uint8_t n = meta[h].next;
 
       meta[h].head = nullptr;
-      // Set up meta data as if the entire slab has been turned into a free list.
+      // Set up meta data as if the entire slab has been turned into a free
+      // list. This means we don't have to check for special cases where we have
+      // returned all the elements, but this is a slab that is still being bump
+      // allocated from. Hence, the bump allocator slab will never be returned
+      // for use in another size class.
       meta[h].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, false)) / sizeclass_to_size(sizeclass));
       meta[h].needed = 1;
       meta[h].link = 1;

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -160,10 +160,12 @@ namespace snmalloc
       if ((used & 1) == 1)
         return alloc_slab(sizeclass);
 
-      meta[0].allocated = 1;
       meta[0].head = nullptr;
+      // Set up meta data as if the entire slab has been turned into a free list.
+      meta[0].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, true)) / sizeclass_to_size(sizeclass));
+      meta[0].link = 1;
+      meta[0].needed = 1;
       meta[0].sizeclass = static_cast<uint8_t>(sizeclass);
-      meta[0].link = get_initial_offset(sizeclass, true);
 
       used++;
       return reinterpret_cast<Slab*>(this);
@@ -178,9 +180,11 @@ namespace snmalloc
       uint8_t n = meta[h].next;
 
       meta[h].head = nullptr;
-      meta[h].allocated = 1;
+      // Set up meta data as if the entire slab has been turned into a free list.
+      meta[h].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, false)) / sizeclass_to_size(sizeclass));
+      meta[h].needed = 1;
+      meta[h].link = 1;
       meta[h].sizeclass = static_cast<uint8_t>(sizeclass);
-      meta[h].link = get_initial_offset(sizeclass, false);
 
       head = h + n + 1;
       used += 2;

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -166,7 +166,9 @@ namespace snmalloc
       // returned all the elements, but this is a slab that is still being bump
       // allocated from. Hence, the bump allocator slab will never be returned
       // for use in another size class.
-      meta[0].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, true)) / sizeclass_to_size(sizeclass));
+      meta[0].allocated = (uint16_t)(
+        (SLAB_SIZE - get_initial_offset(sizeclass, true)) /
+        sizeclass_to_size(sizeclass));
       meta[0].link = 1;
       meta[0].needed = 1;
       meta[0].sizeclass = static_cast<uint8_t>(sizeclass);
@@ -189,7 +191,9 @@ namespace snmalloc
       // returned all the elements, but this is a slab that is still being bump
       // allocated from. Hence, the bump allocator slab will never be returned
       // for use in another size class.
-      meta[h].allocated = (uint16_t)((SLAB_SIZE - get_initial_offset(sizeclass, false)) / sizeclass_to_size(sizeclass));
+      meta[h].allocated = (uint16_t)(
+        (SLAB_SIZE - get_initial_offset(sizeclass, false)) /
+        sizeclass_to_size(sizeclass));
       meta[h].needed = 1;
       meta[h].link = 1;
       meta[h].sizeclass = static_cast<uint8_t>(sizeclass);

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -80,7 +80,7 @@ namespace snmalloc
    */
   class ThreadAllocCommon
   {
-    friend void* lazy_replacement_slow();
+    friend void* init_thread_allocator();
 
   protected:
     static inline void inner_release()

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -43,7 +43,7 @@ namespace snmalloc
    * replacement. This function returns true, if the allocator passed in
    * requires initialisation. As the TLS state is managed externally,
    * this will always return false.
-   */
+   **/
   SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     UNUSED(existing);
@@ -54,7 +54,7 @@ namespace snmalloc
    * Function passed as a tempalte parameter to `Allocator` to allow lazy
    * replacement.  There is nothing to initialise in this case, so we expect
    * this to never be called.
-   */
+   **/
   SNMALLOC_FAST_PATH void* init_thread_allocator()
   {
     return nullptr;
@@ -94,7 +94,7 @@ namespace snmalloc
 
     /**
      * Default clean up does nothing except print statistics if enabled.
-     */
+     **/
     static void register_cleanup()
     {
 #  ifdef USE_SNMALLOC_STATS
@@ -254,7 +254,7 @@ namespace snmalloc
    * replacement. This function returns true, if the allocated passed in,
    * is the placeholder allocator.  If it returns true, then
    * `init_thread_allocator` should be called.
-   */
+   **/
   SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     return existing == &GlobalPlaceHolder;

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -40,8 +40,8 @@ namespace snmalloc
 
   /**
    * Function passed as a template parameter to `Allocator` to allow lazy
-   * replacement. This function returns true, if the allocated passed in,
-   * is the placeholder allocator. As the TLS state is managed externally,
+   * replacement. This function returns true, if the allocator passed in
+   * requires initialisation. As the TLS state is managed externally,
    * this will always return false.
    **/
   SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
@@ -59,7 +59,6 @@ namespace snmalloc
   {
     return nullptr;
   }
-
 
   using ThreadAlloc = ThreadAllocUntypedWrapper;
 #else
@@ -227,11 +226,12 @@ namespace snmalloc
 #  endif
 
   /**
-   * Slow path for the placeholder replacement. 
+   * Slow path for the placeholder replacement.
    * Function passed as a tempalte parameter to `Allocator` to allow lazy
    * replacement.  This function initialises the thread local state if requried.
    * The simple check that this is the global placeholder is inlined, the rest
-   * of it is only hit in a very unusual case and so should go off the fast path.
+   * of it is only hit in a very unusual case and so should go off the fast
+   * path.
    */
   SNMALLOC_SLOW_PATH inline void* init_thread_allocator()
   {

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -75,9 +75,11 @@ namespace snmalloc
    * empty.
    */
   inline const char GlobalPlaceHolder[sizeof(Alloc)] = {0};
-
   inline Alloc* get_GlobalPlaceHolder()
   {
+    // This cast is not legal.  Effectively, we want a minimal constructor
+    // for the global allocator as zero, and then a second constructor for
+    // the rest.  This is UB.
     auto a = reinterpret_cast<const Alloc*>(&GlobalPlaceHolder);
     return const_cast<Alloc*>(a);
   }

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -229,7 +229,13 @@ namespace snmalloc
   SNMALLOC_SLOW_PATH inline void* init_thread_allocator()
   {
     auto*& local_alloc = ThreadAlloc::get_reference();
-    SNMALLOC_ASSERT(local_alloc == &GlobalPlaceHolder);
+    if (local_alloc != &GlobalPlaceHolder)
+    {
+      // If someone reuses a noncachable call, then we can end up here.
+      // The allocator has already been initialised. Could either error
+      // to say stop doing this, or just give them the initialised version.
+      return local_alloc;
+    }
     local_alloc = current_alloc_pool()->acquire();
     SNMALLOC_ASSERT(local_alloc != &GlobalPlaceHolder);
     ThreadAlloc::register_cleanup();

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -246,7 +246,7 @@ namespace snmalloc
    */
   SNMALLOC_FAST_PATH bool first_allocation(void* existing)
   {
-    return existing != &GlobalPlaceHolder;
+    return existing == &GlobalPlaceHolder;
   }
 #endif
 } // namespace snmalloc

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -68,7 +68,7 @@ namespace snmalloc
    * slabs to allocate from, it will discover that it is the placeholder and
    * replace itself with the thread-local allocator, allocating one if
    * required.  This avoids a branch on the fast path.
-   * 
+   *
    * The fake allocator is a zero initialised area of memory of the correct
    * size. All data structures used potentially before initialisation must be
    * okay with zero init to move to the slow path, that is, zero must signify

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -43,7 +43,7 @@ namespace snmalloc
    * replacement. This function returns true, if the allocator passed in
    * requires initialisation. As the TLS state is managed externally,
    * this will always return false.
-   **/
+   */
   SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     UNUSED(existing);
@@ -54,7 +54,7 @@ namespace snmalloc
    * Function passed as a tempalte parameter to `Allocator` to allow lazy
    * replacement.  There is nothing to initialise in this case, so we expect
    * this to never be called.
-   **/
+   */
   SNMALLOC_FAST_PATH void* init_thread_allocator()
   {
     return nullptr;
@@ -94,7 +94,7 @@ namespace snmalloc
 
     /**
      * Default clean up does nothing except print statistics if enabled.
-     **/
+     */
     static void register_cleanup()
     {
 #  ifdef USE_SNMALLOC_STATS
@@ -254,7 +254,7 @@ namespace snmalloc
    * replacement. This function returns true, if the allocated passed in,
    * is the placeholder allocator.  If it returns true, then
    * `init_thread_allocator` should be called.
-   **/
+   */
   SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     return existing == &GlobalPlaceHolder;

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -44,7 +44,7 @@ namespace snmalloc
    * is the placeholder allocator. As the TLS state is managed externally,
    * this will always return false.
    **/
-  SNMALLOC_FAST_PATH bool first_allocation(void* existing)
+  SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     UNUSED(existing);
     return false;
@@ -158,7 +158,7 @@ namespace snmalloc
       return get_reference();
 #  else
       auto alloc = get_reference();
-      if (unlikely(first_allocation(alloc)))
+      if (unlikely(needs_initialisation(alloc)))
       {
         alloc = reinterpret_cast<Alloc*>(init_thread_allocator());
       }
@@ -255,7 +255,7 @@ namespace snmalloc
    * is the placeholder allocator.  If it returns true, then
    * `init_thread_allocator` should be called.
    **/
-  SNMALLOC_FAST_PATH bool first_allocation(void* existing)
+  SNMALLOC_FAST_PATH bool needs_initialisation(void* existing)
   {
     return existing == &GlobalPlaceHolder;
   }

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -62,7 +62,7 @@ namespace snmalloc
    * This struct is used to represent callbacks for notification from the
    * platform. It contains a next pointer as client is responsible for
    * allocation as we cannot assume an allocator at this point.
-   **/
+   */
   struct PalNotificationObject
   {
     std::atomic<PalNotificationObject*> pal_next;
@@ -72,12 +72,12 @@ namespace snmalloc
 
   /***
    * Wrapper for managing notifications for PAL events
-   **/
+   */
   class PalNotifier
   {
     /**
      * List of callbacks to notify
-     **/
+     */
     std::atomic<PalNotificationObject*> callbacks = nullptr;
 
   public:
@@ -86,7 +86,7 @@ namespace snmalloc
      *
      * The object should never be deallocated by the client after calling
      * this.
-     **/
+     */
     void register_notification(PalNotificationObject* callback)
     {
       callback->pal_next = nullptr;
@@ -105,7 +105,7 @@ namespace snmalloc
 
     /**
      * Calls the pal_notify of all the registered objects.
-     **/
+     */
     void notify_all()
     {
       PalNotificationObject* curr = callbacks;

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -62,7 +62,7 @@ namespace snmalloc
    * This struct is used to represent callbacks for notification from the
    * platform. It contains a next pointer as client is responsible for
    * allocation as we cannot assume an allocator at this point.
-   */
+   **/
   struct PalNotificationObject
   {
     std::atomic<PalNotificationObject*> pal_next;
@@ -72,12 +72,12 @@ namespace snmalloc
 
   /***
    * Wrapper for managing notifications for PAL events
-   */
+   **/
   class PalNotifier
   {
     /**
      * List of callbacks to notify
-     */
+     **/
     std::atomic<PalNotificationObject*> callbacks = nullptr;
 
   public:
@@ -86,7 +86,7 @@ namespace snmalloc
      *
      * The object should never be deallocated by the client after calling
      * this.
-     */
+     **/
     void register_notification(PalNotificationObject* callback)
     {
       callback->pal_next = nullptr;
@@ -105,7 +105,7 @@ namespace snmalloc
 
     /**
      * Calls the pal_notify of all the registered objects.
-     */
+     **/
     void notify_all()
     {
       PalNotificationObject* curr = callbacks;

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -34,7 +34,7 @@ namespace snmalloc
 
     /**
      * List of callbacks for low-memory notification
-     **/
+     */
     static inline PalNotifier low_memory_callbacks;
 
     /**
@@ -98,7 +98,7 @@ namespace snmalloc
      * Register callback object for low-memory notifications.
      * Client is responsible for allocation, and ensuring the object is live
      * for the duration of the program.
-     **/
+     */
     static void
     register_for_low_memory_callback(PalNotificationObject* callback)
     {

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -34,7 +34,7 @@ namespace snmalloc
 
     /**
      * List of callbacks for low-memory notification
-     */
+     **/
     static inline PalNotifier low_memory_callbacks;
 
     /**
@@ -98,7 +98,7 @@ namespace snmalloc
      * Register callback object for low-memory notifications.
      * Client is responsible for allocation, and ensuring the object is live
      * for the duration of the program.
-     */
+     **/
     static void
     register_for_low_memory_callback(PalNotificationObject* callback)
     {

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -1,0 +1,113 @@
+/**
+ * The first operation a thread performs takes a different path to every subsequent operation
+ * as it must lazily initialise the thread local allocator. This tests performs all sizes of
+ * allocation, and deallocation as the first operation.
+ ***/
+
+#include "test/setup.h"
+#include <snmalloc.h>
+#include <thread>
+
+void alloc1(size_t size)
+{
+  void* r = snmalloc::ThreadAlloc::get_noncachable()->alloc(size);
+  snmalloc::ThreadAlloc::get_noncachable()->dealloc(r);
+}
+
+void alloc2(size_t size)
+{
+  auto a = snmalloc::ThreadAlloc::get_noncachable();
+  void* r = a->alloc(size);
+  a->dealloc(r);
+}
+
+void alloc3(size_t size)
+{
+  auto a = snmalloc::ThreadAlloc::get_noncachable();
+  void* r = a->alloc(size);
+  a->dealloc(r,size);
+}
+
+void alloc4(size_t size)
+{
+  auto a = snmalloc::ThreadAlloc::get();
+  void* r = a->alloc(size);
+  a->dealloc(r);
+}
+
+void dealloc1(void* p, size_t)
+{
+  snmalloc::ThreadAlloc::get_noncachable()->dealloc(p);
+}
+
+void dealloc2(void* p, size_t size)
+{
+  snmalloc::ThreadAlloc::get_noncachable()->dealloc(p,size);
+}
+
+void dealloc3(void* p, size_t)
+{
+  snmalloc::ThreadAlloc::get()->dealloc(p);
+}
+
+void dealloc4(void* p, size_t size)
+{
+  snmalloc::ThreadAlloc::get()->dealloc(p, size);
+}
+
+void f(size_t size)
+{
+  auto t1 = std::thread(alloc1, size);
+  auto t2 = std::thread(alloc2, size);
+  auto t3 = std::thread(alloc3, size);
+  auto t4 = std::thread(alloc4, size);
+  
+  auto a = snmalloc::ThreadAlloc::get();
+  auto p1 = a->alloc(size);
+  auto p2 = a->alloc(size);
+  auto p3 = a->alloc(size);
+  auto p4 = a->alloc(size);
+
+  auto t5 = std::thread(dealloc1, p1, size);
+  auto t6 = std::thread(dealloc2, p2, size);
+  auto t7 = std::thread(dealloc3, p3, size);
+  auto t8 = std::thread(dealloc4, p4, size);
+
+  t1.join();
+  t2.join();
+  t3.join();
+  t4.join();
+  t5.join();
+  t6.join();
+  t7.join();
+  t8.join();
+}
+
+int main(int, char**)
+{
+  setup();
+
+  f(0);
+  f(1);
+  f(3);
+  f(5);
+  f(7);
+  for (size_t exp = 1; exp < snmalloc::SUPERSLAB_BITS; exp++)
+  {
+    f(1ULL << exp);
+    f(3ULL << exp);
+    f(5ULL << exp);
+    f(7ULL << exp);
+    f((1ULL << exp) + 1);
+    f((3ULL << exp) + 1);
+    f((5ULL << exp) + 1);
+    f((7ULL << exp) + 1);
+    f((1ULL << exp) - 1);
+    f((3ULL << exp) - 1);
+    f((5ULL << exp) - 1);
+    f((7ULL << exp) - 1);
+  }
+}
+
+
+

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -1,10 +1,12 @@
 /**
- * The first operation a thread performs takes a different path to every subsequent operation
- * as it must lazily initialise the thread local allocator. This tests performs all sizes of
- * allocation, and deallocation as the first operation.
- ***/
+ * The first operation a thread performs takes a different path to every
+ * subsequent operation as it must lazily initialise the thread local allocator.
+ * This tests performs all sizes of allocation, and deallocation as the first
+ * operation.
+ */
 
 #include "test/setup.h"
+
 #include <snmalloc.h>
 #include <thread>
 
@@ -25,7 +27,7 @@ void alloc3(size_t size)
 {
   auto a = snmalloc::ThreadAlloc::get_noncachable();
   void* r = a->alloc(size);
-  a->dealloc(r,size);
+  a->dealloc(r, size);
 }
 
 void alloc4(size_t size)
@@ -42,7 +44,7 @@ void dealloc1(void* p, size_t)
 
 void dealloc2(void* p, size_t size)
 {
-  snmalloc::ThreadAlloc::get_noncachable()->dealloc(p,size);
+  snmalloc::ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 
 void dealloc3(void* p, size_t)
@@ -61,7 +63,7 @@ void f(size_t size)
   auto t2 = std::thread(alloc2, size);
   auto t3 = std::thread(alloc3, size);
   auto t4 = std::thread(alloc4, size);
-  
+
   auto a = snmalloc::ThreadAlloc::get();
   auto p1 = a->alloc(size);
   auto p2 = a->alloc(size);
@@ -108,6 +110,3 @@ int main(int, char**)
     f((7ULL << exp) - 1);
   }
 }
-
-
-

--- a/src/test/perf/low_memory/low-memory.cc
+++ b/src/test/perf/low_memory/low-memory.cc
@@ -97,7 +97,7 @@ void reduce_pressure(Queue& allocations)
  * Wrapper to handle Pals that don't have the method.
  * Template parameter required to handle `if constexpr` always evaluating both
  * sides.
- **/
+ */
 template<typename PAL>
 void register_for_pal_notifications()
 {

--- a/src/test/perf/low_memory/low-memory.cc
+++ b/src/test/perf/low_memory/low-memory.cc
@@ -97,7 +97,7 @@ void reduce_pressure(Queue& allocations)
  * Wrapper to handle Pals that don't have the method.
  * Template parameter required to handle `if constexpr` always evaluating both
  * sides.
- */
+ **/
 template<typename PAL>
 void register_for_pal_notifications()
 {


### PR DESCRIPTION
* Make separate bump allocator ptr per thread and size class.
   - Now a slab in the per-class list is guaranteed to have at least one free allocation, not including 
     bump allocation.
   - This enables more separation between how we are trying to find memory

* Refactor code to 
   - Separate checks and slow paths to favour tail calls
   - Generally make all slow paths tail calls to improve codegen

The general form of allocation is now
1. Local free list for this allocator
2. Grab next free list for this allocator
3. Bump allocate from local bump ptr
4. Grab new slab to bump allocate from

There are special cases interleaved into this

  * Handle message queue
  * If the thread local allocator needs initialising.

The first occurs between 1 and 2, and the second occurs between, 3 and 4.
