### PR TITLE
Add checks for deallocation with size

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -210,6 +210,24 @@ namespace snmalloc
       UNUSED(size);
       return free(p);
 #else
+#  if defined(CHECK_CLIENT)
+      auto asize = alloc_size(p);
+      auto asc = size_to_sizeclass(asize);
+      if (size_to_sizeclass(size) != asc)
+      {
+        // Correction for large classes.
+        if (asc > NUM_SIZECLASSES)
+        {
+          if (bits::next_pow2(size) != asize)
+            error("Deallocating with incorrect size supplied.");
+        }
+        // Correction for zero sized allocations.
+        else if ((size != 0) && (asc != 0))
+        {
+          error("Deallocating with incorrect size supplied.");
+        }
+      }
+#  endif
       constexpr sizeclass_t sizeclass = size_to_sizeclass_const(size);
 
       if (sizeclass < NUM_SMALL_CLASSES)
@@ -249,6 +267,24 @@ namespace snmalloc
       UNUSED(size);
       return free(p);
 #else
+#  if defined(CHECK_CLIENT)
+      auto asize = alloc_size(p);
+      auto asc = size_to_sizeclass(asize);
+      if (size_to_sizeclass(size) != asc)
+      {
+        // Correction for large classes.
+        if (asc > NUM_SIZECLASSES)
+        {
+          if (bits::next_pow2(size) != asize)
+            error("Deallocating with incorrect size supplied.");
+        }
+        // Correction for zero sized allocations.
+        else if ((size != 0) && (asc != 0))
+        {
+          error("Deallocating with incorrect size supplied.");
+        }
+      }
+#  endif
       if (likely((size - 1) <= (sizeclass_to_size(NUM_SMALL_CLASSES - 1) - 1)))
       {
         Superslab* super = Superslab::get(p);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -199,18 +199,13 @@ namespace snmalloc
 #endif
     }
 
-    /*
-     * Free memory of a statically known size. Must be called with an
-     * external pointer.
+    /**
+     * Checks the allocation at `p` could have been validly allocated with
+     * a size of `size`.
      */
-    template<size_t size>
-    void dealloc(void* p)
+    void check_size(void* p, size_t size)
     {
-#ifdef USE_MALLOC
-      UNUSED(size);
-      return free(p);
-#else
-#  if defined(CHECK_CLIENT)
+#if defined(CHECK_CLIENT)
       auto asize = alloc_size(p);
       auto asc = size_to_sizeclass(asize);
       if (size_to_sizeclass(size) != asc)
@@ -227,7 +222,21 @@ namespace snmalloc
           error("Deallocating with incorrect size supplied.");
         }
       }
-#  endif
+#endif
+    }
+
+    /*
+     * Free memory of a statically known size. Must be called with an
+     * external pointer.
+     */
+    template<size_t size>
+    void dealloc(void* p)
+    {
+#ifdef USE_MALLOC
+      UNUSED(size);
+      return free(p);
+#else
+      check_size(p, size);
       constexpr sizeclass_t sizeclass = size_to_sizeclass_const(size);
 
       if (sizeclass < NUM_SMALL_CLASSES)
@@ -267,24 +276,7 @@ namespace snmalloc
       UNUSED(size);
       return free(p);
 #else
-#  if defined(CHECK_CLIENT)
-      auto asize = alloc_size(p);
-      auto asc = size_to_sizeclass(asize);
-      if (size_to_sizeclass(size) != asc)
-      {
-        // Correction for large classes.
-        if (asc > NUM_SIZECLASSES)
-        {
-          if (bits::next_pow2(size) != asize)
-            error("Deallocating with incorrect size supplied.");
-        }
-        // Correction for zero sized allocations.
-        else if ((size != 0) && (asc != 0))
-        {
-          error("Deallocating with incorrect size supplied.");
-        }
-      }
-#  endif
+      check_size(p, size);
       if (likely((size - 1) <= (sizeclass_to_size(NUM_SMALL_CLASSES - 1) - 1)))
       {
         Superslab* super = Superslab::get(p);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -222,6 +222,9 @@ namespace snmalloc
           error("Deallocating with incorrect size supplied.");
         }
       }
+#else
+      UNUSED(p);
+      UNUSED(size);
 #endif
     }
 


### PR DESCRIPTION
Ensure that the size deallocated with is the correct size. If the size
supplied is wrong, then internal invariants can break.