### PR TITLE
Reduce code duplication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ The [Windows](src/pal/pal_windows.h), and
 [FreeBSD kernel](src/pal/pal_freebsd_kernel.h) implementations give examples of
 non-POSIX environments that snmalloc supports.
 
+The POSIX PAL uses `mmap` to map memory.
+Some POSIX or POSIX-like systems require minor tweaks to this behaviour.
+Rather than requiring these to copy and paste the code, a PAL that inherits from the POSIX PAL can define one or both of these (`static constexpr`) fields to customise the `mmap` behaviour.
+
+ - `default_mmap_flags` allows a PAL to provide additional `MAP_*`
+    flags to all `mmap` calls.
+ - `anonymous_memory_fd` allows the PAL to override the default file
+   descriptor used for memory mappings.
+
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -25,70 +25,16 @@ namespace snmalloc
     static constexpr uint64_t pal_features = PALBSD::pal_features;
 
     /**
-     *  OS specific function for zeroing memory with the Apple application
-     *  tag id.
-     *
-     *  See comment below.
-     */
-    template<bool page_aligned = false>
-    void zero(void* p, size_t size)
-    {
-      if (page_aligned || is_aligned_block<page_size>(p, size))
-      {
-        SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
-        void* r = mmap(
-          p,
-          size,
-          PROT_READ | PROT_WRITE,
-          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
-          pal_anon_id,
-          0);
-
-        if (r != MAP_FAILED)
-          return;
-      }
-
-      bzero(p, size);
-    }
-
-    /**
-     * Reserve memory with the Apple application tag id.
-     *
-     * See comment below.
-     */
-    std::pair<void*, size_t> reserve_at_least(size_t size)
-    {
-      // Magic number for over-allocating chosen by the Pal
-      // These should be further refined based on experiments.
-      constexpr size_t min_size =
-        bits::is64() ? bits::one_at_bit(32) : bits::one_at_bit(28);
-      auto size_request = bits::max(size, min_size);
-
-      void* p = mmap(
-        nullptr,
-        size_request,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS,
-        pal_anon_id,
-        0);
-
-      if (p == MAP_FAILED)
-        error("Out of memory");
-
-      return {p, size_request};
-    }
-
-  private:
-    /**
-     * Anonymous page tag ID
+     * Anonymous page tag ID.
      *
      * Darwin platform allows to gives an ID to anonymous pages via
      * the VM_MAKE_TAG's macro, from 240 up to 255 are guaranteed
      * to be free of usage, however eventually a lower could be taken
      * (e.g. LLVM sanitizers has 99) so we can monitor their states
-     * via vmmap for instance.
+     * via vmmap for instance. This value is provided to `mmap` as the file
+     * descriptor for the mapping.
      */
-    static constexpr int pal_anon_id = VM_MAKE_TAG(PALAnonID);
+    static constexpr int anonymous_memory_fd = VM_MAKE_TAG(PALAnonID);
   };
 } // namespace snmalloc
 #endif

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -54,7 +54,7 @@ namespace snmalloc
     template<typename T>
     struct DefaultMMAPFlags<T, decltype((void)T::default_mmap_flags, 0)>
     {
-      static const int fd = T::default_mmap_flags;
+      static const int flags = T::default_mmap_flags;
     };
 
     /**

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -77,7 +77,7 @@ namespace snmalloc
      * anonymous memory. This exposes the `anonymous_memory_fd` field in `OS`.
      */
     template<typename T>
-    struct AnonFD<T, decltype((void)T::default_mmap_flags, 0)>
+    struct AnonFD<T, decltype((void)T::anonymous_memory_fd, 0)>
     {
       /**
        * The PAL's provided file descriptor for anonymous memory.  This is


### PR DESCRIPTION
The Apple and Haiku PALs both had *almost* identical code to the POSIX
PAL, differing only in some small argument variables.  This is fragile
and easy to accidentally get out of sync.  For example, the changes to
`reserve_at_least` involved copying identical code into multiple PALs
and it's easy to accidentally miss one.

This change introduces two optional fields on POSIX-derived PALs:

 - `default_mmap_flags` allows a PAL to provide additional `MAP_*`
   flags to all `mmap` calls.
 - `anonymous_memory_fd` allows the PAL to override the default file
   descriptor used for memory mappings.

If a PAL does not provide these, default values are used.