### PR TITLE
Fix includes for the OE Pal.

### DIFF
--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -3,6 +3,9 @@
 #include "pal_consts.h"
 
 // If simultating OE, then we need the underlying platform
+#if defined(OPEN_ENCLAVE)
+#  include "pal_open_enclave.h"
+#endif
 #if !defined(OPEN_ENCLAVE) || defined(OPEN_ENCLAVE_SIMULATION)
 #  include "pal_apple.h"
 #  include "pal_freebsd.h"
@@ -11,9 +14,6 @@
 #  include "pal_netbsd.h"
 #  include "pal_openbsd.h"
 #  include "pal_windows.h"
-#endif
-#if defined(OPEN_ENCLAVE)
-#  include "pal_open_enclave.h"
 #endif
 #include "pal_plain.h"
 

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ds/address.h"
 #include "pal_plain.h"
 #ifdef OPEN_ENCLAVE
 extern "C" const void* __oe_get_heap_base();


### PR DESCRIPTION
The Pal should include address.h, this was masked as other Pals included
it, but are only included for simulating OE scenarios, rather than
the actual build for OE.