### PR TITLE
WIP: Foreign frees

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -385,12 +385,13 @@ namespace snmalloc
 
 #  ifdef CHECK_CLIENT
       Superslab* super = Superslab::get(p);
-      if (size > 64 || address_cast(super) != address_cast(p))
+      if (size > CMLargeMax || address_cast(super) != address_cast(p))
       {
         error("Not deallocating start of an object");
       }
 #  endif
       large_dealloc(p, 1ULL << size);
+
 #endif
     }
 
@@ -426,11 +427,13 @@ namespace snmalloc
 
       auto ss = super;
 
-      while (size > 64)
+      while (size >= CMLargeRangeMin)
       {
         // This is a large alloc redirect.
         ss = pointer_offset_signed(
-          ss, -(static_cast<ptrdiff_t>(1) << (size - 64)));
+          ss,
+          -(static_cast<ptrdiff_t>(1)
+            << (size - CMLargeRangeMin + SUPERSLAB_BITS)));
         size = ChunkMap::get(ss);
       }
 

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -137,4 +137,11 @@ namespace snmalloc
     "SLAB_COUNT must be a power of 2");
   static_assert(
     SLAB_COUNT <= (UINT8_MAX + 1), "SLAB_COUNT must fit in a uint8_t");
+
+  /*
+   * Granularity of potential pointers to closures for pointer-sized
+   * out-of-band metadata map.
+   */
+  static constexpr size_t OOBMAP_BITS = 24;
+
 } // namespace snmalloc

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -14,7 +14,7 @@ namespace snmalloc
   {
     CMNotOurs = 0,
     CMSuperslab = 1,
-    CMMediumslab = 2
+    CMMediumslab = 2,
 
     /*
      * Values 3 (inclusive) through SUPERSLAB_BITS (exclusive) are as yet
@@ -23,14 +23,26 @@ namespace snmalloc
      * Values SUPERSLAB_BITS (inclusive) through 64 (exclusive, as it would
      * represent the entire address space) are used for log2(size) at the
      * heads of large allocations.  See SuperslabMap::set_large_size.
-     *
-     * Values 64 (inclusive) through 128 (exclusive) are used for entries
-     * within a large allocation.  A value of x at pagemap entry p indicates
-     * that there are at least 2^(x-64) (inclusive) and at most 2^(x+1-64)
-     * (exclusive) page map entries between p and the start of the
-     * allocation.  See SuperslabMap::set_large_size and external_address's
+     */
+    CMLargeMin = SUPERSLAB_BITS,
+    CMLargeMax = 63,
+
+    /*
+     * Values 64 (inclusive) through 64 + SUPERSLAB_BITS (exclusive) are unused
+     */
+
+    /*
+     * Values 64 + SUPERSLAB_BITS (inclusive) through 128 (exclusive) are used
+     * for entries within a large allocation.  A value of x at pagemap entry p
+     * indicates that there are at least 2^(x-64) (inclusive) and at most
+     * 2^(x+1-64) (exclusive) page map entries between p and the start of the
+     * allocation.  See ChunkMap::set_large_size and external_address's
      * handling of large reallocation redirections.
-     *
+     */
+    CMLargeRangeMin = 64 + SUPERSLAB_BITS,
+    CMLargeRangeMax = 127,
+
+    /*
      * Values 128 (inclusive) through 255 (inclusive) are as yet unused.
      */
 
@@ -47,12 +59,12 @@ namespace snmalloc
 // Use flat map is under a single node.
 #  define SNMALLOC_MAX_FLATPAGEMAP_SIZE PAGEMAP_NODE_SIZE
 #endif
-  static constexpr bool USE_FLATPAGEMAP = pal_supports<LazyCommit> ||
+  static constexpr bool CHUNKMAP_USE_FLATPAGEMAP = pal_supports<LazyCommit> ||
     (SNMALLOC_MAX_FLATPAGEMAP_SIZE >=
      sizeof(FlatPagemap<SUPERSLAB_BITS, uint8_t>));
 
   using ChunkmapPagemap = std::conditional_t<
-    USE_FLATPAGEMAP,
+    CHUNKMAP_USE_FLATPAGEMAP,
     FlatPagemap<SUPERSLAB_BITS, uint8_t>,
     Pagemap<SUPERSLAB_BITS, uint8_t, 0>>;
 
@@ -208,7 +220,7 @@ namespace snmalloc
       {
         size_t run = 1ULL << i;
         PagemapProvider::pagemap().set_range(
-          ss, static_cast<uint8_t>(64 + i + SUPERSLAB_BITS), run);
+          ss, static_cast<uint8_t>(CMLargeRangeMin + i), run);
         ss = ss + SUPERSLAB_SIZE * run;
       }
     }

--- a/src/mem/foreignalloc.h
+++ b/src/mem/foreignalloc.h
@@ -1,0 +1,24 @@
+#pragma once
+
+extern "C"
+{
+  /**
+   * A closure telling us how to free back to a foreign allocator.
+   *
+   * Any security-domain crossing will be encapsulated inside `->free()` here.
+   *
+   * Because our OOBMap is quite coarse-grained (to make up for the fact that
+   * it's storing pointers) relative to the ChunkMap, the `->free()` function
+   * here could internally dispatch on the address to route to one of many
+   * sandboxes within the OOBMap granule, assuming that more than one fit.  If
+   * this becomes common, we should adjust the interface here to either fix the
+   * type of `arg` or expose another function pointer to associate at a finer
+   * scale.
+   */
+
+  struct ForeignAllocator
+  {
+    void (*free)(void* arg, void* p);
+    void* arg;
+  };
+}

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -182,6 +182,7 @@ namespace snmalloc
     init_thread_allocator,
     GlobalVirtual,
     SNMALLOC_DEFAULT_CHUNKMAP,
+    SNMALLOC_DEFAULT_OOBMAP,
     true>;
 
   inline AllocPool<GlobalVirtual, Alloc>*& current_alloc_pool()

--- a/src/mem/oobmap.h
+++ b/src/mem/oobmap.h
@@ -1,0 +1,93 @@
+#pragma once
+
+namespace snmalloc
+{
+  /*
+   * Like the ChunkMap, the OOBMap might be flat or might be paged.
+   *
+   * Unlike the ChunkMap, which stored a byte per granule, the OOBMap
+   * stores a pointer per granule (which are generally larger than the
+   * PageMap's).
+   */
+
+  static constexpr bool OOBMAP_USE_FLATPAGEMAP = pal_supports<LazyCommit> ||
+    (SNMALLOC_MAX_FLATPAGEMAP_SIZE >=
+     sizeof(FlatPagemap<OOBMAP_BITS, uintptr_t>));
+
+  using OOBMapPagemap = std::conditional_t<
+    OOBMAP_USE_FLATPAGEMAP,
+    FlatPagemap<OOBMAP_BITS, uintptr_t>,
+    Pagemap<OOBMAP_BITS, uintptr_t, 0>>;
+
+  static const size_t OOBMAP_SIZE = 1ULL << OOBMAP_BITS;
+
+  /*
+   * See GlobalPagemapTemplate.
+   */
+  template<typename T>
+  class GlobalOOBMapTemplate
+  {
+    inline static T global_oobmap;
+
+  public:
+    static OOBMapPagemap& pagemap()
+    {
+      return global_oobmap;
+    }
+  };
+
+  using GlobalOOBMap = GlobalOOBMapTemplate<OOBMapPagemap>;
+
+  /*
+   * TODO: We probably also want to duplicate the `ExternalGlobalPagemap`
+   * machinery for the `OOBMap`, too.
+   */
+
+  template<typename OOBMapProvider = GlobalOOBMap>
+  struct DefaultOOBMap
+  {
+    /// Get the metadata for a given address.
+    static void* get(address_t p)
+    {
+      return reinterpret_cast<void*>(OOBMapProvider::pagemap().get(p));
+    }
+
+    static void* get(void* p)
+    {
+      return get(address_cast(p));
+    }
+
+    /// Set the metadata for a given address
+    static void set_oob(address_t p, void* f)
+    {
+      OOBMapProvider::pagemap().set(p, reinterpret_cast<uintptr_t>(f));
+    }
+
+    static void set_oob(void* p, void* f)
+    {
+      set_oob(address_cast(p), f);
+    }
+
+    /// Set the metadata for a range of addresses
+    static void set_oob_range(void* p, size_t size, void* f)
+    {
+      auto pc = address_cast(p);
+      auto fc = reinterpret_cast<uintptr_t>(f);
+
+      size_t size_bits = bits::next_pow2_bits(size);
+      OOBMapProvider::pagemap().set(pc, fc);
+      auto ps = pc + OOBMAP_SIZE;
+      for (size_t i = 0; i < size_bits - OOBMAP_BITS; i++)
+      {
+        size_t run = 1ULL << i;
+        OOBMapProvider::pagemap().set_range(ps, fc, run);
+        ps += OOBMAP_SIZE * run;
+      }
+    }
+  };
+
+#ifndef SNMALLOC_DEFAULT_OOBMAP
+#  define SNMALLOC_DEFAULT_OOBMAP snmalloc::DefaultOOBMap<>
+#endif
+
+} // namespace snmalloc

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -326,9 +326,7 @@ namespace snmalloc
   private:
     static constexpr size_t COVERED_BITS =
       bits::ADDRESS_BITS - GRANULARITY_BITS;
-    static constexpr size_t CONTENT_BITS =
-      bits::next_pow2_bits_const(sizeof(T));
-    static constexpr size_t ENTRIES = 1ULL << (COVERED_BITS + CONTENT_BITS);
+    static constexpr size_t ENTRIES = 1ULL << COVERED_BITS;
     static constexpr size_t SHIFT = GRANULARITY_BITS;
 
     std::atomic<T> top[ENTRIES];

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -256,4 +256,11 @@ extern "C"
     get_slow_allocator()->dealloc(ptr);
   }
 #endif
+
+  SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(snmalloc_designate_foreign)(
+    void* p, size_t size, struct ForeignAllocator* fa)
+  {
+    SNMALLOC_DEFAULT_CHUNKMAP::set_foreign_range(p, size);
+    SNMALLOC_DEFAULT_OOBMAP::set_oob_range(p, size, fa);
+  }
 }

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -382,7 +382,7 @@ int main(int argc, char** argv)
   setup();
 #ifdef TEST_LIMITED
   size_t count = 0;
-  test_limited(512 * MiB, count);
+  test_limited(656 * MiB, count);
   test_limited(2 * GiB, count);
   test_limited(
     8 *

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -23,10 +23,22 @@ extern "C" void host_free(void*);
 extern "C" void* enclave_malloc(size_t);
 extern "C" void enclave_free(void*);
 
+void host_to_enclave_free(void* arg, void* p)
+{
+  // No security domain transition, but hand off to enclave allocator
+  UNUSED(arg);
+
+  std::cout << "HTEF " << p << std::endl;
+
+  enclave_free(p);
+}
+
 extern "C" void*
 enclave_snmalloc_pagemap_global_get(snmalloc::PagemapConfig const**);
 extern "C" void*
 host_snmalloc_pagemap_global_get(snmalloc::PagemapConfig const**);
+extern "C" void*
+host_snmalloc_designate_foreign(void*, size_t, struct ForeignAllocator*);
 
 using namespace snmalloc;
 int main()
@@ -46,6 +58,10 @@ int main()
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;
 
   // Call these functions to trigger asserts if the cast-to-self doesn't work.
+  //
+  // Note that these check *type* compatibility but do not actually unify the
+  // two Pagemaps: that is, the enclave and host allocators continue to have
+  // separate pagemaps.
   const PagemapConfig* c;
   enclave_snmalloc_pagemap_global_get(&c);
   host_snmalloc_pagemap_global_get(&c);
@@ -58,4 +74,17 @@ int main()
 
   host_free(a);
   enclave_free(b);
+
+  /*
+   * Designate the OE space as a foreign allocator in the host allocator's maps
+   */
+  struct ForeignAllocator* fa_enclave =
+    static_cast<ForeignAllocator*>(host_malloc(sizeof fa_enclave));
+  fa_enclave->arg = NULL;
+  fa_enclave->free = host_to_enclave_free;
+
+  host_snmalloc_designate_foreign(oe_base, size, fa_enclave);
+
+  auto x = enclave_malloc(128);
+  host_free(x);
 }


### PR DESCRIPTION
A sketch of one possible route towards allowing `snmalloc`'s `free` to trampoline out to another allocator and possibly even across security domains.

This introduces another, separate `Pagemap` structure, the `OOBMap`, which stores a `uintptr_t` per granule, which is taken to be 16M right now.  It's not clear whether this should scale with chunk size or be completely independent.

This is a WIP; there are some scattered TODOs in the code at the moment, as this is just intended to be a sketch for design review.  The "interface", `snmalloc_designate_foreign`, is almost surely not the desired API, and so I am more than open to suggestions!

The `OOBMap` should be useful as a different substrate for #198 as per #231, but there is the concern that CHERI will require that we access both maps in many cases, whereas this PR results in code that accesses the `OOBMap` only on the slow path.  Some restructuring may be in order when we seek to merge both, but that can happen over there.