### PR TITLE
Make up for the lack of intrinsic headers in Open Enclave

### DIFF
--- a/src/aal/aal_x86_sgx.h
+++ b/src/aal/aal_x86_sgx.h
@@ -3,8 +3,6 @@
 #ifdef _MSC_VER
 #  include <immintrin.h>
 #  include <intrin.h>
-#else
-#  include <emmintrin.h>
 #endif
 
 #if defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || \
@@ -34,7 +32,11 @@ namespace snmalloc
      */
     static inline void pause()
     {
+#ifdef _MSC_VER
       _mm_pause();
+#else
+      asm volatile("pause");
+#endif
     }
 
     /**
@@ -42,7 +44,11 @@ namespace snmalloc
      */
     static inline void prefetch(void* ptr)
     {
+#ifdef _MSC_VER
       _mm_prefetch(reinterpret_cast<const char*>(ptr), _MM_HINT_T0);
+#else
+      asm volatile("prefetcht0 %0" ::"m"(ptr));
+#endif
     }
 
     /**


### PR DESCRIPTION
Fix the main remaining problem that prevents building oesnmalloc with -nostdinc. There's still a issue with the order in which headers are copied in the OE build but that's nothing to do with snmalloc.

Paging @anakrish because I can't work how to add him to Reviewers for some reason.

It is probably worth noting that this can be removed if/when 
a subset of https://github.com/openenclave/openenclave/issues/1766 is implemented in OE. That's been open for over a year though, so I would still like to have this change considered.