### PR TITLE
Fix typo in macro definition for 16MiB shared library shim (#253).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     add_shim(snmallocshim SHARED ${SHARED_FILES})
     add_shim(snmallocshim-1mib SHARED ${SHARED_FILES})
     add_shim(snmallocshim-16mib SHARED ${SHARED_FILES})
-    target_compile_definitions(snmallocshim-16mib PRIVATE SNMALOC_USE_LARGE_CHUNKS)
+    target_compile_definitions(snmallocshim-16mib PRIVATE SNMALLOC_USE_LARGE_CHUNKS)
     # Build a shim with some settings from oe.
     add_shim(snmallocshim-oe SHARED ${SHARED_FILES})
     oe_simulate(snmallocshim-oe)


### PR DESCRIPTION
This has been present since 4e1f5829a754ab9c170ec090979d3a670d2d5d1a and resulted in the 16MiB shared library shim using the default 1MiB chunk size.