### PR TITLE
Workaround for QEMU behaviour.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(USE_MEASURE "Measure performance with histograms" OFF)
 option(EXPOSE_EXTERNAL_PAGEMAP "Expose the global pagemap" OFF)
 option(EXPOSE_EXTERNAL_RESERVE "Expose an interface to reserve memory using the default memory provider" OFF)
 option(SNMALLOC_RUST_SUPPORT "Build static library for rust" OFF)
+option(SNMALLOC_QEMU_WORKAROUND "Disable using madvise(DONT_NEED) to zero memory on Linux" Off)
 set(CACHE_FRIENDLY_OFFSET OFF CACHE STRING "Base offset to place linked-list nodes.")
 
 if ((CMAKE_BUILD_TYPE STREQUAL "Release") AND (NOT SNMALLOC_CI_BUILD))
@@ -110,6 +111,10 @@ set(CMAKE_CXX_STANDARD 17)
 
 if(USE_SNMALLOC_STATS)
   target_compile_definitions(snmalloc_lib INTERFACE -DUSE_SNMALLOC_STATS)
+endif()
+
+if(SNMALLOC_QEMU_WORKAROUND)
+  target_compile_definitions(snmalloc_lib INTERFACE -DSNMALLOC_QEMU_WORKAROUND)
 endif()
 
 if(USE_MEASURE)

--- a/src/aal/aal_arm.h
+++ b/src/aal/aal_arm.h
@@ -2,8 +2,10 @@
 
 #if defined(__aarch64__)
 #  define SNMALLOC_VA_BITS_64
+#  include <arm64_neon.h>
 #else
 #  define SNMALLOC_VA_BITS_32
+#  include <arm_neon.h>
 #endif
 
 #include <iostream>
@@ -20,13 +22,19 @@ namespace snmalloc
      */
     static constexpr uint64_t aal_features =
       IntegerPointers | NoCpuCycleCounters;
+
     /**
      * On pipelined processors, notify the core that we are in a spin loop and
      * that speculative execution past this point may not be a performance gain.
      */
     static inline void pause()
     {
-      __asm__ volatile("yield");
+      __yield();
+    }
+
+    static inline void prefetch(void* ptr)
+    {
+      __prefetch(ptr);
     }
   };
 

--- a/src/aal/aal_arm.h
+++ b/src/aal/aal_arm.h
@@ -2,10 +2,14 @@
 
 #if defined(__aarch64__)
 #  define SNMALLOC_VA_BITS_64
-#  include <arm64_neon.h>
+#  ifdef _MSC_VER
+#    include <arm64_neon.h>
+#  endif
 #else
 #  define SNMALLOC_VA_BITS_32
-#  include <arm_neon.h>
+#  ifdef _MSC_VER
+#    include <arm_neon.h>
+#  endif
 #endif
 
 #include <iostream>
@@ -29,12 +33,20 @@ namespace snmalloc
      */
     static inline void pause()
     {
+#ifdef _MSC_VER
       __yield();
+#else
+      __asm__ volatile("yield");
+#endif
     }
 
     static inline void prefetch(void* ptr)
     {
+#ifdef _MSC_VER
       __prefetch(ptr);
+#else
+      __asm__ inline("prfm pldl1keep, [%0]" : "=r"(ptr));
+#endif
     }
   };
 

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -37,12 +37,16 @@ namespace snmalloc
     template<bool page_aligned = false>
     void zero(void* p, size_t size) noexcept
     {
+// QEMU does not seem to be giving the desired behaviour for MADV_DONTNEED.
+// switch back to memset only for QEMU.
+#ifndef SNMALLOC_QEMU_WORKAROUND
       if (page_aligned || is_aligned_block<OS_PAGE_SIZE>(p, size))
       {
         SNMALLOC_ASSERT(is_aligned_block<OS_PAGE_SIZE>(p, size));
         madvise(p, size, MADV_DONTNEED);
       }
       else
+#endif
       {
         ::memset(p, 0, size);
       }

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -39,14 +39,14 @@ namespace snmalloc
     {
 // QEMU does not seem to be giving the desired behaviour for MADV_DONTNEED.
 // switch back to memset only for QEMU.
-#ifndef SNMALLOC_QEMU_WORKAROUND
+#  ifndef SNMALLOC_QEMU_WORKAROUND
       if (page_aligned || is_aligned_block<OS_PAGE_SIZE>(p, size))
       {
         SNMALLOC_ASSERT(is_aligned_block<OS_PAGE_SIZE>(p, size));
         madvise(p, size, MADV_DONTNEED);
       }
       else
-#endif
+#  endif
       {
         ::memset(p, 0, size);
       }


### PR DESCRIPTION
This is not hooked up to anything yet.  Once @achamayou has completed the containerised build #145, then we can add the AARCH64 QEMU build, and this will be used.