### PR TITLE
Illumos systems/Solaris support.

### DIFF
--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -14,6 +14,7 @@
 #  include "pal_linux.h"
 #  include "pal_netbsd.h"
 #  include "pal_openbsd.h"
+#  include "pal_solaris.h"
 #  include "pal_windows.h"
 #endif
 #include "pal_plain.h"
@@ -38,6 +39,8 @@ namespace snmalloc
     PALNetBSD;
 #  elif defined(__OpenBSD__)
     PALOpenBSD;
+#  elif defined(__sun)
+    PALSolaris;
 #  else
 #    error Unsupported platform
 #  endif

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <utility>

--- a/src/pal/pal_solaris.h
+++ b/src/pal/pal_solaris.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#if defined(__sun)
+#  include "pal_posix.h"
+
+namespace snmalloc
+{
+  /**
+   * Platform abstraction layer for Solaris.  This provides features for this
+   * system.
+   */
+  class PALSolaris : public PALPOSIX<PALSolaris>
+  {
+  public:
+    /**
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
+     *
+     */
+    static constexpr uint64_t pal_features = PALPOSIX::pal_features;
+
+    /**
+     * Solaris requires an explicit no-reserve flag in `mmap` to guarantee lazy
+     * commit.
+     */
+    static constexpr int default_mmap_flags = MAP_NORESERVE;
+  };
+} // namespace snmalloc
+#endif


### PR DESCRIPTION
MAP_NORESERVE flag usage for memory over commit permitted only
 in the mmap context.