### PR TITLE
Fix clang-format lookup to do what the comment says

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,7 @@ macro(clangformat_targets)
   # tool.  It does not work with older versions as AfterCaseLabel is not supported
   # in earlier versions.
   find_program(CLANG_FORMAT NAMES
-    clang-format-9
-    clang-format)
+    clang-format-9)
 
   # If we've found a clang-format tool, generate a target for it, otherwise emit
   # a warning.


### PR DESCRIPTION
Despite the comment, the cmakelist will in fact take "clang-format" and use it even if it's pre-9 and incompatible.

As a pre-9 user (a choice dictated by dependencies I have no control over), this is my preferred fix. I suppose adjusting the comment to match what the cmakelist does would also work.