### PR TITLE
Defensive code for alloc/dealloc during TLS teardown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
   else()
     add_compile_options(-fno-exceptions -fno-rtti -g -ftls-model=initial-exec -fomit-frame-pointer)
+    if(SNMALLOC_CI_BUILD OR (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
+      # Get better stack traces in CI and Debug.
+      target_link_libraries(snmalloc_lib INTERFACE "-rdynamic")
+    endif()
 
     if((${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64") OR
        (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86") OR

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,11 +224,11 @@ jobs:
     matrix:
       64-bit Debug Clang:
         BuildType: Debug
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
       64-bit Release Clang:
         BuildType: Release
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,7 @@ jobs:
 
   - script: |
       choco install --accept-license -y Ninja llvm
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
     displayName: 'Dependencies'
 
   - task: CMake@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,7 +239,7 @@ jobs:
 
   - script: |
       choco install --accept-license -y Ninja llvm
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
     displayName: 'Dependencies'
 
   - task: CMake@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,6 +226,10 @@ jobs:
         BuildType: Debug
         CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe"'
         JFlag: -j 4
+      64-bit Release Clang:
+        BuildType: Release
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang++.exe"'
+        JFlag: -j 4
 
   steps:
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,11 +224,11 @@ jobs:
     matrix:
       64-bit Debug Clang:
         BuildType: Debug
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_RC_COMPILER="C:/Program Files/LLVM/bin/llvm-rc"'
         JFlag: -j 4
       64-bit Release Clang:
         BuildType: Release
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_RC_COMPILER="C:/Program Files/LLVM/bin/llvm-rc"'
         JFlag: -j 4
 
   steps:
@@ -239,7 +239,6 @@ jobs:
 
   - script: |
       choco install --accept-license -y Ninja llvm
-      set "PATH=%PATH%;C:/Program Files/LLVM/bin/"
     displayName: 'Dependencies'
 
   - task: CMake@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,7 @@ jobs:
 
   - script: |
       choco install --accept-license -y Ninja llvm
+      set "PATH=%PATH%;C:/Program Files/LLVM/bin/"
     displayName: 'Dependencies'
 
   - task: CMake@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,9 +243,10 @@ jobs:
 
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      mkdir build
+      cd build
       cmake .. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On
       cmake --build . --config ${BuildType}
-    workingDirectory: build
     displayName: 'build'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,11 +224,11 @@ jobs:
     matrix:
       64-bit Debug Clang:
         BuildType: Debug
-        CMakeArgs: '-GNinja -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
       64-bit Release Clang:
         BuildType: Release
-        CMakeArgs: '-GNinja -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,11 +224,11 @@ jobs:
     matrix:
       64-bit Debug Clang:
         BuildType: Debug
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
       64-bit Release Clang:
         BuildType: Release
-        CMakeArgs: '-GNinja -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
+        CMakeArgs: '-GNinja -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"'
         JFlag: -j 4
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,18 +239,13 @@ jobs:
 
   - script: |
       choco install --accept-license -y Ninja llvm
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
     displayName: 'Dependencies'
 
-  - task: CMake@1
-    displayName: 'CMake .. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On'
-    inputs:
-      cmakeArgs: '.. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On'
-
-  - task: CMake@1
-    displayName: 'CMake --build . --config ${BuildType}'
-    inputs:
-      cmakeArgs: '--build . --config ${BuildType}'
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      cmake .. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On
+      cmake --build . --config ${BuildType}
+    displayName: 'build'
 
   - script: |
       set PATH=%PATH%;"C:\Program Files\LLVM\bin\"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,6 +245,7 @@ jobs:
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       cmake .. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On
       cmake --build . --config ${BuildType}
+    workingDirectory: build
     displayName: 'build'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,7 +242,7 @@ jobs:
     displayName: 'Dependencies'
 
   - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       mkdir build
       cd build
       cmake .. $(CMakeArgs) -DCMAKE_BUILD_TYPE=$(BuildType) -DSNMALLOC_CI_BUILD=On -DSNMALLOC_RUST_SUPPORT=On

--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -67,13 +67,13 @@ namespace snmalloc
         error("Only one inflight ABA operation at a time is allowed.");
       operation_in_flight = true;
 
-      return
-        Cmp{{independent.ptr.load(std::memory_order_relaxed),
-            independent.aba.load(std::memory_order_relaxed)},
-            this};
+      return Cmp{{independent.ptr.load(std::memory_order_relaxed),
+                  independent.aba.load(std::memory_order_relaxed)},
+                 this};
     }
 
-    struct Cmp {
+    struct Cmp
+    {
       Linked old;
       ABA* parent;
 
@@ -120,6 +120,7 @@ namespace snmalloc
   {
     std::atomic<T*> ptr = nullptr;
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
+
   public:
     struct Cmp;
 
@@ -134,6 +135,7 @@ namespace snmalloc
     struct Cmp
     {
       ABA* parent;
+
     public:
       T* ptr()
       {

--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -164,7 +164,6 @@ namespace snmalloc
 #  ifndef NDEBUG
         operation_in_flight = false;
 #  endif
-
       }
     };
   };

--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -11,12 +11,12 @@
  */
 namespace snmalloc
 {
-#ifdef PLATFORM_IS_X86
-#  ifndef NDEBUG
+#ifndef NDEBUG
   // LL/SC typically can only perform one operation at a time
   // check this on other platforms using a thread_local.
   inline thread_local bool operation_in_flight = false;
-#  endif
+#endif
+#ifdef PLATFORM_IS_X86
   template<typename T, Construction c = RequiresInit>
   class ABA
   {

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -47,7 +47,8 @@ namespace snmalloc
     { \
       if (!(expr)) \
       { \
-        snmalloc::error("assert fail: " #expr " in " __FILE__ " on " TOSTRING(__LINE__)); \
+        snmalloc::error("assert fail: " #expr " in " __FILE__ \
+                        " on " TOSTRING(__LINE__)); \
       } \
     }
 #endif

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -36,6 +36,9 @@ namespace snmalloc
   void error(const char* const str);
 } // namespace snmalloc
 
+#define TOSTRING(expr) TOSTRING2(expr)
+#define TOSTRING2(expr) #expr
+
 #ifdef NDEBUG
 #  define SNMALLOC_ASSERT(expr) \
     {}
@@ -44,7 +47,7 @@ namespace snmalloc
     { \
       if (!(expr)) \
       { \
-        snmalloc::error("assert fail"); \
+        snmalloc::error("assert fail: " #expr " in " __FILE__ " on " TOSTRING(__LINE__)); \
       } \
     }
 #endif

--- a/src/ds/mpmcstack.h
+++ b/src/ds/mpmcstack.h
@@ -29,9 +29,9 @@ namespace snmalloc
 
       do
       {
-        T* top = ABAT::ptr(cmp);
+        T* top = cmp.ptr();
         last->next.store(top, std::memory_order_release);
-      } while (!stack.compare_exchange(cmp, first));
+      } while (!cmp.store_conditional(first));
     }
 
     T* pop()
@@ -44,13 +44,13 @@ namespace snmalloc
 
       do
       {
-        top = ABAT::ptr(cmp);
+        top = cmp.ptr();
 
         if (top == nullptr)
           break;
 
         next = top->next.load(std::memory_order_acquire);
-      } while (!stack.compare_exchange(cmp, next));
+      } while (!cmp.store_conditional(next));
 
       return top;
     }
@@ -63,11 +63,11 @@ namespace snmalloc
 
       do
       {
-        top = ABAT::ptr(cmp);
+        top = cmp.ptr();
 
         if (top == nullptr)
           break;
-      } while (!stack.compare_exchange(cmp, nullptr));
+      } while (!cmp.store_conditional(nullptr));
 
       return top;
     }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -63,7 +63,7 @@ namespace snmalloc
    * allocator if it is has been been initialised already. Splitting into two
    * functions allows for the code to be structured into tail calls to improve
    * codegen.  The second template takes a function that takes the allocator
-   * that is initialised, and the value returned, is returned by 
+   * that is initialised, and the value returned, is returned by
    * `InitThreadAllocator`.  This is used incase we are running during teardown
    * and the thread local allocator cannot be kept alive.
    *
@@ -1110,7 +1110,7 @@ namespace snmalloc
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(size_t size)
     {
-      std::function<void*(void*)> f = inline [size](void* alloc) {
+      std::function<void*(void*)> f = [size](void* alloc) {
         return reinterpret_cast<Allocator*>(alloc)->alloc(size);
       };
       return InitThreadAllocator(f);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -62,7 +62,10 @@ namespace snmalloc
    * passed the global allocator.  The second initialises the thread-local
    * allocator if it is has been been initialised already. Splitting into two
    * functions allows for the code to be structured into tail calls to improve
-   * codegen.
+   * codegen.  The second template takes a function that takes the allocator
+   * that is initialised, and the value returned, is returned by 
+   * `InitThreadAllocator`.  This is used incase we are running during teardown
+   * and the thread local allocator cannot be kept alive.
    *
    * The `MemoryProvider` defines the source of memory for this allocator.
    * Allocators try to reuse address space by allocating from existing slabs or
@@ -1107,7 +1110,7 @@ namespace snmalloc
     template<ZeroMem zero_mem, AllowReserve allow_reserve>
     SNMALLOC_SLOW_PATH void* small_alloc_first_alloc(size_t size)
     {
-      std::function<void*(void*)> f = [size](void* alloc) {
+      std::function<void*(void*)> f = inline [size](void* alloc) {
         return reinterpret_cast<Allocator*>(alloc)->alloc(size);
       };
       return InitThreadAllocator(f);

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -111,7 +111,7 @@ namespace snmalloc
       return large_allocator.stats;
     }
 
-    template<class MP>
+    template<class MP, class Alloc>
     friend class AllocPool;
 
     /**

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -7,11 +7,13 @@
 namespace snmalloc
 {
   inline bool needs_initialisation(void*);
-  void* init_thread_allocator();
+  std::pair<void*, bool> init_thread_allocator();
+  void release_thread_allocator();
 
   using Alloc = Allocator<
     needs_initialisation,
     init_thread_allocator,
+    release_thread_allocator,
     GlobalVirtual,
     SNMALLOC_DEFAULT_CHUNKMAP,
     true>;
@@ -21,6 +23,7 @@ namespace snmalloc
                       Allocator<
                         needs_initialisation,
                         init_thread_allocator,
+                        release_thread_allocator,
                         MemoryProvider,
                         SNMALLOC_DEFAULT_CHUNKMAP,
                         true>,
@@ -29,6 +32,7 @@ namespace snmalloc
     using Alloc = Allocator<
       needs_initialisation,
       init_thread_allocator,
+      release_thread_allocator,
       MemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
       true>;

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -9,29 +9,11 @@ namespace snmalloc
   inline bool needs_initialisation(void*);
   void* init_thread_allocator(std::function<void*(void*)>&);
 
-  using Alloc = Allocator<
-    needs_initialisation,
-    init_thread_allocator,
-    GlobalVirtual,
-    SNMALLOC_DEFAULT_CHUNKMAP,
-    true>;
-
-  template<class MemoryProvider>
+  template<class MemoryProvider, class Alloc>
   class AllocPool : Pool<
-                      Allocator<
-                        needs_initialisation,
-                        init_thread_allocator,
-                        MemoryProvider,
-                        SNMALLOC_DEFAULT_CHUNKMAP,
-                        true>,
+                      Alloc,
                       MemoryProvider>
   {
-    using Alloc = Allocator<
-      needs_initialisation,
-      init_thread_allocator,
-      MemoryProvider,
-      SNMALLOC_DEFAULT_CHUNKMAP,
-      true>;
     using Parent = Pool<Alloc, MemoryProvider>;
 
   public:
@@ -197,17 +179,24 @@ namespace snmalloc
     }
   };
 
-  inline AllocPool<GlobalVirtual>*& current_alloc_pool()
+  using Alloc = Allocator<
+    needs_initialisation,
+    init_thread_allocator,
+    GlobalVirtual,
+    SNMALLOC_DEFAULT_CHUNKMAP,
+    true>;
+
+  inline AllocPool<GlobalVirtual, Alloc>*& current_alloc_pool()
   {
     return Singleton<
-      AllocPool<GlobalVirtual>*,
-      AllocPool<GlobalVirtual>::make>::get();
+      AllocPool<GlobalVirtual, Alloc>*,
+      AllocPool<GlobalVirtual, Alloc>::make>::get();
   }
 
-  template<class MemoryProvider>
-  inline AllocPool<MemoryProvider>* make_alloc_pool(MemoryProvider& mp)
+  template<class MemoryProvider, class Alloc>
+  inline AllocPool<MemoryProvider, Alloc>* make_alloc_pool(MemoryProvider& mp)
   {
-    return AllocPool<MemoryProvider>::make(mp);
+    return AllocPool<MemoryProvider, Alloc>::make(mp);
   }
 
 } // namespace snmalloc

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -7,13 +7,11 @@
 namespace snmalloc
 {
   inline bool needs_initialisation(void*);
-  std::pair<void*, bool> init_thread_allocator();
-  void release_thread_allocator();
+  void* init_thread_allocator(std::function<void*(void*)>&);
 
   using Alloc = Allocator<
     needs_initialisation,
     init_thread_allocator,
-    release_thread_allocator,
     GlobalVirtual,
     SNMALLOC_DEFAULT_CHUNKMAP,
     true>;
@@ -23,7 +21,6 @@ namespace snmalloc
                       Allocator<
                         needs_initialisation,
                         init_thread_allocator,
-                        release_thread_allocator,
                         MemoryProvider,
                         SNMALLOC_DEFAULT_CHUNKMAP,
                         true>,
@@ -32,7 +29,6 @@ namespace snmalloc
     using Alloc = Allocator<
       needs_initialisation,
       init_thread_allocator,
-      release_thread_allocator,
       MemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
       true>;

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -173,6 +173,29 @@ namespace snmalloc
       UNUSED(result);
 #endif
     }
+
+    void
+    debug_in_use(size_t count)
+    {
+      auto alloc = Parent::iterate();
+      while (alloc != nullptr)
+      {
+        if (alloc->debug_is_in_use())
+        {
+          if (count == 0)
+          {
+            error("ERROR: allocator in use.");
+          }
+          count --;
+        }
+        alloc = Parent::iterate(alloc);
+
+        if (count != 0)
+        {
+          error("Error: two few allocators in use.");
+        }
+      }
+    }
   };
 
   inline AllocPool<GlobalVirtual>*& current_alloc_pool()

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -10,9 +10,7 @@ namespace snmalloc
   void* init_thread_allocator(std::function<void*(void*)>&);
 
   template<class MemoryProvider, class Alloc>
-  class AllocPool : Pool<
-                      Alloc,
-                      MemoryProvider>
+  class AllocPool : Pool<Alloc, MemoryProvider>
   {
     using Parent = Pool<Alloc, MemoryProvider>;
 

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -174,8 +174,7 @@ namespace snmalloc
 #endif
     }
 
-    void
-    debug_in_use(size_t count)
+    void debug_in_use(size_t count)
     {
       auto alloc = Parent::iterate();
       while (alloc != nullptr)
@@ -186,7 +185,7 @@ namespace snmalloc
           {
             error("ERROR: allocator in use.");
           }
-          count --;
+          count--;
         }
         alloc = Parent::iterate(alloc);
 

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -92,7 +92,7 @@ namespace snmalloc
 
     /**
      * Return to the pool a list of object previously retrieved by `extract`
-     * 
+     *
      * Do not return objects from `acquire`.
      */
     void restore(T* first, T* last)

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -50,7 +50,10 @@ namespace snmalloc
       T* p = stack.pop();
 
       if (p != nullptr)
+      {
+        p->set_in_use();
         return p;
+      }
 
       p = memory_provider
             .template alloc_chunk<T, bits::next_pow2_const(sizeof(T))>(
@@ -60,14 +63,21 @@ namespace snmalloc
       p->list_next = list;
       list = p;
 
+      p->set_in_use();
       return p;
     }
 
+    /**
+     * Return to the pool an object previously retrieved by `acquire`
+     *
+     * Do not return objects from `extract`.
+     */
     void release(T* p)
     {
       // The object's destructor is not run. If the object is "reallocated", it
       // is returned without the constructor being run, so the object is reused
       // without re-initialisation.
+      p->reset_in_use();
       stack.push(p);
     }
 
@@ -80,6 +90,11 @@ namespace snmalloc
       return p->next;
     }
 
+    /**
+     * Return to the pool a list of object previously retrieved by `extract`
+     * 
+     * Do not return objects from `acquire`.
+     */
     void restore(T* first, T* last)
     {
       // Pushes a linked list of objects onto the stack. Use to put a linked

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -17,5 +17,19 @@ namespace snmalloc
     std::atomic<T*> next = nullptr;
     /// Used by the pool to keep the list of all entries ever created.
     T* list_next;
+    std::atomic_flag in_use = ATOMIC_FLAG_INIT;
+
+  public:
+    void set_in_use()
+    {
+      if (in_use.test_and_set())
+        error("Critical error: double use of Pooled Type!");
+    }
+
+    void reset_in_use()
+    {
+      in_use.clear();
+    }
+
   };
 } // namespace snmalloc

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -30,5 +30,13 @@ namespace snmalloc
     {
       in_use.clear();
     }
+
+    bool debug_is_in_use()
+    {
+      bool result = in_use.test_and_set();
+      if (!result)
+        in_use.clear();
+      return result;
+    }
   };
 } // namespace snmalloc

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -30,6 +30,5 @@ namespace snmalloc
     {
       in_use.clear();
     }
-
   };
 } // namespace snmalloc

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -57,6 +57,7 @@ namespace snmalloc
    */
   SNMALLOC_FAST_PATH void* init_thread_allocator(std::function<void*(void*)>& f)
   {
+    error("Critical Error: This should never be called.");
     return f(nullptr);
   }
 
@@ -96,7 +97,7 @@ namespace snmalloc
     /**
      * Thread local variable that is set to true, once `inner_release`
      * has been run.  If we try to reinitialise the allocator once
-     * `inner_release` has run, then we can stay on hte slow path so we don't
+     * `inner_release` has run, then we can stay on the slow path so we don't
      * leak allocators.
      *
      * This is required to allow for the allocator to be called during
@@ -173,9 +174,7 @@ namespace snmalloc
     /**
      * Public interface, returns the allocator for this thread, constructing
      * one if necessary.
-     *
-     * The returned Alloc* is guaranteed to be initialised.  This incurs a cost,
-     * so use `get_noncachable` if you can meet its criteria.
+     * This incurs a cost, so use `get_noncachable` if you can meet its criteria.
      */
     static SNMALLOC_FAST_PATH Alloc* get()
     {
@@ -183,7 +182,7 @@ namespace snmalloc
       return get_reference();
 #  else
       auto*& alloc = get_reference();
-      if (unlikely(needs_initialisation(alloc)))
+      if (unlikely(needs_initialisation(alloc)) && !has_run)
       {
         std::function<void*(void*)> f = [](void*) { return nullptr; };
         // Call `init_thread_allocator` to perform down call in case

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -174,7 +174,8 @@ namespace snmalloc
     /**
      * Public interface, returns the allocator for this thread, constructing
      * one if necessary.
-     * This incurs a cost, so use `get_noncachable` if you can meet its criteria.
+     * This incurs a cost, so use `get_noncachable` if you can meet its
+     * criteria.
      */
     static SNMALLOC_FAST_PATH Alloc* get()
     {
@@ -277,7 +278,7 @@ namespace snmalloc
       local_alloc = current_alloc_pool()->acquire();
     }
     auto result = f(local_alloc);
-    // Check if we have already run the destructor for the TLS.  If so, 
+    // Check if we have already run the destructor for the TLS.  If so,
     // we need to deallocate the allocator.
     if (ThreadAlloc::register_cleanup())
       ThreadAlloc::inner_release();

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -277,9 +277,9 @@ namespace snmalloc
     {
       local_alloc = current_alloc_pool()->acquire();
     }
-    // Check if we have already run the destructor for the TLS.  If so, then
-    // we need the caller to handle this specially as we are in teardown.
     auto result = f(local_alloc);
+    // Check if we have already run the destructor for the TLS.  If so, 
+    // we need to deallocate the allocator.
     if (ThreadAlloc::register_cleanup())
       ThreadAlloc::inner_release();
     return result;

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -147,7 +147,9 @@ namespace snmalloc
      */
     static inline Alloc*& get_reference()
     {
-      static thread_local Alloc* alloc = get_GlobalPlaceHolder();
+      // Inline casting as codegen doesn't create a lazy init like this.
+      static thread_local Alloc* alloc =
+        const_cast<Alloc*>(reinterpret_cast<const Alloc*>(&GlobalPlaceHolder));
       return alloc;
     }
 

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -55,11 +55,21 @@ namespace snmalloc
    * replacement.  There is nothing to initialise in this case, so we expect
    * this to never be called.
    */
+#ifdef _MSC_VER
+// 32Bit Windows release MSVC is determining this as having unreachable code for
+// f(nullptr), which is true.  But other platforms don't. Disabling the warning
+// seems simplist.
+#  pragma warning(push)
+#  pragma warning(disable: 4702)
+#endif
   SNMALLOC_FAST_PATH void* init_thread_allocator(std::function<void*(void*)>& f)
   {
     error("Critical Error: This should never be called.");
     return f(nullptr);
   }
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
   using ThreadAlloc = ThreadAllocUntypedWrapper;
 #else

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -185,7 +185,7 @@ namespace snmalloc
       auto*& alloc = get_reference();
       if (unlikely(needs_initialisation(alloc)))
       {
-        std::function<void*(void*)> f = [](void*){return nullptr;};
+        std::function<void*(void*)> f = [](void*) { return nullptr; };
         // Call `init_thread_allocator` to perform down call in case
         // register_clean_up does more.
         // During teardown for the destructor based ThreadAlloc this will set
@@ -267,8 +267,7 @@ namespace snmalloc
    * path.
    * The second component of the return indicates if this TLS is being torndown.
    */
-  SNMALLOC_FAST_PATH void*
-  init_thread_allocator(std::function<void*(void*)>& f)
+  SNMALLOC_FAST_PATH void* init_thread_allocator(std::function<void*(void*)>& f)
   {
     auto*& local_alloc = ThreadAlloc::get_reference();
     // If someone reuses a noncachable call, then we can end up here

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -186,7 +186,7 @@ namespace snmalloc
         std::function<void*(void*)> f = [](void*){return nullptr;};
         // Call `init_thread_allocator` to perform down call in case
         // register_clean_up does more.
-        // During teardown for the destructor based one this will set
+        // During teardown for the destructor based ThreadAlloc this will set
         // alloc to GlobalPlaceHolder;
         init_thread_allocator(f);
       }

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -267,7 +267,7 @@ namespace snmalloc
    * path.
    * The second component of the return indicates if this TLS is being torndown.
    */
-  SNMALLOC_SLOW_PATH inline void*
+  SNMALLOC_FAST_PATH void*
   init_thread_allocator(std::function<void*(void*)>& f)
   {
     auto*& local_alloc = ThreadAlloc::get_reference();

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -49,7 +49,7 @@ namespace snmalloc
     DefaultPal;
 #endif
 
-  inline void error(const char* const str)
+  SNMALLOC_SLOW_PATH inline void error(const char* const str)
   {
     Pal::error(str);
   }

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -55,7 +55,6 @@ namespace snmalloc
     static void error(const char* const str) noexcept
     {
       puts(str);
-      fflush(stdout);
       print_stack_trace();
       abort();
     }

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -2,10 +2,12 @@
 
 #include "../ds/address.h"
 #include "../mem/allocconfig.h"
-
+#include <execinfo.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 extern "C" int puts(const char* str);
 
@@ -40,7 +42,16 @@ namespace snmalloc
      */
     static void error(const char* const str) noexcept
     {
+      constexpr int SIZE = 1024;
+      void *buffer[SIZE];
+
       puts(str);
+      fflush(stdout);
+
+      auto nptrs = backtrace(buffer, SIZE);
+      backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO);
+      fflush(stdout);
+
       abort();
     }
 

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -54,7 +54,6 @@ namespace snmalloc
      */
     static void error(const char* const str) noexcept
     {
-
       puts(str);
       fflush(stdout);
       print_stack_trace();

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -38,21 +38,26 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = LazyCommit;
 
+    static void print_stack_trace()
+    {
+      constexpr int SIZE = 1024;
+      void* buffer[SIZE];
+      auto nptrs = backtrace(buffer, SIZE);
+      fflush(stdout);
+      backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO);
+      puts("");
+      fflush(stdout);
+    }
+
     /**
      * Report a fatal error an exit.
      */
     static void error(const char* const str) noexcept
     {
-      constexpr int SIZE = 1024;
-      void* buffer[SIZE];
 
       puts(str);
       fflush(stdout);
-
-      auto nptrs = backtrace(buffer, SIZE);
-      backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO);
-      fflush(stdout);
-
+      print_stack_trace();
       abort();
     }
 

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -2,9 +2,10 @@
 
 #include "../ds/address.h"
 #include "../mem/allocconfig.h"
+
 #include <execinfo.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -43,7 +44,7 @@ namespace snmalloc
     static void error(const char* const str) noexcept
     {
       constexpr int SIZE = 1024;
-      void *buffer[SIZE];
+      void* buffer[SIZE];
 
       puts(str);
       fflush(stdout);

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -83,17 +83,22 @@ void f(size_t size)
   t6.join();
   t7.join();
   t8.join();
+  printf(".");
+  fflush(stdout);
 }
 
 int main(int, char**)
 {
   setup();
+  printf(".");
+  fflush(stdout);
 
   f(0);
   f(1);
   f(3);
   f(5);
   f(7);
+  printf("\n");
   for (size_t exp = 1; exp < snmalloc::SUPERSLAB_BITS; exp++)
   {
     f(1ULL << exp);
@@ -108,5 +113,6 @@ int main(int, char**)
     f((3ULL << exp) - 1);
     f((5ULL << exp) - 1);
     f((7ULL << exp) - 1);
+    printf("\n");
   }
 }

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -18,7 +18,7 @@
  */
 void get_test()
 {
-  // This should get the GlobalPlaceHolder is using lazy init
+  // This should get the GlobalPlaceHolder if using lazy init
   auto a1 = snmalloc::ThreadAlloc::get_noncachable();
 
   // This should get a real allocator

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -64,7 +64,7 @@ void f(size_t size)
   auto t3 = std::thread(alloc3, size);
   auto t4 = std::thread(alloc4, size);
 
-  auto a = snmalloc::ThreadAlloc::get();
+  auto a = snmalloc::current_alloc_pool()->acquire();
   auto p1 = a->alloc(size);
   auto p2 = a->alloc(size);
   auto p3 = a->alloc(size);
@@ -83,6 +83,8 @@ void f(size_t size)
   t6.join();
   t7.join();
   t8.join();
+  snmalloc::current_alloc_pool()->release(a);
+  snmalloc::current_alloc_pool()->debug_in_use(0);
   printf(".");
   fflush(stdout);
 }


### PR DESCRIPTION
If an allocation or deallocation occurs during TLS teardown, then it is
possible for a new allocator to be created and then this is leaked. On
the mimalloc-bench mstressN benchmark this was observed leading to a
large memory leak.

This fix, detects if we are in the TLS teardown phase, and if so,
the calls to alloc or dealloc must return the allocator once they have
perform the specific operation.

[Add:] Also fixes unimplemented ABA primitive for ARM.  Currently uses locking.

[Add:] Some debug infrastructure to deal with Posix platforms.