### PR TITLE
Introduce AAL StrictProvenance flag, factor CDLList

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,7 @@ jobs:
   - script: |
       set -eo pipefail
       ninja clangformat
-      git diff --exit-code $(Build.SourceVersion)
+      git diff --exit-code
 
     workingDirectory: build
     failOnStderr: true

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -36,6 +36,12 @@ namespace snmalloc
      * This architecture cannot access cpu cycles counters.
      */
     NoCpuCycleCounters = (1 << 1),
+    /**
+     * This architecture enforces strict pointer provenance; we bound the
+     * pointers given out on malloc() and friends and must, therefore retain
+     * internal high-privilege pointers for recycling memory on free().
+     */
+    StrictProvenance = (1 << 2),
   };
 
   /**


### PR DESCRIPTION
CHERI will assert StrictProvenance (probably via AAL Mixin) and we can gate on that everywhere we need.

One such example is the contents of the CDDList nodes, where on non-StrictProvenance architectures, a relative encoding of the next pointer allows for tolerance of zero-initialized (and not constructed) values.  For StrictProvenance, point explicitly at the next element but accept `nullptr` in lieu of `this` as the empty case.

With these (atop the other PRs I have open), we're back to being able to at least minimally run `snmalloc` on CHERI, but without capability bounds being enforced (that is, all pointers returned always authorize access to the entire underlying large allocation).  Still, it's nice to be doing this in a way of which upstream approves, this time. :)