### PR TITLE
Fix sized delete of nullptr

### DIFF
--- a/src/override/new.cc
+++ b/src/override/new.cc
@@ -43,6 +43,7 @@ void operator delete(void* p)EXCEPTSPEC
 
 void operator delete(void* p, size_t size)EXCEPTSPEC
 {
+  if (p == nullptr) return;
   ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 
@@ -58,6 +59,7 @@ void operator delete[](void* p) EXCEPTSPEC
 
 void operator delete[](void* p, size_t size) EXCEPTSPEC
 {
+  if (p == nullptr) return;
   ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 

--- a/src/override/new.cc
+++ b/src/override/new.cc
@@ -43,7 +43,8 @@ void operator delete(void* p)EXCEPTSPEC
 
 void operator delete(void* p, size_t size)EXCEPTSPEC
 {
-  if (p == nullptr) return;
+  if (p == nullptr)
+    return;
   ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 
@@ -59,7 +60,8 @@ void operator delete[](void* p) EXCEPTSPEC
 
 void operator delete[](void* p, size_t size) EXCEPTSPEC
 {
-  if (p == nullptr) return;
+  if (p == nullptr)
+    return;
   ThreadAlloc::get_noncachable()->dealloc(p, size);
 }
 


### PR DESCRIPTION
The core snmalloc code assumes if you know the size, then it is not
nullptr. However, the C++ delete operator can be called with nullptr.

This change checks for that case.