### PR TITLE
Sparc support proposal.

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -21,7 +21,6 @@
 
 #if defined(__powerpc__) || defined(__powerpc64__)
 #  define PLATFORM_IS_POWERPC
-#  define SNMALLOC_NO_AAL_BUILTINS
 #endif
 
 #if defined(__sparc__)

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -21,6 +21,11 @@
 
 #if defined(__powerpc__) || defined(__powerpc64__)
 #  define PLATFORM_IS_POWERPC
+#  define SNMALLOC_NO_AAL_BUILTINS
+#endif
+
+#if defined(__sparc__)
+#  define PLATFORM_IS_SPARC
 #endif
 
 namespace snmalloc
@@ -54,6 +59,7 @@ namespace snmalloc
     PowerPC,
     X86,
     X86_SGX,
+    Sparc,
   };
 
   /**
@@ -147,6 +153,8 @@ namespace snmalloc
 #  include "aal_arm.h"
 #elif defined(PLATFORM_IS_POWERPC)
 #  include "aal_powerpc.h"
+#elif defined(PLATFORM_IS_SPARC)
+#  include "aal_sparc.h"
 #endif
 
 namespace snmalloc

--- a/src/aal/aal_sparc.h
+++ b/src/aal/aal_sparc.h
@@ -17,7 +17,7 @@ namespace snmalloc
     /**
      * Bitmap of AalFeature flags
      */
-    static constexpr uint64_t aal_features = StrictProvenance;
+    static constexpr uint64_t aal_features = IntegerPointers;
 
     static constexpr enum AalName aal_name = Sparc;
 
@@ -30,8 +30,6 @@ namespace snmalloc
     static constexpr size_t smallest_page_size = 0x1000;
 #endif
 
-    using address_t = uintptr_t;
-
     /**
      * On Sparc ideally pause instructions ought to be
      * optimised per Sparc processor but here a version
@@ -40,7 +38,7 @@ namespace snmalloc
      */
     static inline void pause()
     {
-      __asm__ volatile("rd %ccr, %g0 \n\trd %ccr, %g0 \n\trd %ccr, %g0");
+      __asm__ volatile("rd %%ccr, %%g0" ::: "memory");
     }
 
     static inline void prefetch(void* ptr)
@@ -48,15 +46,14 @@ namespace snmalloc
 #ifdef SNMALLOC_VA_BITS_64
       __asm__ volatile("prefetch [%0], 0" ::"r"(ptr));
 #else
-      (void)ptr;
+      UNUSED(ptr);
 #endif
     }
 
     static inline uint64_t tick()
     {
       uint64_t tick;
-      __asm__ volatile(".byte 0x83, 0x41, 0x00, 0x00");
-      __asm__ volatile("mov %%g1, %0" : "=r"(tick));
+      __asm__ volatile("rd %%asr4, %0" : "=r"(tick));
       return tick;
     }
   };

--- a/src/aal/aal_sparc.h
+++ b/src/aal/aal_sparc.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#if defined(__arch64__) // More reliable than __sparc64__
+#  define SNMALLOC_VA_BITS_64
+#else
+#  define SNMALLOC_VA_BITS_32
+#endif
+
+namespace snmalloc
+{
+  /**
+   * Sparc architecture abstraction layer.
+   */
+  class AAL_Sparc
+  {
+  public:
+    /**
+     * Bitmap of AalFeature flags
+     */
+    static constexpr uint64_t aal_features = StrictProvenance;
+
+    static constexpr enum AalName aal_name = Sparc;
+
+#ifdef SNMALLOC_VA_BITS_64
+    /**
+     * Even Ultra-Sparc I supports 8192 and onwards
+     */
+    static constexpr size_t smallest_page_size = 0x2000;
+#else
+    static constexpr size_t smallest_page_size = 0x1000;
+#endif
+
+    using address_t = uintptr_t;
+
+    /**
+     * On Sparc ideally pause instructions ought to be
+     * optimised per Sparc processor but here a version
+     * as least common denominator to avoid numerous ifdef,
+     * reading Conditions Code Register here
+     */
+    static inline void pause()
+    {
+      __asm__ volatile("rd %ccr, %g0 \n\trd %ccr, %g0 \n\trd %ccr, %g0");
+    }
+
+    static inline void prefetch(void* ptr)
+    {
+#ifdef SNMALLOC_VA_BITS_64
+      __asm__ volatile("prefetch [%0], 0" ::"r"(ptr));
+#else
+      (void)ptr;
+#endif
+    }
+
+    static inline uint64_t tick()
+    {
+      uint64_t tick;
+      __asm__ volatile(".byte 0x83, 0x41, 0x00, 0x00");
+      __asm__ volatile("mov %%g1, %0" : "=r"(tick));
+      return tick;
+    }
+  };
+
+  using AAL_Arch = AAL_Sparc;
+} // namespace snmalloc

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -26,9 +26,7 @@ namespace snmalloc
     static constexpr uint64_t pal_features = PALPOSIX::pal_features;
 
     static constexpr size_t page_size =
-      (Aal::aal_name == PowerPC ?
-         0x10000 :
-         (Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000));
+      Aal::aal_name == PowerPC ? 0x10000 : PALPOSIX::page_size;
 
     /**
      * OS specific function for zeroing memory.

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -26,7 +26,7 @@ namespace snmalloc
     static constexpr uint64_t pal_features = PALPOSIX::pal_features;
 
     static constexpr size_t page_size =
-      Aal::aal_name == PowerPC ? 0x10000 : 0x1000;
+      (Aal::aal_name == PowerPC ? 0x10000 : (Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000));
 
     /**
      * OS specific function for zeroing memory.

--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -26,7 +26,9 @@ namespace snmalloc
     static constexpr uint64_t pal_features = PALPOSIX::pal_features;
 
     static constexpr size_t page_size =
-      (Aal::aal_name == PowerPC ? 0x10000 : (Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000));
+      (Aal::aal_name == PowerPC ?
+         0x10000 :
+         (Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000));
 
     /**
      * OS specific function for zeroing memory.

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -39,7 +39,8 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = 0;
 
-    static constexpr size_t page_size = 0x1000;
+    static constexpr size_t page_size =
+      Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000;
 
     [[noreturn]] static void error(const char* const str)
     {

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -39,8 +39,7 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = 0;
 
-    static constexpr size_t page_size =
-      Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000;
+    static constexpr size_t page_size = Aal::smallest_page_size;
 
     [[noreturn]] static void error(const char* const str)
     {

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -98,7 +98,7 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = LazyCommit;
 
-    static constexpr size_t page_size = 0x1000;
+    static constexpr size_t page_size = Aal::smallest_page_size;
 
     static void print_stack_trace()
     {

--- a/src/pal/pal_solaris.h
+++ b/src/pal/pal_solaris.h
@@ -19,8 +19,6 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = PALPOSIX::pal_features;
 
-    static constexpr size_t page_size =
-      Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000;
     /**
      * Solaris requires an explicit no-reserve flag in `mmap` to guarantee lazy
      * commit.

--- a/src/pal/pal_solaris.h
+++ b/src/pal/pal_solaris.h
@@ -19,6 +19,8 @@ namespace snmalloc
      */
     static constexpr uint64_t pal_features = PALPOSIX::pal_features;
 
+    static constexpr size_t page_size =
+      Aal::aal_name == Sparc ? Aal::smallest_page_size : 0x1000;
     /**
      * Solaris requires an explicit no-reserve flag in `mmap` to guarantee lazy
      * commit.


### PR DESCRIPTION
Also cmpxchg16gb support detection is based on the host but on
 a cross compile context it fails to apply properly.