### PR TITLE
Increase Remote batch size

### DIFF
--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -63,7 +63,7 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   SNMALLOC_FAST_PATH T* pointer_align_down(void* p)
   {
-    if constexp (alignment == 1)
+    if constexpr (alignment == 1)
       return static_cast<T*>(p);
     else
       static_assert(alignment > 0);
@@ -82,7 +82,7 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   inline T* pointer_align_up(void* p)
   {
-    if constexp (alignment == 1)
+    if constexpr (alignment == 1)
       return static_cast<T*>(p);
     else
       static_assert(alignment > 0);

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -63,16 +63,18 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   SNMALLOC_FAST_PATH T* pointer_align_down(void* p)
   {
+    static_assert(alignment > 0);
+    static_assert(bits::next_pow2_const(alignment) == alignment);
     if constexpr (alignment == 1)
       return static_cast<T*>(p);
     else
-      static_assert(alignment > 0);
-      static_assert(bits::next_pow2_const(alignment) == alignment);
+    {
 #if __has_builtin(__builtin_align_down)
       return static_cast<T*>(__builtin_align_down(p, alignment));
 #else
       return pointer_cast<T>(bits::align_down(address_cast(p), alignment));
 #endif
+    }
   }
 
   /**
@@ -82,17 +84,18 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   inline T* pointer_align_up(void* p)
   {
+    static_assert(alignment > 0);
+    static_assert(bits::next_pow2_const(alignment) == alignment);
     if constexpr (alignment == 1)
       return static_cast<T*>(p);
     else
-      static_assert(alignment > 0);
-      static_assert(bits::next_pow2_const(alignment) == alignment);
+    {
 #if __has_builtin(__builtin_align_up)
       return static_cast<T*>(__builtin_align_up(p, alignment));
 #else
       return pointer_cast<T>(bits::align_up(address_cast(p), alignment));
 #endif
-   }
+    }
   }
 
   /**

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -63,12 +63,15 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   SNMALLOC_FAST_PATH T* pointer_align_down(void* p)
   {
-    static_assert(alignment > 0);
-    static_assert(bits::next_pow2_const(alignment) == alignment);
+    if constexp (alignment == 1)
+      return static_cast<T*>(p);
+    else
+      static_assert(alignment > 0);
+      static_assert(bits::next_pow2_const(alignment) == alignment);
 #if __has_builtin(__builtin_align_down)
-    return static_cast<T*>(__builtin_align_down(p, alignment));
+      return static_cast<T*>(__builtin_align_down(p, alignment));
 #else
-    return pointer_cast<T>(bits::align_down(address_cast(p), alignment));
+      return pointer_cast<T>(bits::align_down(address_cast(p), alignment));
 #endif
   }
 
@@ -79,13 +82,17 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   inline T* pointer_align_up(void* p)
   {
-    static_assert(alignment > 0);
-    static_assert(bits::next_pow2_const(alignment) == alignment);
+    if constexp (alignment == 1)
+      return static_cast<T*>(p);
+    else
+      static_assert(alignment > 0);
+      static_assert(bits::next_pow2_const(alignment) == alignment);
 #if __has_builtin(__builtin_align_up)
-    return static_cast<T*>(__builtin_align_up(p, alignment));
+      return static_cast<T*>(__builtin_align_up(p, alignment));
 #else
-    return pointer_cast<T>(bits::align_up(address_cast(p), alignment));
+      return pointer_cast<T>(bits::align_up(address_cast(p), alignment));
 #endif
+   }
   }
 
   /**

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -35,7 +35,7 @@ namespace snmalloc
 #ifdef USE_REMOTE_BATCH
     REMOTE_BATCH
 #else
-    64
+    4096
 #endif
     ;
 


### PR DESCRIPTION
The remote batch size has not changed since the fast path optimisations.
The optimisations mean we are checking the queue considerably less
often, so the batch should be larger.  This has a dramatic improvement
on performance on a few of the mimalloc microbenchmarks.

It is set to 4096 as this should cover the worse case scenario of only
remote deallocation at 16 bytes for the 2^16 slab size.