### PR TITLE
Don't require 16-byte CAS on x86.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ jobs:
         CMakeArgs: ''
         Image: plietar/snmalloc-build_linux_x86:latest
 
-  container: $(Image)
+  container: $[ variables['Image'] ]
   steps:
   - script: |
       ci/scripts/build.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,80 +9,106 @@ jobs:
   displayName: Linux
   pool:
     vmImage: 'ubuntu-18.04'
-  container: snmallocciteam/build_linux_x64:latest
 
   strategy:
     matrix:
-      Clang-7 Debug:
+      64-bit Clang-7 Debug:
         CC: clang-7
         CXX: clang++-7
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Clang-7 Release:
+      64-bit Clang-7 Release:
         CC: clang-7
         CXX: clang++-7
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Clang-8 Debug:
+      64-bit Clang-8 Debug:
         CC: clang-8
         CXX: clang++-8
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Clang-8 Release:
+      64-bit Clang-8 Release:
         CC: clang-8
         CXX: clang++-8
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Clang-9 Debug:
+      64-bit Clang-9 Debug:
         CC: clang-9
         CXX: clang++-9
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Clang-9 Release:
+      64-bit Clang-9 Release:
         CC: clang-9
         CXX: clang++-9
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      GCC-8 Debug:
+      64-bit GCC-8 Debug:
         CC: gcc-8
         CXX: g++-8
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      GCC-8 Release:
+      64-bit GCC-8 Release:
         CC: gcc-8
         CXX: g++-8
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Self Host:
+      64-bit Self Host:
         CC: clang-7
         CXX: clang++-7
         BuildType: Debug
         SelfHost: true
         CMakeArgs: ''
+        Image: snmallocciteam/build_linux_x64:latest
 
-      Cache Friendly:
+      64-bit Cache Friendly:
         CC: clang-7
         CXX: clang++-7
         BuildType: Debug
         SelfHost: false
         CMakeArgs: '-DCACHE_FRIENDLY_OFFSET=64'
+        Image: snmallocciteam/build_linux_x64:latest
 
+      32-bit Clang-9 Debug:
+        CC: clang-9
+        CXX: clang++-9
+        BuildType: Debug
+        SelfHost: false
+        CMakeArgs: ''
+        Image: plietar/snmalloc-build_linux_x86:latest
+
+      32-bit Clang-9 Release:
+        CC: clang-9
+        CXX: clang++-9
+        BuildType: Release
+        SelfHost: false
+        CMakeArgs: ''
+        Image: plietar/snmalloc-build_linux_x86:latest
+
+  container: $(Image)
   steps:
   - script: |
       ci/scripts/build.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ jobs:
         BuildType: Debug
         SelfHost: false
         CMakeArgs: ''
-        Image: plietar/snmalloc-build_linux_x86:latest
+        Image: snmallocciteam/build_linux_x86:latest
 
       32-bit Clang-9 Release:
         CC: clang-9
@@ -106,7 +106,7 @@ jobs:
         BuildType: Release
         SelfHost: false
         CMakeArgs: ''
-        Image: plietar/snmalloc-build_linux_x86:latest
+        Image: snmallocciteam/build_linux_x86:latest
 
   container: $[ variables['Image'] ]
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,21 +111,21 @@ jobs:
   container: $[ variables['Image'] ]
   steps:
   - script: |
+      set -eo pipefail
       ci/scripts/build.sh
     env:
       CC: $(CC)
       CXX: $(CXX)
       BUILD_TYPE: $(BuildType)
       CMAKE_ARGS: $(CMakeArgs)
-    failOnStderr: true
     displayName: 'Build'
 
   - script: |
+      set -eo pipefail
       ci/scripts/test.sh
     env:
       SELF_HOST: $(SelfHost)
       BUILD_TYPE: $(BuildType)
-    failOnStderr: true
     displayName: 'Test'
 
 - job:

--- a/ci/linux_x86
+++ b/ci/linux_x86
@@ -1,0 +1,7 @@
+FROM multiarch/ubuntu-core:x86-bionic
+
+WORKDIR /src
+
+RUN apt update \
+    && apt install --no-install-recommends -y ninja-build clang++-9 cmake \
+    && apt -y clean

--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -99,9 +99,10 @@ namespace snmalloc
           (__int64)value,
           (__int64*)&old);
 #  else
-#    if defined(__GNUC__) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16)
+#    if defined(__GNUC__) && defined(SNMALLOC_VA_BITS_64) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16)
 #error You must compile with -mcx16 to enable 16-byte atomic compare and swap.
 #    endif
+
         Linked xchg{value, old.aba + 1};
         std::atomic<Linked>& addr = parent->linked;
 

--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -99,7 +99,8 @@ namespace snmalloc
           (__int64)value,
           (__int64*)&old);
 #  else
-#    if defined(__GNUC__) && defined(SNMALLOC_VA_BITS_64) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16)
+#    if defined(__GNUC__) && defined(SNMALLOC_VA_BITS_64) && \
+      !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16)
 #error You must compile with -mcx16 to enable 16-byte atomic compare and swap.
 #    endif
 


### PR DESCRIPTION
We only need to CAS 2 pointers, which is always possible on x86.

This uses the `plietar/snmalloc-build_linux_x86:latest` docker image, obviously that should be changed to something under snmallocciteam.