### PR TITLE
Callback fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,6 @@ macro(warnings_high)
       add_compile_options(-Wsign-conversion)
     endif ()
     add_compile_options(-Wall -Wextra -Werror -Wundef)
-    # There are a few places with subtle reasons for array access being correct
-    # GCC's warnings are too aggressive and incorrectly assume the code is wrong.
-    # Disabling only in Release is so the ASSUME can be mapped to assert and check
-    # at runtime in debug.  This ensures we are covering the cases of concern with 
-    # debug checks, but not incurring runtime penalties in release.
-    if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
-      add_compile_options(-Wno-array-bounds)
-    endif ()
   endif()
 endmacro()
 

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -366,7 +366,8 @@ namespace snmalloc
         p = memory_provider.template reserve<false>(large_class);
         if (p == nullptr)
           return nullptr;
-        memory_provider.template notify_using<zero_mem>(p, size);
+        memory_provider.template notify_using<zero_mem>(
+          p, bits::align_up(size, OS_PAGE_SIZE));
       }
       else
       {

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -296,6 +296,20 @@ void test_calloc_16M()
   alloc->dealloc(p1);
 }
 
+void test_calloc_large_bug()
+{
+  auto alloc = ThreadAlloc::get();
+  // Perform large calloc, to check for correct zeroing from PAL.
+  // Some PALS have special paths for PAGE aligned zeroing of large
+  // allocations.  This is a large allocation that is intentionally
+  // not a multiple of page size.
+  const size_t size = (SUPERSLAB_SIZE << 3) - 7;
+
+  void* p1 = alloc->alloc<YesZero>(size);
+  SNMALLOC_ASSERT(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  alloc->dealloc(p1);
+}
+
 int main(int argc, char** argv)
 {
   setup();
@@ -309,6 +323,7 @@ int main(int argc, char** argv)
   UNUSED(argv);
 #endif
 
+  test_calloc_large_bug();
   test_external_pointer_dealloc_bug();
   test_external_pointer_large();
   test_alloc_dealloc_64k();


### PR DESCRIPTION
The recent changes to the call-backs did not correctly pass the template parameters. This PR
* Adds a test to cover this case
* Passes the template parameters
* Call more specific entry points
* Re-enables GCC warning as we no longer trip up the spurious warning.