### PR TITLE
CHERI prep: stave off amplification for Remote routing

### DIFF
--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -126,7 +126,7 @@ namespace snmalloc
           if (alloc->remote.capacity < REMOTE_CACHE)
           {
             alloc->stats().remote_post();
-            alloc->remote.post(alloc->id());
+            alloc->remote.post(alloc->get_trunc_id());
             done = false;
           }
 

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -11,6 +11,8 @@ namespace snmalloc
   //  using sizeclass_t = uint8_t;
   using sizeclass_compress_t = uint8_t;
 
+  constexpr static uintptr_t SIZECLASS_MASK = 0xFF;
+
   constexpr static uint16_t get_initial_offset(sizeclass_t sc, bool is_short);
   constexpr static size_t sizeclass_to_size(sizeclass_t sizeclass);
   constexpr static size_t


### PR DESCRIPTION
Smuggle the size class in Remote objects, so that we can leave Remote pointers bounded to their underlying allocation and yet forward a Remote message using only local state.  That is, we need to avoid going to the {Alloc,Super,Medium,Meta}slab headers unless we're consuming the Remote message back into our free lists.