### PR TITLE
Draft: Tree index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
   else()
-    add_compile_options(-fno-exceptions -fno-rtti -g -ftls-model=initial-exec -fomit-frame-pointer)
+    add_compile_options(-fno-exceptions -fno-rtti -g -ftls-model=initial-exec -fomit-frame-pointer -mcmodel=large)
     if(SNMALLOC_CI_BUILD OR (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
       # Get better stack traces in CI and Debug.
       target_link_libraries(snmalloc_lib INTERFACE "-rdynamic")

--- a/src/ds/treeindex.h
+++ b/src/ds/treeindex.h
@@ -1,0 +1,220 @@
+#include "../aal/aal.h"
+
+#include <atomic>
+
+namespace snmalloc
+{
+  /**
+   * This class provides an index of size total_entries.
+   *
+   * By specifying a way to allocated blocks, `alloc_block` and the block size
+   * in bytes, `block_size` the index is made into a tree. `get` is wait-free
+   * and has no conditionals, `set` can block if two threads are attempting to
+   * add a sub-node in the tree at the same time.
+   */
+  template<
+    typename T,
+    size_t total_entries,
+    void* (*alloc_block)() = nullptr,
+    size_t block_size_template = 0>
+  class TreeIndex
+  {
+    static constexpr size_t block_size = block_size_template == 0 ?
+      total_entries * sizeof(T) :
+      block_size_template;
+
+    static_assert(
+      (block_size_template == 0) == (alloc_block == nullptr),
+      "Must set alloc_block and block_size_template parameter");
+
+    static_assert(
+      block_size >= sizeof(uintptr_t) * 2,
+      "Block must contain at least two pointers.");
+    static_assert(block_size >= sizeof(T), "Block must contain at least one T");
+
+  public:
+    static constexpr bool is_leaf = (total_entries * sizeof(T)) <= block_size;
+
+    /**
+     * Calculate the entries that are stored at this level of the tree.
+     *
+     * `TT` is used to allow the change of representation from T at the bottom
+     *level to pointers at higher levels. `entries` is used to say how many
+     *entries are required at this level.
+     **/
+    template<typename TT, size_t entries>
+    static constexpr size_t calc_entries()
+    {
+      if constexpr (entries * sizeof(TT) <= block_size)
+      {
+        return entries;
+      }
+      else
+      {
+        constexpr size_t next = (entries * sizeof(TT)) / block_size;
+        return calc_entries<void*, next>();
+      }
+    }
+
+    /// The number of elements at this level of the tree.
+    static constexpr size_t entries = calc_entries<T, total_entries>();
+    /// The number of entries each sub entry should contain.
+    static constexpr size_t sub_entries = total_entries / entries;
+
+    /**
+     * Type for the next level in the tree. If the current level is a leaf
+     * then this is not used.
+     */
+    using SubT = std::conditional_t<
+      is_leaf,
+      void*,
+      TreeIndex<T, sub_entries, alloc_block, block_size>>;
+
+    /**
+     * Type of entries in the tree that point to lower levels.
+     * If this level is a leaf, then this type is not used.
+     */
+    struct Ptr
+    {
+      SubT* value;
+
+      constexpr Ptr() noexcept : value(is_leaf ? nullptr : original()) {}
+
+      Ptr(SubT* v) noexcept : value(v) {}
+    };
+
+    // Type of entries for this level of the tree
+    using Entries = std::conditional_t<is_leaf, T, Ptr>;
+
+#if !defined(_MSC_VER) || defined(__clang__)
+    // The address used for default address for this level in the tree.
+    inline static SubT original_block{};
+#endif
+
+    constexpr static SubT* original()
+    {
+#if defined(_MSC_VER) && !defined(__clang__)
+      // The address used for default address for this level in the tree.
+      // MSVC does not support the `inline static` of the self type.
+      constexpr static SubT original_block{};
+#endif
+      if constexpr (is_leaf)
+      {
+        return nullptr;
+      }
+      else
+      {
+        return const_cast<SubT*>(&original_block);
+      }
+    };
+
+#if !defined(_MSC_VER) || defined(__clang__)
+    // The address used for the lock at for this level in the tree.
+    inline static SubT lock_block{};
+#endif
+    constexpr static SubT* lock()
+    {
+#if defined(_MSC_VER) && !defined(__clang__)
+      // The address used for the lock at for this level in the tree.
+      // MSVC does not support the `inline static` of the self type.
+      constexpr static SubT lock_block{};
+#endif
+      if constexpr (is_leaf)
+      {
+        return nullptr;
+      }
+      else
+      {
+        return const_cast<SubT*>(&lock_block);
+      }
+    };
+
+    constexpr TreeIndex() noexcept {}
+
+    /// Get element at this index.
+    T get(size_t index)
+    {
+      if constexpr (is_leaf)
+      {
+        return array[index].load(std::memory_order_relaxed);
+      }
+      else
+      {
+        return (array[index / sub_entries]
+                  .load(std::memory_order_relaxed)
+                  .value)
+          ->get(index % sub_entries);
+      }
+    }
+
+    /// Set element at this index.
+    void set(size_t index, T v)
+    {
+      if constexpr (is_leaf)
+      {
+        array[index] = v;
+      }
+      else
+      {
+        auto next =
+          array[index / sub_entries].load(std::memory_order_relaxed).value;
+        if ((next != original()) && (next != lock()))
+        {
+          next->set(index % sub_entries, v);
+          return;
+        }
+        set_slow(index, v);
+      }
+    }
+
+    /**
+     * Returns the pointer to the leaf entry associated with this index.
+     * If the entry was not already in the tree creates a unique entry
+     * for it.
+     */
+    std::atomic<T>* get_addr(size_t index)
+    {
+      if constexpr (is_leaf)
+      {
+        return &(array[index / sub_entries]);
+      }
+      else
+      {
+        auto expected = Ptr(original());
+        if (array[index / sub_entries].compare_exchange_strong(
+              expected, Ptr(lock())))
+        {
+          // Allocate new TreeIndex
+          void* new_block = alloc_block();
+          // Initialise the block
+          auto new_block_typed = new (new_block) SubT();
+          // Unlock TreeIndex
+          array[index / sub_entries].store(
+            Ptr(new_block_typed), std::memory_order_relaxed);
+        }
+        while (
+          array[index / sub_entries].load(std::memory_order_relaxed).value ==
+          lock())
+        {
+          Aal::pause();
+        }
+
+        return array[index / sub_entries]
+          .load(std::memory_order_relaxed)
+          .value->get_addr(index % sub_entries);
+      }
+    }
+
+  private:
+    void set_slow(size_t index, T v)
+    {
+      auto p = get_addr(index);
+      p->store(v, std::memory_order_relaxed);
+    }
+
+    /**
+     *  Data stored for this level of the tree.
+     */
+    std::atomic<Entries> array[entries];
+  };
+}

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -43,18 +43,7 @@ namespace snmalloc
   static_assert(
     SUPERSLAB_BITS > CMMediumslab, "Large allocations may be too small");
 
-#ifndef SNMALLOC_MAX_FLATPAGEMAP_SIZE
-// Use flat map is under a single node.
-#  define SNMALLOC_MAX_FLATPAGEMAP_SIZE PAGEMAP_NODE_SIZE
-#endif
-  static constexpr bool USE_FLATPAGEMAP = pal_supports<LazyCommit> ||
-    (SNMALLOC_MAX_FLATPAGEMAP_SIZE >=
-     sizeof(FlatPagemap<SUPERSLAB_BITS, uint8_t>));
-
-  using ChunkmapPagemap = std::conditional_t<
-    USE_FLATPAGEMAP,
-    FlatPagemap<SUPERSLAB_BITS, uint8_t>,
-    Pagemap<SUPERSLAB_BITS, uint8_t, 0>>;
+  using ChunkmapPagemap = PagemapV2<SUPERSLAB_BITS, uint8_t>;
 
   /**
    * Mixin used by `ChunkMap` to directly access the pagemap via a global
@@ -76,7 +65,7 @@ namespace snmalloc
      * The global pagemap variable.  The name of this symbol will include the
      * type of `T`.
      */
-    inline static T global_pagemap;
+    inline static ChunkmapPagemap global_pagemap{};
 
   public:
     /**

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -217,11 +217,11 @@ namespace snmalloc
      * Primitive allocator for structure that are required before
      * the allocator can be running.
      */
-    template<typename T, size_t alignment, typename... Args>
-    T* alloc_chunk(Args&&... args)
+    template<size_t tsize, size_t alignment>
+    void* alloc_chunk_untyped()
     {
       // Cache line align
-      size_t size = bits::align_up(sizeof(T), 64);
+      size_t size = bits::align_up(tsize, 64);
 
       void* p;
       {
@@ -261,6 +261,17 @@ namespace snmalloc
       PAL::template notify_using<NoZero>(
         page_start, static_cast<size_t>(page_end - page_start));
 
+      return p;
+    }
+
+    /**
+     * Primitive allocator for structure that are required before
+     * the allocator can be running.
+     */
+    template<typename T, size_t alignment, typename... Args>
+    T* alloc_chunk(Args&&... args)
+    {
+      auto p = alloc_chunk_untyped<sizeof(T), alignment>();
       return new (p) T(std::forward<Args...>(args)...);
     }
 

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -2,6 +2,7 @@
 
 #include "../ds/bits.h"
 #include "../ds/helpers.h"
+#include "../ds/treeindex.h"
 
 #include <atomic>
 #include <utility>
@@ -46,299 +47,45 @@ namespace snmalloc
   };
 
   /**
-   * The Pagemap is the shared data structure ultimately used by multiple
-   * snmalloc threads / allocators to determine who owns memory and,
-   * therefore, to whom deallocated memory should be returned.  The
-   * allocators do not interact with this directly but rather via the
-   * static ChunkMap object, which encapsulates knowledge about the
-   * pagemap's parametric type T.
-   */
-  template<size_t GRANULARITY_BITS, typename T, T default_content>
-  class Pagemap
-  {
-  private:
-    static constexpr size_t COVERED_BITS =
-      bits::ADDRESS_BITS - GRANULARITY_BITS;
-    static constexpr size_t CONTENT_BITS =
-      bits::next_pow2_bits_const(sizeof(T));
-
-    static_assert(
-      PAGEMAP_NODE_BITS - CONTENT_BITS < COVERED_BITS,
-      "Should use the FlatPageMap as it does not require a tree");
-
-    static constexpr size_t BITS_FOR_LEAF = PAGEMAP_NODE_BITS - CONTENT_BITS;
-    static constexpr size_t ENTRIES_PER_LEAF = 1 << BITS_FOR_LEAF;
-    static constexpr size_t LEAF_MASK = ENTRIES_PER_LEAF - 1;
-
-    static constexpr size_t BITS_PER_INDEX_LEVEL =
-      PAGEMAP_NODE_BITS - POINTER_BITS;
-    static constexpr size_t ENTRIES_PER_INDEX_LEVEL = 1 << BITS_PER_INDEX_LEVEL;
-    static constexpr size_t ENTRIES_MASK = ENTRIES_PER_INDEX_LEVEL - 1;
-
-    static constexpr size_t INDEX_BITS =
-      BITS_FOR_LEAF > COVERED_BITS ? 0 : COVERED_BITS - BITS_FOR_LEAF;
-
-    static constexpr size_t INDEX_LEVELS = INDEX_BITS / BITS_PER_INDEX_LEVEL;
-    static constexpr size_t TOPLEVEL_BITS =
-      INDEX_BITS - (INDEX_LEVELS * BITS_PER_INDEX_LEVEL);
-    static constexpr size_t TOPLEVEL_ENTRIES = 1 << TOPLEVEL_BITS;
-    static constexpr size_t TOPLEVEL_SHIFT =
-      (INDEX_LEVELS * BITS_PER_INDEX_LEVEL) + BITS_FOR_LEAF + GRANULARITY_BITS;
-
-    // Value used to represent when a node is being added too
-    static constexpr InvalidPointer<1> LOCKED_ENTRY{};
-
-    struct Leaf
-    {
-      std::atomic<T> values[ENTRIES_PER_LEAF];
-    };
-
-    struct PagemapEntry
-    {
-      std::atomic<PagemapEntry*> entries[ENTRIES_PER_INDEX_LEVEL];
-    };
-
-    static_assert(
-      sizeof(PagemapEntry) == sizeof(Leaf), "Should be the same size");
-
-    static_assert(
-      sizeof(PagemapEntry) == PAGEMAP_NODE_SIZE, "Should be the same size");
-
-    // Init removed as not required as this is only ever a global
-    // cl is generating a memset of zero, which will be a problem
-    // in libc/ucrt bring up.  On ucrt this will run after the first
-    // allocation.
-    //  TODO: This is fragile that it is not being memset, and we should review
-    //  to ensure we don't get bitten by this in the future.
-    std::atomic<PagemapEntry*> top[TOPLEVEL_ENTRIES]; // = {nullptr};
-
-    template<bool create_addr>
-    SNMALLOC_FAST_PATH PagemapEntry*
-    get_node(std::atomic<PagemapEntry*>* e, bool& result)
-    {
-      // The page map nodes are all allocated directly from the OS zero
-      // initialised with a system call.  We don't need any ordered to guarantee
-      // to see that correctly. The only transistions are monotone and handled
-      // by the slow path.
-      PagemapEntry* value = e->load(std::memory_order_relaxed);
-
-      if (likely(value > LOCKED_ENTRY))
-      {
-        result = true;
-        return value;
-      }
-      if constexpr (create_addr)
-      {
-        return get_node_slow(e, result);
-      }
-      else
-      {
-        result = false;
-        return nullptr;
-      }
-    }
-
-    SNMALLOC_SLOW_PATH PagemapEntry*
-    get_node_slow(std::atomic<PagemapEntry*>* e, bool& result)
-    {
-      // The page map nodes are all allocated directly from the OS zero
-      // initialised with a system call.  We don't need any ordered to guarantee
-      // to see that correctly.
-      PagemapEntry* value = e->load(std::memory_order_relaxed);
-
-      if ((value == nullptr) || (value == LOCKED_ENTRY))
-      {
-        value = nullptr;
-
-        if (e->compare_exchange_strong(
-              value, LOCKED_ENTRY, std::memory_order_relaxed))
-        {
-          auto& v = default_memory_provider();
-          value = v.alloc_chunk<PagemapEntry, OS_PAGE_SIZE>();
-          e->store(value, std::memory_order_release);
-        }
-        else
-        {
-          while (address_cast(e->load(std::memory_order_relaxed)) ==
-                 LOCKED_ENTRY)
-          {
-            Aal::pause();
-          }
-          value = e->load(std::memory_order_acquire);
-        }
-      }
-      result = true;
-      return value;
-    }
-
-    template<bool create_addr>
-    SNMALLOC_FAST_PATH std::pair<Leaf*, size_t>
-    get_leaf_index(uintptr_t addr, bool& result)
-    {
-#ifdef FreeBSD_KERNEL
-      // Zero the top 16 bits - kernel addresses all have them set, but the
-      // data structure assumes that they're zero.
-      addr &= 0xffffffffffffULL;
-#endif
-      size_t ix = addr >> TOPLEVEL_SHIFT;
-      size_t shift = TOPLEVEL_SHIFT;
-      std::atomic<PagemapEntry*>* e = &top[ix];
-
-      for (size_t i = 0; i < INDEX_LEVELS; i++)
-      {
-        PagemapEntry* value = get_node<create_addr>(e, result);
-        if (unlikely(!result))
-          return {nullptr, 0};
-
-        shift -= BITS_PER_INDEX_LEVEL;
-        ix = (static_cast<size_t>(addr) >> shift) & ENTRIES_MASK;
-        e = &value->entries[ix];
-
-        if constexpr (INDEX_LEVELS == 1)
-        {
-          UNUSED(i);
-          break;
-        }
-        i++;
-
-        if (i == INDEX_LEVELS)
-          break;
-      }
-
-      Leaf* leaf = reinterpret_cast<Leaf*>(get_node<create_addr>(e, result));
-
-      if (unlikely(!result))
-        return {nullptr, 0};
-
-      shift -= BITS_FOR_LEAF;
-      ix = (static_cast<size_t>(addr) >> shift) & LEAF_MASK;
-      return {leaf, ix};
-    }
-
-    template<bool create_addr>
-    SNMALLOC_FAST_PATH std::atomic<T>* get_addr(uintptr_t p, bool& success)
-    {
-      auto leaf_ix = get_leaf_index<create_addr>(p, success);
-      return &(leaf_ix.first->values[leaf_ix.second]);
-    }
-
-    std::atomic<T>* get_ptr(uintptr_t p)
-    {
-      bool success;
-      return get_addr<true>(p, success);
-    }
-
-  public:
-    /**
-     * The pagemap configuration describing this instantiation of the template.
-     */
-    static constexpr PagemapConfig config = {
-      1, false, sizeof(uintptr_t), GRANULARITY_BITS, sizeof(T)};
-
-    /**
-     * Cast a `void*` to a pointer to this template instantiation, given a
-     * config describing the configuration.  Return null if the configuration
-     * passed does not correspond to this template instantiation.
-     *
-     * This intended to allow code that depends on the pagemap having a
-     * specific representation to fail gracefully.
-     */
-    static Pagemap* cast_to_pagemap(void* pm, const PagemapConfig* c)
-    {
-      if (
-        (c->version != 1) || (c->is_flat_pagemap) ||
-        (c->sizeof_pointer != sizeof(uintptr_t)) ||
-        (c->pagemap_bits != GRANULARITY_BITS) ||
-        (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
-      {
-        return nullptr;
-      }
-      return static_cast<Pagemap*>(pm);
-    }
-
-    /**
-     * Returns the index of a pagemap entry within a given page.  This is used
-     * in code that propagates changes to the pagemap elsewhere.
-     */
-    size_t index_for_address(uintptr_t p)
-    {
-      bool success;
-      return (OS_PAGE_SIZE - 1) &
-        reinterpret_cast<size_t>(get_addr<true>(p, success));
-    }
-
-    /**
-     * Returns the address of the page containing
-     */
-    void* page_for_address(uintptr_t p)
-    {
-      bool success;
-      return pointer_align_down<OS_PAGE_SIZE>(get_addr<true>(p, success));
-    }
-
-    T get(uintptr_t p)
-    {
-      bool success;
-      auto addr = get_addr<false>(p, success);
-      if (!success)
-        return default_content;
-      return addr->load(std::memory_order_relaxed);
-    }
-
-    void set(uintptr_t p, T x)
-    {
-      bool success;
-      auto addr = get_addr<true>(p, success);
-      addr->store(x, std::memory_order_relaxed);
-    }
-
-    void set_range(uintptr_t p, T x, size_t length)
-    {
-      bool success;
-      do
-      {
-        auto leaf_ix = get_leaf_index<true>(p, success);
-        size_t ix = leaf_ix.second;
-
-        auto last = bits::min(LEAF_MASK + 1, ix + length);
-
-        auto diff = last - ix;
-
-        for (; ix < last; ix++)
-        {
-          SNMALLOC_ASSUME(leaf_ix.first != nullptr);
-          leaf_ix.first->values[ix] = x;
-        }
-
-        length = length - diff;
-        p = p + (diff << GRANULARITY_BITS);
-      } while (length > 0);
-    }
-  };
-
-  /**
    * Simple pagemap that for each GRANULARITY_BITS of the address range
    * stores a T.
    */
   template<size_t GRANULARITY_BITS, typename T>
-  class alignas(OS_PAGE_SIZE) FlatPagemap
+  class alignas(OS_PAGE_SIZE) PagemapV2
   {
   private:
+    static_assert(
+      sizeof(T) == bits::next_pow2_const(sizeof(T)),
+      "Needed for good performance.");
     static constexpr size_t COVERED_BITS =
       bits::ADDRESS_BITS - GRANULARITY_BITS;
     static constexpr size_t CONTENT_BITS =
       bits::next_pow2_bits_const(sizeof(T));
-    static constexpr size_t ENTRIES = 1ULL << (COVERED_BITS + CONTENT_BITS);
+    static constexpr size_t ENTRIES = 1ULL << COVERED_BITS;
     static constexpr size_t SHIFT = GRANULARITY_BITS;
 
-    std::atomic<T> top[ENTRIES];
+    static void* alloc_block()
+    {
+      return default_memory_provider()
+        .alloc_chunk_untyped<PAGEMAP_NODE_SIZE, OS_PAGE_SIZE>();
+    }
+
+    using TreeIndexType = std::conditional_t<
+      pal_supports<LazyCommit>,
+      snmalloc::TreeIndex<T, ENTRIES>,
+      snmalloc::TreeIndex<T, ENTRIES, alloc_block, PAGEMAP_NODE_SIZE>>;
+
+    TreeIndexType tree_index{};
 
   public:
     /**
      * The pagemap configuration describing this instantiation of the template.
      */
-    static constexpr PagemapConfig config = {
-      1, true, sizeof(uintptr_t), GRANULARITY_BITS, sizeof(T)};
+    static constexpr PagemapConfig config = {2,
+                                             TreeIndexType::is_leaf,
+                                             sizeof(uintptr_t),
+                                             GRANULARITY_BITS,
+                                             sizeof(T)};
 
     /**
      * Cast a `void*` to a pointer to this template instantiation, given a
@@ -348,27 +95,27 @@ namespace snmalloc
      * This intended to allow code that depends on the pagemap having a
      * specific representation to fail gracefully.
      */
-    static FlatPagemap* cast_to_pagemap(void* pm, const PagemapConfig* c)
+    static PagemapV2* cast_to_pagemap(void* pm, const PagemapConfig* c)
     {
       if (
-        (c->version != 1) || (!c->is_flat_pagemap) ||
+        (c->version != 2) || (c->is_flat_pagemap == TreeIndexType::is_leaf) ||
         (c->sizeof_pointer != sizeof(uintptr_t)) ||
         (c->pagemap_bits != GRANULARITY_BITS) ||
         (c->size_of_entry != sizeof(T)) || (!std::is_integral_v<T>))
       {
         return nullptr;
       }
-      return static_cast<FlatPagemap*>(pm);
+      return static_cast<PagemapV2*>(pm);
     }
 
     T get(uintptr_t p)
     {
-      return top[p >> SHIFT].load(std::memory_order_relaxed);
+      return tree_index.get(p >> SHIFT);
     }
 
     void set(uintptr_t p, T x)
     {
-      top[p >> SHIFT].store(x, std::memory_order_relaxed);
+      tree_index.set(p >> SHIFT, x);
     }
 
     void set_range(uintptr_t p, T x, size_t length)
@@ -376,7 +123,7 @@ namespace snmalloc
       size_t index = p >> SHIFT;
       do
       {
-        top[index].store(x, std::memory_order_relaxed);
+        tree_index.set(index, x);
         index++;
         length--;
       } while (length > 0);
@@ -396,9 +143,10 @@ namespace snmalloc
     void* page_for_address(uintptr_t p)
     {
       SNMALLOC_ASSERT(
-        (reinterpret_cast<uintptr_t>(&top) & (OS_PAGE_SIZE - 1)) == 0);
+         (reinterpret_cast<uintptr_t>(tree_index.get_addr(0)) & (OS_PAGE_SIZE - 1)) == 0);
       return reinterpret_cast<void*>(
-        reinterpret_cast<uintptr_t>(&top[p >> SHIFT]) & ~(OS_PAGE_SIZE - 1));
+        reinterpret_cast<uintptr_t>(tree_index.get_addr(p >> SHIFT)) &
+        ~(OS_PAGE_SIZE - 1));
     }
   };
 } // namespace snmalloc

--- a/src/test/func/treeindex/treeindex.cc
+++ b/src/test/func/treeindex/treeindex.cc
@@ -1,0 +1,170 @@
+#include <ds/treeindex.h>
+#include <iostream>
+#include <pal/pal.h>
+#include <test/setup.h>
+
+void* alloc_block_16bit()
+{
+  return malloc(65536);
+}
+
+void* alloc_block_4bit()
+{
+  return malloc(16);
+}
+
+constexpr size_t LARGE_RANGE = 1ULL << 38;
+
+constexpr size_t RANGE = 1ULL << 20;
+constexpr size_t SUB_RANGE = 1ULL << 18;
+
+using std_tree = snmalloc::TreeIndex<uint8_t, RANGE, alloc_block_16bit, 65536>;
+using flat_tree = snmalloc::TreeIndex<uint8_t, RANGE>;
+using fine_tree = snmalloc::TreeIndex<uint8_t, RANGE, alloc_block_4bit, 16>;
+
+using std_tree_l =
+  snmalloc::TreeIndex<uint8_t, LARGE_RANGE, alloc_block_16bit, 65536>;
+using flat_tree_l = snmalloc::TreeIndex<uint8_t, LARGE_RANGE>;
+using fine_tree_l =
+  snmalloc::TreeIndex<uint8_t, LARGE_RANGE, alloc_block_4bit, 16>;
+
+using std_tree_u64 =
+  snmalloc::TreeIndex<uint64_t, RANGE, alloc_block_16bit, 65536>;
+using flat_tree_u64 = snmalloc::TreeIndex<uint64_t, RANGE>;
+using fine_tree_u64 =
+  snmalloc::TreeIndex<uint64_t, RANGE, alloc_block_4bit, 16>;
+
+std_tree tree1{};
+std_tree_l tree1_l{};
+std_tree_u64 tree1_u64{};
+
+fine_tree tree2{};
+fine_tree_l tree2_l{};
+fine_tree_u64 tree2_u64{};
+
+// If platforms don't support lazy commit, don't test the flat map.
+using flat_tree_test_u64 = std::conditional_t<
+  snmalloc::pal_supports<snmalloc::LazyCommit>,
+  flat_tree_u64,
+  std_tree_u64>;
+
+// If platforms don't support lazy commit, don't test the flat map.
+using flat_tree_test = std::conditional_t<
+  snmalloc::pal_supports<snmalloc::LazyCommit>,
+  flat_tree,
+  std_tree>;
+
+using flat_tree_l_test = std::conditional_t<
+  snmalloc::pal_supports<snmalloc::LazyCommit>,
+  flat_tree_l,
+  std_tree_l>;
+
+flat_tree_test tree3{};
+flat_tree_l_test tree3_l{};
+flat_tree_test_u64 tree3_u64{};
+
+/**
+ * Add noinline indirection to ASM can be inspected easily for quality
+ */
+template<typename T>
+NOINLINE uint8_t treeget(T& tree, size_t index)
+{
+  return (uint8_t)tree.get(index);
+}
+
+/**
+ * Print the shape of tree for debugging.
+ */
+template<typename T>
+void print_tree_shape(int level = 0)
+{
+  if constexpr (T::is_leaf)
+  {
+    UNUSED(level);
+    std::cout << "Leaf entries: ";
+    std::cout << T::entries << std::endl;
+  }
+  else
+  {
+    if (level == 0)
+    {
+      std::cout << "Root entries: ";
+    }
+    else
+    {
+      std::cout << "Node entries: ";
+    }
+    std::cout << T::entries << std::endl;
+    print_tree_shape<typename T::SubT>(level + 1);
+  }
+}
+
+/**
+ * Run a few simple patterns through the tree.
+ */
+template<typename T>
+void test(T& tree)
+{
+  print_tree_shape<T>(0);
+
+  // Check can read whole range
+  for (size_t i = 0; i < RANGE; i++)
+  {
+    if (treeget(tree, i) != 0)
+    {
+      abort();
+    }
+  }
+
+  for (size_t i = 0; i < SUB_RANGE; i++)
+  {
+    tree.set(i, 1);
+    if (tree.get(i + 1) != 0)
+    {
+      abort();
+    }
+  }
+
+  for (size_t i = 0; i < RANGE; i++)
+  {
+    if (tree.get(i) != ((i < SUB_RANGE) ? 1 : 0))
+    {
+      abort();
+    }
+  }
+
+  for (size_t i = 0; i < SUB_RANGE; i += 2)
+  {
+    tree.set(i, 0);
+  }
+
+  for (size_t i = 0; i < RANGE; i++)
+  {
+    if (tree.get(i) != (i < (SUB_RANGE)) && ((i % 2) == 1) ? 1 : 0)
+    {
+      abort();
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  UNUSED(argc);
+  UNUSED(argv);
+
+  setup();
+
+  test(tree1);
+  test(tree1_l);
+  test(tree1_u64);
+  test(tree2);
+  test(tree2_l);
+  test(tree2_u64);
+
+  if constexpr (snmalloc::pal_supports<snmalloc::LazyCommit>)
+  {
+    test(tree3);
+    test(tree3_l);
+    test(tree3_u64);
+  }
+}


### PR DESCRIPTION
I have been investigating optimising the Windows code for deallocation. This change should improve the pagemap code considerably.  It implements the hierachical map, and flat map into a single class.  It uses constexpr programming to work out how many levels, and generate type safe code for all the levels.