### PR TITLE
Add back the peek methods to ABA.

### DIFF
--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -114,6 +114,12 @@ namespace snmalloc
 
       Cmp(const Cmp&) = delete;
     };
+
+    // This method is used in Verona
+    T* peek()
+    {
+      return independent.ptr.load(std::memory_order_relaxed);
+    }
   };
 #else
   /**
@@ -166,6 +172,12 @@ namespace snmalloc
 #  endif
       }
     };
+
+    // This method is used in Verona
+    T* peek()
+    {
+      return ptr.load(std::memory_order_relaxed);
+    }
   };
 #endif
 } // namespace snmalloc


### PR DESCRIPTION
These are used by the Verona runtime.