### PR TITLE
DragonFly support (userland).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,10 +282,11 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     foreach(TEST ${TESTS})
       if (WIN32
           OR (CMAKE_SYSTEM_NAME STREQUAL NetBSD)
-          OR (CMAKE_SYSTEM_NAME STREQUAL OpenBSD))
+          OR (CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+          OR (CMAKE_SYSTEM_NAME STREQUAL DragonFly))
         # Windows does not support aligned allocation well enough
         # for pass through.
-        # NetBSD and OpenBSD do not support malloc*size calls.
+        # NetBSD, OpenBSD and DragonFlyBSD do not support malloc*size calls.
         set(FLAVOURS 1;16;oe)
       else()
         set(FLAVOURS 1;16;oe;malloc)

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -10,6 +10,7 @@
 #endif
 #if !defined(OPEN_ENCLAVE) || defined(OPEN_ENCLAVE_SIMULATION)
 #  include "pal_apple.h"
+#  include "pal_dragonfly.h"
 #  include "pal_freebsd.h"
 #  include "pal_freebsd_kernel.h"
 #  include "pal_haiku.h"
@@ -43,6 +44,8 @@ namespace snmalloc
     PALOpenBSD;
 #  elif defined(__sun)
     PALSolaris;
+#  elif defined(__DragonFly__)
+    PALDragonfly;
 #  else
 #    error Unsupported platform
 #  endif

--- a/src/pal/pal_dragonfly.h
+++ b/src/pal/pal_dragonfly.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#if defined(__DragonFly__) && !defined(_KERNEL)
+#  include "pal_bsd.h"
+
+namespace snmalloc
+{
+  /**
+   * DragonflyBSD-specific platform abstraction layer.
+   *
+   * This adds DragonFlyBSD-specific aligned allocation to the BSD
+   * implementation.
+   */
+  class PALDragonfly : public PALBSD<PALDragonfly>
+  {
+  public:
+    /**
+     * Bitmap of PalFeatures flags indicating the optional features that this
+     * PAL supports.
+     *
+     * The DragonflyBSD PAL does not currently add any features beyond
+     * of those of the BSD Pal.
+     * Like FreeBSD, MAP_NORESERVE is implicit.
+     * This field is declared explicitly to remind anyone modifying this class
+     * to add new features that they should add any required feature flags.
+     */
+    static constexpr uint64_t pal_features = PALPOSIX::pal_features;
+  };
+} // namespace snmalloc
+#endif


### PR DESCRIPTION
- Close to OpenBSD as there is no malloc*size api nor arbritrary
 alignment support.
- Like FreeBSD, MAP_NORESERVE never had been implemented even tough
 still present in the header but not mentioned in the man page,
FreeBSD has reserved the value for another later usage seems
 DragonFly has just out of sync header.