### PR TITLE
Use cmake to find backtrace()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,14 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
         add_compile_options(-march=native)
       endif()
     endif()
+
+    find_package(Backtrace)
+    if(${Backtrace_FOUND})
+      target_compile_definitions(snmalloc_lib INTERFACE -DBACKTRACE_HEADER="${Backtrace_HEADER}")
+      target_link_libraries(snmalloc_lib INTERFACE ${Backtrace_LIBRARIES})
+      target_include_directories(snmalloc_lib INTERFACE ${Backtrace_INCLUD_DIRS})
+    endif()
+
   endif()
 
   macro(subdirlist result curdir)

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -2,9 +2,8 @@
 
 #include "../ds/address.h"
 #include "../mem/allocconfig.h"
-#if __has_include(<execinfo.h>)
-#  define SNMALLOC_HAS_BACKTRACE 1
-#  include <execinfo.h>
+#if defined(BACKTRACE_HEADER)
+#  include BACKTRACE_HEADER
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,7 +41,7 @@ namespace snmalloc
 
     static void print_stack_trace()
     {
-#ifdef SNMALLOC_HAS_BACKTRACE
+#ifdef BACKTRACE_HEADER
       constexpr int SIZE = 1024;
       void* buffer[SIZE];
       auto nptrs = backtrace(buffer, SIZE);


### PR DESCRIPTION
On FreeBSD, this notably requires the use of -lexecinfo, as backtrace()
is not available in -lc.  Rather than testing in C, test in cmake.