### PR TITLE
Linux/musl test: build fix proposal.

### DIFF
--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -13,8 +13,8 @@
  */
 #  include <sys/resource.h>
 #  include <sys/sysinfo.h>
+#  include <sys/wait.h>
 #  include <unistd.h>
-#  include <wait.h>
 #  define TEST_LIMITED
 #  define KiB (1024ull)
 #  define MiB (KiB * KiB)


### PR DESCRIPTION
Build complain about wrong header inclusion, sys/wait.h ough to be
 instead.