### PR TITLE
Superslab bug fix

### DIFF
--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -81,7 +81,10 @@ namespace snmalloc
     {
       allocator = alloc;
 
-      if (kind != Super)
+      // If Superslab is larger than a page, then we cannot guarantee it still
+      // has a valid layout as the subsequent pages could have been freed and
+      // zeroed, hence only skip initialisation if smaller.
+      if (kind != Super || (sizeof(Superslab) >= OS_PAGE_SIZE))
       {
         if (kind != Fresh)
         {

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -135,6 +135,9 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<OS::page_size>(p, size));
 #ifdef USE_POSIX_COMMIT_CHECKS
+      // Fill memory so that when we switch the pages back on we don't make
+      // assumptions on the content.
+      memset(p, 0x5a, size);
       mprotect(p, size, PROT_NONE);
 #else
       UNUSED(p);


### PR DESCRIPTION
Fixes the meta-data initialisation for the superslab in the 16MiB case.

This superseeds #258 as the problem is more general.