### PR TITLE
WIP: Allow the AAL to set bounds on returned pointers and let the ChunkMap amplify them back

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -157,6 +157,16 @@ namespace snmalloc
     }
 
     /**
+     * For architectures without StrictProvenance, there is no such thing as
+     * provenance, and so nothing to do here.
+     */
+    static inline ReturnPtr reprovenance(ReturnPtr p, void* q)
+    {
+      UNUSED(p);
+      return unsafe_return_ptr(q);
+    }
+
+    /**
      * Non-StrictProvenance architectures can get away with storing just the
      * metadata in the chunkmap.  See ChunkMapSuperslabKind.
      */

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -155,6 +155,29 @@ namespace snmalloc
       UNUSED(size);
       return unsafe_return_ptr(p);
     }
+
+    /**
+     * Non-StrictProvenance architectures can get away with storing just the
+     * metadata in the chunkmap.  See ChunkMapSuperslabKind.
+     */
+    using ChunkmapValueType = uint8_t;
+
+    static inline uint8_t chunkmap_extract_type(ChunkmapValueType cv)
+    {
+      return cv;
+    }
+
+    static inline void* chunkmap_amplify_ptr(ChunkmapValueType cv, ReturnPtr p)
+    {
+      UNUSED(cv);
+      return p.ptr;
+    }
+
+    static inline ChunkmapValueType chunkmap_value(void* p, uint8_t cmssk)
+    {
+      UNUSED(p);
+      return cmssk;
+    }
   };
 
 } // namespace snmalloc

--- a/src/ds/returnptr.h
+++ b/src/ds/returnptr.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace snmalloc
+{
+  /**
+   * A convenience type that we can use to annotate internal functions
+   * which return pointers that are headed out to the application or
+   * which have come back.
+   */
+  class ReturnPtr
+  {
+  public:
+    void* ptr;
+
+    ReturnPtr(const std::nullptr_t n)
+    {
+      this->ptr = n;
+    }
+
+    inline bool operator==(const ReturnPtr& rhs)
+    {
+      return this->ptr == rhs.ptr;
+    }
+
+    inline bool operator!=(const ReturnPtr& rhs)
+    {
+      return this->ptr != rhs.ptr;
+    }
+  };
+
+  /**
+   * Construct a ReturnPointer from an arbitrary void pointer.  This is
+   * "unsafe" in the sense of Haskell's "unsafe": the type system cannot
+   * save us from ourselves, so extra care is required.
+   */
+  static inline ReturnPtr unsafe_return_ptr(const void* p)
+  {
+    return *reinterpret_cast<ReturnPtr*>(&p);
+  }
+} // namespace snmalloc

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -394,7 +394,7 @@ namespace snmalloc
     }
 
     template<Boundary location = Start>
-    static void* external_pointer(void* p)
+    void* external_pointer(void* p_)
     {
 #ifdef USE_MALLOC
       error("Unsupported");

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -212,7 +212,8 @@ namespace snmalloc
     void check_size(void* p, size_t size)
     {
 #if defined(CHECK_CLIENT)
-      auto asize = alloc_size(p);
+      void* ampp = chunkmap().amplify(unsafe_return_ptr(p));
+      auto asize = alloc_size_amp(ampp);
       auto asc = size_to_sizeclass(asize);
       if (size_to_sizeclass(size) != asc)
       {
@@ -460,8 +461,7 @@ namespace snmalloc
       error("Not allocated by this allocator");
     }
 
-  public:
-    SNMALLOC_FAST_PATH size_t alloc_size(const void* p)
+    SNMALLOC_FAST_PATH static size_t alloc_size_amp(const void* p)
     {
       // This must be called on an external pointer.
       size_t size = ChunkMap::get(address_cast(p));
@@ -492,6 +492,12 @@ namespace snmalloc
       }
 
       return alloc_size_error();
+    }
+
+  public:
+    SNMALLOC_FAST_PATH size_t alloc_size(const void* p)
+    {
+      return alloc_size_amp(chunkmap().amplify(unsafe_return_ptr(p)));
     }
 
     size_t get_id()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -460,7 +460,7 @@ namespace snmalloc
     }
 
   public:
-    SNMALLOC_FAST_PATH static size_t alloc_size(const void* p)
+    SNMALLOC_FAST_PATH size_t alloc_size(const void* p)
     {
       // This must be called on an external pointer.
       size_t size = ChunkMap::get(address_cast(p));

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -811,7 +811,7 @@ namespace snmalloc
           while (prev != nullptr)
           {
             ReturnPtr n = Metaslab::follow_next(prev);
-            Superslab* super = Superslab::get(prev.ptr);
+            Superslab* super = Superslab::get(chunkmap().amplify(prev));
             small_dealloc_offseted_inner(super, slab, prev, i);
             prev = n;
           }

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace snmalloc
 {
-  enum ChunkMapSuperslabKind
+  enum ChunkMapSuperslabKind : uint8_t
   {
     CMNotOurs = 0,
     CMSuperslab = 1,

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -164,6 +164,17 @@ namespace snmalloc
     }
 
     /**
+     * Amplify a ReturnPtr back to its containing Superslab
+     */
+    static void* amplify(ReturnPtr p)
+    {
+      static_assert(
+        !aal_supports<StrictProvenance>,
+        "Don't look at me; I'm only here for the type checker");
+      return p.ptr;
+    }
+
+    /**
      * Set a pagemap entry indicating that there is a superslab at the
      * specified index.
      */

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -158,6 +158,14 @@ namespace snmalloc
     /**
      * Get the pagemap entry corresponding to a specific address.
      */
+    static uint8_t get(ReturnPtr p)
+    {
+      return get(address_cast(p.ptr));
+    }
+
+    /**
+     * Get the pagemap entry corresponding to a specific address.
+     */
     static uint8_t get(void* p)
     {
       return get(address_cast(p));

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -7,7 +7,7 @@
 namespace snmalloc
 {
   inline bool needs_initialisation(void*);
-  void* init_thread_allocator(function_ref<void*(void*)>);
+  ReturnPtr init_thread_allocator(function_ref<ReturnPtr(void*)>);
 
   template<class MemoryProvider, class Alloc>
   class AllocPool : Pool<Alloc, MemoryProvider>

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -93,7 +93,7 @@ namespace snmalloc
       return p;
     }
 
-    bool dealloc(void* p)
+    bool dealloc(ReturnPtr p)
     {
       SNMALLOC_ASSERT(head > 0);
 
@@ -116,10 +116,10 @@ namespace snmalloc
     }
 
   private:
-    uint16_t pointer_to_index(void* p)
+    uint16_t pointer_to_index(ReturnPtr p)
     {
       // Get the offset from the slab for a memory location.
-      return static_cast<uint16_t>(pointer_diff(this, p) >> 8);
+      return static_cast<uint16_t>(pointer_diff(this, p.ptr) >> 8);
     }
   };
 } // namespace snmalloc

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -27,7 +27,8 @@ namespace snmalloc
   {
   public:
     /**
-     *  Pointer to first free entry in this slab
+     *  Pointer to first free entry in this slab.  Recall that free lists
+     *  contain already-bounded objects.
      *
      *  The list will be (allocated - needed - 1) long. The -1 is
      *  for the `link` element which is not in the free list.

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -12,6 +12,11 @@ namespace snmalloc
    * A region of memory destined for a remote allocator's dealloc() via the
    * message passing system.  This structure is placed at the beginning of
    * the allocation itself when it is queued for sending.
+   *
+   * A Remote* is itself a ReturnPtr; that is, for architectures supporting
+   * StrictProvenance, this pointer is bounded to the allocation in question
+   * and so is suitable for direct inclusion into free lists.  Other uses
+   * may require amplification.
    */
   struct Remote
   {

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -62,7 +62,8 @@ namespace snmalloc
 #    pragma warning(push)
 #    pragma warning(disable : 4702)
 #  endif
-  SNMALLOC_FAST_PATH void* init_thread_allocator(function_ref<void*(void*)> f)
+  SNMALLOC_FAST_PATH ReturnPtr
+  init_thread_allocator(function_ref<ReturnPtr(void*)> f)
   {
     error("Critical Error: This should never be called.");
     return f(nullptr);
@@ -101,7 +102,7 @@ namespace snmalloc
    */
   class ThreadAllocCommon
   {
-    friend void* init_thread_allocator(function_ref<void*(void*)>);
+    friend ReturnPtr init_thread_allocator(function_ref<ReturnPtr(void*)>);
 
   protected:
     /**
@@ -276,7 +277,8 @@ namespace snmalloc
    * path.
    * The second component of the return indicates if this TLS is being torndown.
    */
-  SNMALLOC_FAST_PATH void* init_thread_allocator(function_ref<void*(void*)> f)
+  SNMALLOC_FAST_PATH ReturnPtr
+  init_thread_allocator(function_ref<ReturnPtr(void*)> f)
   {
     auto*& local_alloc = ThreadAlloc::get_reference();
     // If someone reuses a noncachable call, then we can end up here

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -26,7 +26,7 @@ extern "C"
 {
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(__malloc_end_pointer)(void* ptr)
   {
-    return Alloc::external_pointer<OnePastEnd>(ptr);
+    return ThreadAlloc::get_noncachable()->external_pointer<OnePastEnd>(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(malloc)(size_t size)
@@ -82,7 +82,7 @@ extern "C"
 #ifndef NDEBUG
     // This check is redundant, because the check in memcpy will fail if this
     // is skipped, but it's useful for debugging.
-    if (Alloc::external_pointer<Start>(ptr) != ptr)
+    if (ThreadAlloc::get_noncachable()->external_pointer<Start>(ptr) != ptr)
     {
       error(
         "Calling realloc on pointer that is not to the start of an allocation");
@@ -96,7 +96,8 @@ extern "C"
     void* p = SNMALLOC_NAME_MANGLE(malloc)(size);
     if (p != nullptr)
     {
-      SNMALLOC_ASSERT(p == Alloc::external_pointer<Start>(p));
+      SNMALLOC_ASSERT(
+        p == ThreadAlloc::get_noncachable()->external_pointer<Start>(p));
       sz = bits::min(size, sz);
       memcpy(p, ptr, sz);
       SNMALLOC_NAME_MANGLE(free)(ptr);

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -60,7 +60,7 @@ extern "C"
   size_t SNMALLOC_NAME_MANGLE(malloc_usable_size)(
     MALLOC_USABLE_SIZE_QUALIFIER void* ptr)
   {
-    return Alloc::alloc_size(ptr);
+    return ThreadAlloc::get_noncachable()->alloc_size(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(realloc)(void* ptr, size_t size)
@@ -88,7 +88,7 @@ extern "C"
         "Calling realloc on pointer that is not to the start of an allocation");
     }
 #endif
-    size_t sz = Alloc::alloc_size(ptr);
+    size_t sz = SNMALLOC_NAME_MANGLE(malloc_usable_size)(ptr);
     // Keep the current allocation if the given size is in the same sizeclass.
     if (sz == round_size(size))
       return ptr;

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -174,8 +174,8 @@ void test_external_pointer()
     for (size_t offset = 0; offset < size; offset += 17)
     {
       void* p2 = pointer_offset(p1, offset);
-      void* p3 = Alloc::external_pointer(p2);
-      void* p4 = Alloc::external_pointer<End>(p2);
+      void* p3 = alloc->external_pointer(p2);
+      void* p4 = alloc->external_pointer<End>(p2);
       UNUSED(p3);
       UNUSED(p4);
       SNMALLOC_ASSERT(p1 == p3);
@@ -188,21 +188,21 @@ void test_external_pointer()
   current_alloc_pool()->debug_check_empty();
 };
 
-void check_offset(void* base, void* interior)
+void check_offset(Alloc* alloc, void* base, void* interior)
 {
-  void* calced_base = Alloc::external_pointer((void*)interior);
+  void* calced_base = alloc->external_pointer((void*)interior);
   if (calced_base != (void*)base)
     abort();
 }
 
-void check_external_pointer_large(size_t* base)
+void check_external_pointer_large(Alloc* alloc, size_t* base)
 {
   size_t size = *base;
   char* curr = (char*)base;
   for (size_t offset = 0; offset < size; offset += 1 << 24)
   {
-    check_offset(base, (void*)(curr + offset));
-    check_offset(base, (void*)(curr + offset + (1 << 24) - 1));
+    check_offset(alloc, base, (void*)(curr + offset));
+    check_offset(alloc, base, (void*)(curr + offset + (1 << 24) - 1));
   }
 }
 
@@ -230,14 +230,14 @@ void test_external_pointer_large()
     // Store allocators size for this object
     *objects[i] = alloc->alloc_size(objects[i]);
 
-    check_external_pointer_large(objects[i]);
+    check_external_pointer_large(alloc, objects[i]);
     if (i > 0)
-      check_external_pointer_large(objects[i - 1]);
+      check_external_pointer_large(alloc, objects[i - 1]);
   }
 
   for (size_t i = 0; i < count; i++)
   {
-    check_external_pointer_large(objects[i]);
+    check_external_pointer_large(alloc, objects[i]);
   }
 
   std::cout << "Total size allocated in test_external_pointer_large: "
@@ -268,7 +268,7 @@ void test_external_pointer_dealloc_bug()
 
   for (size_t i = 0; i < count; i++)
   {
-    Alloc::external_pointer(allocs[i]);
+    alloc->external_pointer(allocs[i]);
   }
 
   alloc->dealloc(allocs[0]);
@@ -281,7 +281,7 @@ void test_alloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc(size);
-  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -292,7 +292,7 @@ void test_calloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -306,7 +306,7 @@ void test_calloc_large_bug()
   const size_t size = (SUPERSLAB_SIZE << 3) - 7;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -228,7 +228,7 @@ void test_external_pointer_large()
     // store object
     objects[i] = (size_t*)alloc->alloc(size);
     // Store allocators size for this object
-    *objects[i] = Alloc::alloc_size(objects[i]);
+    *objects[i] = alloc->alloc_size(objects[i]);
 
     check_external_pointer_large(objects[i]);
     if (i > 0)
@@ -281,7 +281,7 @@ void test_alloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc(size);
-  SNMALLOC_ASSERT(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -292,7 +292,7 @@ void test_calloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_ASSERT(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -306,7 +306,7 @@ void test_calloc_large_bug()
   const size_t size = (SUPERSLAB_SIZE << 3) - 7;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_ASSERT(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_ASSERT(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -73,7 +73,7 @@ namespace test
         size_t size = *external_ptr;
         size_t offset = (size >> 4) * (rand & 15);
         void* interior_ptr = pointer_offset(external_ptr, offset);
-        void* calced_external = Alloc::external_pointer(interior_ptr);
+        void* calced_external = alloc->external_pointer(interior_ptr);
         if (calced_external != external_ptr)
           abort();
       }

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -33,7 +33,7 @@ namespace test
       // store object
       objects[i] = (size_t*)alloc->alloc(size);
       // Store allocators size for this object
-      *objects[i] = Alloc::alloc_size(objects[i]);
+      *objects[i] = alloc->alloc_size(objects[i]);
     }
   }
 


### PR DESCRIPTION
<s>This builds atop #191 and #185; sorry, it's hard to have commutative patches. :(</s>

I would appreciate feedback about the AAL function `apply_bounds` and the use of the `ReturnPtr` type alias to ensure that the internal allocation functions have `apply_bounds` at their leaf returns.

<s>This is, of course, only half the story, and the easy half at that.  The `dealloc` functions must re-derive the internal pointers once the PAL is doing anything other than passing through `apply_bounds`.</s>