### PR TITLE
OpenEnclave PAL: Store enclave heap base/end in inline variables.

### DIFF
--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -10,18 +10,6 @@
 #endif
 #define assert please_use_SNMALLOC_ASSERT
 
-void* oe_base;
-void* oe_end;
-extern "C" const void* __oe_get_heap_base()
-{
-  return oe_base;
-}
-
-extern "C" const void* __oe_get_heap_end()
-{
-  return oe_end;
-}
-
 extern "C" void* oe_memset_s(void* p, size_t p_size, int c, size_t size)
 {
   UNUSED(p_size);
@@ -43,8 +31,9 @@ int main()
   // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
   size_t large_class = 28 - SUPERSLAB_BITS;
   size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
-  oe_base = mp.reserve<true>(large_class);
-  oe_end = (uint8_t*)oe_base + size;
+  void* oe_base = mp.reserve<true>(large_class);
+  void* oe_end = (uint8_t*)oe_base + size;
+  PALOpenEnclave::setup_initial_range(oe_base, oe_end);
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   auto a = ThreadAlloc::get();

--- a/src/test/func/two_alloc_types/alloc1.cc
+++ b/src/test/func/two_alloc_types/alloc1.cc
@@ -9,3 +9,8 @@
 // Redefine the namespace, so we can have two versions.
 #define snmalloc snmalloc_enclave
 #include "../../../override/malloc.cc"
+
+extern "C" void oe_allocator_init(void* base, void* end)
+{
+  snmalloc_enclave::PALOpenEnclave::setup_initial_range(base, end);
+}

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -5,18 +5,6 @@
 #include <string.h>
 #include <test/setup.h>
 
-void* oe_base;
-void* oe_end;
-extern "C" const void* __oe_get_heap_base()
-{
-  return oe_base;
-}
-
-extern "C" const void* __oe_get_heap_end()
-{
-  return oe_end;
-}
-
 extern "C" void* oe_memset_s(void* p, size_t p_size, int c, size_t size)
 {
   UNUSED(p_size);
@@ -28,6 +16,7 @@ extern "C" void oe_abort()
   abort();
 }
 
+extern "C" void oe_allocator_init(void* base, void* end);
 extern "C" void* host_malloc(size_t);
 extern "C" void host_free(void*);
 
@@ -51,8 +40,9 @@ int main()
   // For 1MiB superslabs, SUPERSLAB_BITS + 2 is not big enough for the example.
   size_t large_class = 26 - SUPERSLAB_BITS;
   size_t size = 1ULL << (SUPERSLAB_BITS + large_class);
-  oe_base = mp.reserve<true>(large_class);
-  oe_end = (uint8_t*)oe_base + size;
+  void* oe_base = mp.reserve<true>(large_class);
+  void* oe_end = (uint8_t*)oe_base + size;
+  oe_allocator_init(oe_base, oe_end);
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.


### PR DESCRIPTION
PALOpenEnclave object is lazily constructed. I couldn't
figure out a straight-forward way to pass the heap bounds to
the constructor of PALOpenEnclave object.
As an alternative, store the bounds in class-static members of a template
class.

- two_alloc_types/main.cc
  OE use of snmalloc is renamed to snmalloc_enclave.
  Declare oe_base and oe_end inline variables in snmalloc_enclave
  namespace and initialize them.

- fixed_region/fixed_region.cc
  Initialize oe_base and oe_end variables.
  Cache the starting value of oe_base in orig_oe_base and
  use that for asserting that the allocated memory lies
  within the PAL heap. This is because, in pal_open_enclave.h,
  reserve will change the value of oe_base.

CC: @achamayou 
Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>