### PR TITLE
test/contention: release size store first

### DIFF
--- a/src/test/perf/contention/contention.cc
+++ b/src/test/perf/contention/contention.cc
@@ -86,7 +86,7 @@ void test_tasks_f(size_t id)
 
     *res = size;
     size_t* out =
-      contention[n % swapsize].exchange(res, std::memory_order_relaxed);
+      contention[n % swapsize].exchange(res, std::memory_order_acq_rel);
 
     if (out != nullptr)
     {


### PR DESCRIPTION
It is important, in test_tasks_f, that the store of the size to the
allocated block be made visible to other processors before the store of
the pointer itself.  Otherwise, other cores are justified in reading
junk.

This manifests on PowerPC as tripping the "Deallocating with incorrect
size supplied" assertion in alloc.h:/check_size because the value read
from the allocated block may not be a size but rather an internal queue
pointer, which is implausibly large, as sizes go.