### PR TITLE
OpenBSD build fix proposal.

### DIFF
--- a/src/pal/pal_openbsd.h
+++ b/src/pal/pal_openbsd.h
@@ -22,6 +22,21 @@ namespace snmalloc
      * should add any required features.
      */
     static constexpr uint64_t pal_features = PALBSD::pal_features;
+
+    /**
+     *
+     * On OpenBSD, pages seem not discarded in due time
+     * despite normally MADV_FREE is normally fast enough
+     * in other platforms, thus some unit tests are failing.
+     *
+     * Notifying by discarding access instead.
+     */
+
+    void notify_not_using(void* p, size_t size) noexcept
+    {
+      SNMALLOC_ASSERT(is_aligned_block<OS_PAGE_SIZE>(p, size));
+      mprotect(p, size, PROT_NONE);
+    }
   };
 } // namespace snmalloc
 #endif

--- a/src/pal/pal_openbsd.h
+++ b/src/pal/pal_openbsd.h
@@ -32,10 +32,17 @@ namespace snmalloc
      * Notifying by discarding access instead.
      */
 
-    void notify_not_using(void* p, size_t size) noexcept
+    static void notify_not_using(void* p, size_t size) noexcept
     {
-      SNMALLOC_ASSERT(is_aligned_block<OS_PAGE_SIZE>(p, size));
+      SNMALLOC_ASSERT(is_aligned_block<PALOpenBSD::page_size>(p, size));
       mprotect(p, size, PROT_NONE);
+    }
+
+    template<ZeroMem zero_mem>
+    static void notify_using(void* p, size_t size)
+    {
+      SNMALLOC_ASSERT(is_aligned_block<PALOpenBSD::page_size>(p, size));
+      mprotect(p, size, PROT_READ | PROT_WRITE);
     }
   };
 } // namespace snmalloc


### PR DESCRIPTION
Seems on this system pages are not discarded in due time
thus some of unit tests are failing, leading to memory corruption.
Marking those pages not accessible instead and test pass now.