### PR TITLE
Allow the AAL to define address_t

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -46,6 +46,31 @@ namespace snmalloc
   template<class Arch>
   struct AAL_Generic : Arch
   {
+    /*
+     * Provide a default specification of address_t as uintptr_t for Arch-es
+     * that support IntegerPointers.  Those Arch-es without IntegerPoihnters
+     * must explicitly give their address_t.
+     *
+     * This somewhat obtuse way of spelling the defaulting is necessary so
+     * that all arguments to std::conditional_t are valid, even if they
+     * wouldn't be valid in context.  One might rather wish to say
+     *
+     *   std::conditional_t<..., uintptr_t, Arch::address_t>
+     *
+     * but that requires that Arch::address_t always be given, precisely
+     * the thing we're trying to avoid with the conditional.
+     */
+
+    struct default_address_t
+    {
+      using address_t = uintptr_t;
+    };
+
+    using address_t = typename std::conditional_t<
+      (Arch::aal_features & IntegerPointers) != 0,
+      default_address_t,
+      Arch>::address_t;
+
     /**
      * Prefetch a specific address.
      *

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -51,8 +51,7 @@ namespace snmalloc
   {
     static_assert(bits::next_pow2_const(alignment) == alignment);
 
-    return ((static_cast<size_t>(address_cast(p)) | size) & (alignment - 1)) ==
-      0;
+    return ((address_cast(p) | size) & (alignment - 1)) == 0;
   }
 
   /**

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -13,7 +13,7 @@ namespace snmalloc
    * separated into two types, one for raw addresses and one for addresses that
    * can be cast back to pointers.
    */
-  using address_t = uintptr_t;
+  using address_t = Aal::address_t;
 
   /**
    * Perform pointer arithmetic and return the adjusted pointer.

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -17,7 +17,7 @@ namespace snmalloc
      * are always the same, invalid pointer values with different sentinels are
      * always different.
      */
-    template<uintptr_t OtherSentinel>
+    template<address_t OtherSentinel>
     constexpr bool operator==(const InvalidPointer<OtherSentinel>&)
     {
       return Sentinel == OtherSentinel;
@@ -27,7 +27,7 @@ namespace snmalloc
      * are always the same, invalid pointer values with different sentinels are
      * always different.
      */
-    template<uintptr_t OtherSentinel>
+    template<address_t OtherSentinel>
     constexpr bool operator!=(const InvalidPointer<OtherSentinel>&)
     {
       return Sentinel != OtherSentinel;


### PR DESCRIPTION
On CHERI, we will want `address_t` to be `vaddr_t`, an integer type big enough to store an address but that cannot carry provenance (i.e., is too small to hold a capability).