### PR TITLE
Containerise Linux build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,10 +253,14 @@ jobs:
     vmImage: 'ubuntu-18.04'
   container: snmallocciteam/build_linux_x64:latest
   steps:
-  - task: CMake@1
-    displayName: 'CMake ..'
-    inputs:
-      cmakeArgs: '-GNinja ..'
+  - script: |
+      mkdir build
+      cd build
+      cmake -GNinja ..
+      
+    env:
+      CC: /usr/bin/gcc-8
+      CXX: /usr/bin/gcc++-8
 
   - script: |
       set -eo pipefail

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ jobs:
   displayName: Linux
   pool:
     vmImage: 'ubuntu-16.04'
+  container: snmallocciteam/build_linux_x64:latest
+
   strategy:
     matrix:
       Clang-6 Debug:
@@ -55,11 +57,6 @@ jobs:
 
   steps:
   - script: |
-      sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-      sudo apt-get update
-      sudo apt-get install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8
-      # sudo apt-get install clang-6.0 clang++-6.0
-
       sudo update-alternatives --install /usr/bin/cc cc /usr/bin/$(CC) 100
       sudo update-alternatives --set cc /usr/bin/$(CC)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,10 +257,10 @@ jobs:
       mkdir build
       cd build
       cmake -GNinja ..
-      
+
     env:
       CC: /usr/bin/gcc-8
-      CXX: /usr/bin/gcc++-8
+      CXX: /usr/bin/g++-8
 
   - script: |
       set -eo pipefail

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,34 @@ jobs:
         SelfHost: false
         CMakeArgs: ''
 
+      Clang-8 Debug:
+        CC: clang-8
+        CXX: clang++-8
+        BuildType: Debug
+        SelfHost: false
+        CMakeArgs: ''
+
+      Clang-8 Release:
+        CC: clang-8
+        CXX: clang++-8
+        BuildType: Release
+        SelfHost: false
+        CMakeArgs: ''
+
+      Clang-9 Debug:
+        CC: clang-9
+        CXX: clang++-9
+        BuildType: Debug
+        SelfHost: false
+        CMakeArgs: ''
+
+      Clang-9 Release:
+        CC: clang-9
+        CXX: clang++-9
+        BuildType: Release
+        SelfHost: false
+        CMakeArgs: ''
+
       GCC-8 Debug:
         CC: gcc-8
         CXX: g++-8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
       CMAKE_CXX_FLAGS="-std=c++17"
       if [[ "$CXX" == clang++* ]]; then CMAKE_CXX_FLAGS+=" -stdlib=libstdc++"; fi
 
-    displayName: 'Install Build Dependencies'
+    displayName: 'Select compiler version'
 
   - task: CMake@1
     displayName: 'CMake .. $(CMakeArgs) -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On'
@@ -251,17 +251,8 @@ jobs:
   displayName: Format
   pool:
     vmImage: 'ubuntu-18.04'
+  container: snmallocciteam/build_linux_x64:latest
   steps:
-  - script: |
-      set -eo pipefail
-      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
-      sudo apt-get update
-      sudo apt-get install -y clang-format-9 clang-tidy-9
-      sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
-
-    displayName: 'Install clang'
-
   - task: CMake@1
     displayName: 'CMake ..'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,11 +256,11 @@ jobs:
   - task: CMake@1
     displayName: 'CMake ..'
     inputs:
-      cmakeArgs: '..'
+      cmakeArgs: '-GNinja ..'
 
   - script: |
       set -eo pipefail
-      make clangformat
+      ninja clangformat
       git diff --exit-code $(Build.SourceVersion)
 
     workingDirectory: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,21 +8,21 @@ jobs:
 - job:
   displayName: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   container: snmallocciteam/build_linux_x64:latest
 
   strategy:
     matrix:
-      Clang-6 Debug:
-        CC: clang-6.0
-        CXX: clang++-6.0
+      Clang-7 Debug:
+        CC: clang-7
+        CXX: clang++-7
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
 
-      Clang-6 Release:
-        CC: clang-6.0
-        CXX: clang++-6.0
+      Clang-7 Release:
+        CC: clang-7
+        CXX: clang++-7
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
@@ -42,15 +42,15 @@ jobs:
         CMakeArgs: ''
 
       Self Host:
-        CC: clang-6.0
-        CXX: clang++-6.0
+        CC: clang-7
+        CXX: clang++-7
         BuildType: Debug
         SelfHost: true
         CMakeArgs: ''
 
       Cache Friendly:
-        CC: clang-6.0
-        CXX: clang++-6.0
+        CC: clang-7
+        CXX: clang++-7
         BuildType: Debug
         SelfHost: false
         CMakeArgs: '-DCACHE_FRIENDLY_OFFSET=64'

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt update
+RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -1,7 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt update
 RUN apt install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt update
 RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8 cmake
+RUN apt install -y clang-7 clang++-7
+RUN apt install -y clang-8 clang++-8
+RUN apt install -y clang-9 clang++-9

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -8,3 +8,5 @@ RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-d
 RUN apt install -y clang-7 clang++-7
 RUN apt install -y clang-8 clang++-8
 RUN apt install -y clang-9 clang++-9
+RUN apt-get install -y clang-format-9 clang-tidy-9
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -4,4 +4,4 @@ RUN apt update
 RUN apt install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt update
-RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8
+RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8 cmake

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -4,7 +4,7 @@ RUN apt update
 RUN apt install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt update
-RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8 cmake
+RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8 cmake sudo
 RUN apt install -y clang-7 clang++-7
 RUN apt install -y clang-8 clang++-8
 RUN apt install -y clang-9 clang++-9

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 RUN apt update
 RUN apt install -y software-properties-common

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -4,7 +4,7 @@ RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt update \
-    && apt install --no-install-recommends -y sudo cmake ninja-build \
+    && apt install --no-install-recommends -y sudo cmake ninja-build git \
     && apt install --no-install-recommends -y g++-8 \
     && apt install --no-install-recommends -y clang++-7 \
     && apt install --no-install-recommends -y clang++-8 \

--- a/ci/linux_x64
+++ b/ci/linux_x64
@@ -1,12 +1,16 @@
 FROM ubuntu:18.04
 
-RUN apt update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt update
-RUN apt install -y ninja-build libc++-dev libc++abi-dev libc++abi1 libstdc++-7-dev gcc-8 g++-8 cmake sudo
-RUN apt install -y clang-7 clang++-7
-RUN apt install -y clang-8 clang++-8
-RUN apt install -y clang-9 clang++-9
-RUN apt-get install -y clang-format-9 clang-tidy-9
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
+RUN apt update \
+    && apt install -y software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && apt update \
+    && apt install --no-install-recommends -y sudo cmake ninja-build \
+    && apt install --no-install-recommends -y g++-8 \
+    && apt install --no-install-recommends -y clang++-7 \
+    && apt install --no-install-recommends -y clang++-8 \
+    && apt install --no-install-recommends -y clang++-9 \
+    && apt install --no-install-recommends -y clang-format-9 clang-tidy-9 \
+    && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100 \
+    && apt remove -y software-properties-common \
+    && apt -y autoremove \
+    && apt -y clean


### PR DESCRIPTION
Linux CI in docker, groundwork to add QEmu/ARM build, and clang upgrade along the way.

Somewhat slower than before because Pipelines still does not have an image cache, but builds are substantially more reproducible, which is sometimes nice.