### PR TITLE
FlatPagemap: Stop allocating way more space than needed

### DIFF
--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -326,9 +326,7 @@ namespace snmalloc
   private:
     static constexpr size_t COVERED_BITS =
       bits::ADDRESS_BITS - GRANULARITY_BITS;
-    static constexpr size_t CONTENT_BITS =
-      bits::next_pow2_bits_const(sizeof(T));
-    static constexpr size_t ENTRIES = 1ULL << (COVERED_BITS + CONTENT_BITS);
+    static constexpr size_t ENTRIES = 1ULL << COVERED_BITS;
     static constexpr size_t SHIFT = GRANULARITY_BITS;
 
     std::atomic<T> top[ENTRIES];


### PR DESCRIPTION
FlatPagemap computes the size of its internal `top` array as if it needed an
entry per byte, rather than an entry per instance of its template type T.  In
practice. T has always been uint8_t so far, so this hasn't mattered, but when
we use a larger type, suddenly FlatPagemap balloons to much larger than needed.