### PR TITLE
CHERI prep plumbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ macro(clangformat_targets)
     file(GLOB_RECURSE ALL_SOURCE_FILES *.cc *.h *.hh)
     # clangformat does not yet understand concepts well; for the moment, don't
     # ask it to format them.  See https://reviews.llvm.org/D79773
-    list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "src/pal/pal_concept\.h$")
+    list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "src/[^/]*/[^/]*_concept\.h$")
     add_custom_target(
       clangformat
       COMMAND ${CLANG_FORMAT}

--- a/docs/StrictProvenance.md
+++ b/docs/StrictProvenance.md
@@ -1,0 +1,132 @@
+# StrictProvenance Architectures
+
+By "strict (pointer) provenance", we mean that architectural mechanisms exist to make it impossible to use a pointer returned from `alloc()`/`malloc()` to access outside the allocation without also having some other pointer that already authorized those outside accesses.
+CHERI is the canonical example we have in mind, but historically there have been other fat-pointer schemes with similar properties.
+
+Borrowing terminology from CHERI, we speak of the **authority** to a region of address space held by a pointer and will justify actions in terms of this authority.
+We may **bound** the authority of a pointer, deriving a new pointer with a subset of its progenitor's authority; this is assumed to be an ambient action requiring no additional authority.
+Dually, we may **amplify** a pointer, constructing a pointer to the same place as another but with increased authority.[^amplifier-state]
+
+[^amplifier-state] As we are largely following the fat pointer model and its evolution into CHERI capabilities, we achieve amplification through a *stateful*, *software* mechanism, rather than an architectural mechanism.
+Specifically, the amplification mechanism will retain a superset of any authority it may be asked to reconstruct.
+There have, in times past, been capability systems with architectural amplification (e.g., HYDRA's type-directed amplification), but we believe that future systems are unlikely to adopt this latter approach, necessitating the changes we propose below.
+
+## Interaction with Future Temporal Extensions
+
+We take the opportunity of refactoring to support `StrictProvenance` to envision `snmalloc`'s eventual, additional, interaction with memory coloring/versioning techniques such as Arm's MTE (in hybridization with CHERI).
+Using `StrictProvenance` vocabulary and restricting attention to our envisioned use case, these hybridized techniques allow the creation of pointers that can have all their authority asynchronously invalidated.[^mte-cache]
+We may therefore think of these pointers as *temporally bounded*, albeit with an upper bound chosen *a posteriori*.
+
+[^mte-cache] Care will be required to ensure memory ordering of this change across cores.
+
+# Sketching `snmalloc` on `StrictProvenance`
+
+## Allocation
+
+When allocating, we will need to ensure that returned pointers are bounded to no more than the slab entry used to back an allocation.
+It may be useful, mostly for debugging, to more precisely bound returned pointers to the actual allocation size,[^bounds-precision] but this is not required for security.
+(On sufficiently capable architectures, we will also prepare the returned pointer for temporal bounding.)
+
+[^bounds-precision] `StrictProvenance` architectures have historically differed in the precision with which authority can be represented.
+Notably, it may not be possible to achieve byte-granular authority boundaries at every size scale.
+In the case of CHERI specifically, `snmalloc`'s size classes and its alignment policies are already much coarser than the architectural requirements for representable authority, and so it is always possible to bound returned pointers to their slab entry and in most cases more precise authority bounds are also representable.
+
+`realloc()`-ation has several policies available.
+We choose a fairly simple one for the moment: resizing in ways that do not change the backing allocation's `snmalloc` size class are left in place, while any change to the size class triggers an allocate-copy-deallocate sequence.
+Even if `realloc()` leaves the object in place, the returned pointer should have its authority bounded as if this were a new allocation (and so may have less authority than `realloc()`'s pointer argument).
+Notably, this policy is compatible with the existence of size-parameterized deallocation functions: the result of `realloc()` is always associated with the size class corresponding to the requested size.
+(By contrast, shrinking in place in ways that changed the size class would require tracking the largest size associated with the allocation.)
+
+For `realloc()`-ations left in place, we do not invalidate the original pointer and return one with equal temporal bounds (i.e., one that will be invalidated at the same time as the original).
+For moving `realloc()`-ations, with their allocate-copy-deallocate implementation, the result will naturally be the revocation of the original pointer.
+Clients of `realloc()` must not rely on the possible optimization of in-place operation and must not reuse the original pointer after passing it to `realloc()`.
+
+## Deallocation
+
+Strict provenance and bounded returns from `alloc()` imply that we cannot expect things like
+
+```c++
+void dealloc(void *p)
+{
+  Slab *slab = Slab::get(p);
+  ... slab->foo ...
+}
+```
+
+to work: `Slab::get()` is merely some pointer math, and so must either fail to construct its return value (e.g., by trapping) or construct a useless return value (e.g., one that traps on dereference).
+
+On architectures with revocation, deallocation (and reallocation, naturally) must also check that its input pointer is still valid.
+This will require some *atomic* work, to simultaneously mark the backing memory as free(ing) and prevent any other copy of this pointer from being used to deallocate the object.
+
+## Object Lookup
+
+`snmalloc` extends the traditional allocator interface with the `template<Boundary> void* external_pointer(void*)` family of functions, which generate additional pointers to live allocations.
+To ensure that this function is not used as an amplification oracle, it must construct a return pointer with the same validity as its input even as it internally amplifies to access metadata.
+
+XXX It may be worth requiring that the input pointer authorize the entire object?
+What are the desired security properties here?
+
+# Adapting the Implementation
+
+## Design Overview
+
+We will augment our `AddressSpaceManager` with a cache of pointers that span the entire heap managed by `snmalloc`.
+To keep this cache small, we will request very large swaths (GiB-scale on >48-bit ASes) of address space at a time, even if we only populate those regions very slowly.
+This cache will form the core of our amplification mechanism.
+
+Within `snmalloc`, there are several data structures that hold free memory:
+
+* the `LargeAlloc` holds all regions too big to be managed by `MediumSlab`s
+
+* `MediumSlab`s hold free lists
+
+* `Slab`s hold free lists.
+
+* `Slab`s have associated "bump pointer" regions of address space not yet used (facilitating lazy construction of free lists)
+
+* `Alloc`s themselves also hold, per small size class, up to one free list and up to one bump pointer (so that the complexity of `Slab` manipulation is amortized across many allocations)
+
+* `Alloc`s have or point to `RemoteAllocator`s, which contain queues of `Remote` objects formed from deallocated memory.
+
+* `Alloc`s have `RemoteCaches` that also hold `Remote`s.
+
+We take the position that free list entries should be suitable for return, i.e., with authority bounded to their backing slab entry.
+(However, the *contents* of free memory may be dangerous to expose to the user and require clearing prior to handing out.)
+This means that allocation fast paths are unaffected by the requirement to bound return pointers, but that deallocation paths may need to amplify twice, once on receipt of the pointer from the application and again on receipt of the pointer from another `Alloc`.
+
+## Pointer Wrapper Types
+
+We introduce three type aliases for `void *`:
+
+* `AuthPtr<T>`, which we use to mean pointers with elevated authority and pointing to arbitrary contents.
+  They may be (effectively) unbounded, both spatially, by virtue of authorizing access to vast spans of heap, and temporally, in that they may be immune to invalidation.
+  Because the indicated memory is arbitrary, it may not be sufficient to bound the pointer before returning it outside the allocator.
+
+* `FreePtr<T>`, which captures pointers lingering on internal free lists.
+  These are spatially bounded to one allocation and are temporally bounded to some as-yet-indeterminate point in the future.
+  However, the contents of (a subset of) the memory they authorize may yet be unsafe to reveal to the client and may need to be cleared on allocation paths.
+
+* `ReturnPtr`, which captures the pointers crossing the client interface.
+  These are (spatially and temporally) bounded to just one, *live* allocation.
+  They are created on the allocation paths from `AuthPtr` or `FreePtr` and are amplified back (and invalidated) on deallocation paths.
+  The contents of authorized memory are arbitrary but safe for the client to (have) handled.
+  The type is not parameterized because we intend it to be used only as `void *`.
+
+## Primitive Architectural Operations
+
+Several new functions are introduced to AALs to capture primitives of the Architecture:
+
+* `FreePtr<T> ptrauth_bound(AuthPtr<T> a, size_t sz)` spatially bounds the pointer `a` to have authority ranging only from its current target to its current target plus `sz` bytes (which must be within `a`'s authority).
+  No imprecision in authority is permitted.
+
+  (Note that this method currently applies spatial bounds but not temporal bounds.)
+
+* `AuthPtr<T> ptrauth_rebound(AuthPtr<T> a, ReturnPtr p)` is the *architectural primitive* enabling the software amplification mechanism.
+  It combines the authority of `a` and the current target of `p`.
+  The result may be safely dereferenced iff `a` authorizes access to `p`'s target; the result is temporally unbounded.
+  The simplest sufficient (but not necessary) condition to ensure safety is that authority of `a` is a superset of the authority of `p` and `p` points within its authority.
+
+## Amplification
+
+The `AddressSpaceManager` now exposes a method with signature `AuthPtr<T> ptrauth_amplify(ReturnPtr p)` which uses `ptrauth_rebound` to construct a pointer targeting `p`'s target but bearing the authority of the primordial allocation granule (as provided by the kernel) containing this address.
+This pointer can be used to reach the `Allocslab` metadata associated with `p` (and a good bit more, besides!).

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -102,7 +102,7 @@ namespace snmalloc
      * architectures to avoid needing to implement a custom `prefetch` method
      * if they are used only with a compiler that provides the builtin.
      */
-    static inline void prefetch(void* ptr)
+    static inline void prefetch(void* ptr) noexcept
     {
 #if __has_builtin(__builtin_prefetch) && !defined(SNMALLOC_NO_AAL_BUILTINS)
       __builtin_prefetch(ptr);
@@ -119,7 +119,7 @@ namespace snmalloc
      * architectures to avoid needing to implement a custom `tick` method
      * if they are used only with a compiler that provides the builtin.
      */
-    static inline uint64_t tick()
+    static inline uint64_t tick() noexcept
     {
       if constexpr (
         (Arch::aal_features & NoCpuCycleCounters) == NoCpuCycleCounters)

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -1,5 +1,8 @@
 #pragma once
+#include "../ds/concept.h"
 #include "../ds/defines.h"
+#include "aal_concept.h"
+#include "aal_consts.h"
 
 #include <chrono>
 #include <cstdint>
@@ -29,38 +32,6 @@
 
 namespace snmalloc
 {
-  /**
-   * Flags in a bitfield of attributes of this architecture, much like
-   * PalFeatures.
-   */
-  enum AalFeatures : uint64_t
-  {
-    /**
-     * This architecture does not discriminate between integers and pointers,
-     * and so may use bit operations on pointer values.
-     */
-    IntegerPointers = (1 << 0),
-    /**
-     * This architecture cannot access cpu cycles counters.
-     */
-    NoCpuCycleCounters = (1 << 1),
-    /**
-     * This architecture enforces strict pointer provenance; we bound the
-     * pointers given out on malloc() and friends and must, therefore retain
-     * internal high-privilege pointers for recycling memory on free().
-     */
-    StrictProvenance = (1 << 2),
-  };
-
-  enum AalName : int
-  {
-    ARM,
-    PowerPC,
-    X86,
-    X86_SGX,
-    Sparc,
-  };
-
   /**
    * Architecture Abstraction Layer. Includes default implementations of some
    * functions using compiler builtins.  Falls back to the definitions in the
@@ -160,7 +131,7 @@ namespace snmalloc
 {
   using Aal = AAL_Generic<AAL_Arch>;
 
-  template<AalFeatures F, typename AAL = Aal>
+  template<AalFeatures F, SNMALLOC_CONCEPT(ConceptAAL) AAL = Aal>
   constexpr static bool aal_supports = (AAL::aal_features & F) == F;
 } // namespace snmalloc
 

--- a/src/aal/aal_concept.h
+++ b/src/aal/aal_concept.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#ifdef __cpp_concepts
+#  include "../ds/concept.h"
+#  include "aal_consts.h"
+
+#  include <cstdint>
+#  include <utility>
+
+namespace snmalloc
+{
+  /**
+   * AALs must advertise the bit vector of supported features, their name,
+   * 
+   */
+  template<typename AAL>
+  concept ConceptAAL_static_members = requires()
+  {
+    typename std::integral_constant<uint64_t, AAL::aal_features>;
+    typename std::integral_constant<int, AAL::aal_name>;
+  };
+
+  /**
+   * AALs provide a prefetch operation.
+   */
+  template<typename AAL>
+  concept ConceptAAL_prefetch = requires(void *ptr)
+  {
+    { AAL::prefetch(ptr) } noexcept -> ConceptSame<void>;
+  };
+
+  /**
+   * AALs provide a notion of high-precision timing.
+   */
+  template<typename AAL>
+  concept ConceptAAL_tick = requires()
+  {
+    { AAL::tick() } noexcept -> ConceptSame<uint64_t>;
+  };
+
+  template<typename AAL>
+  concept ConceptAAL =
+    ConceptAAL_static_members<AAL> &&
+    ConceptAAL_prefetch<AAL> &&
+    ConceptAAL_tick<AAL>;
+
+} // namespace snmalloc
+#endif

--- a/src/aal/aal_consts.h
+++ b/src/aal/aal_consts.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+
+namespace snmalloc
+{
+  /**
+   * Flags in a bitfield of attributes of this architecture, much like
+   * PalFeatures.
+   */
+  enum AalFeatures : uint64_t
+  {
+    /**
+     * This architecture does not discriminate between integers and pointers,
+     * and so may use bit operations on pointer values.
+     */
+    IntegerPointers = (1 << 0),
+    /**
+     * This architecture cannot access cpu cycles counters.
+     */
+    NoCpuCycleCounters = (1 << 1),
+    /**
+     * This architecture enforces strict pointer provenance; we bound the
+     * pointers given out on malloc() and friends and must, therefore retain
+     * internal high-privilege pointers for recycling memory on free().
+     */
+    StrictProvenance = (1 << 2),
+  };
+
+  enum AalName : int
+  {
+    ARM,
+    PowerPC,
+    X86,
+    X86_SGX,
+    Sparc,
+  };
+} // namespace snmalloc

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../pal/pal_consts.h"
 #include "bits.h"
+#include "ptrwrap.h"
 
 #include <cstdint>
 
@@ -24,6 +25,12 @@ namespace snmalloc
     return reinterpret_cast<T*>(reinterpret_cast<char*>(base) + diff);
   }
 
+  template<typename T>
+  inline AuthPtr<T> pointer_offset(AuthPtr<T> base, size_t diff)
+  {
+    return mk_authptr<T>(pointer_offset(base.unsafe_auth_ptr, diff));
+  }
+
   /**
    * Perform pointer arithmetic and return the adjusted pointer.
    */
@@ -40,6 +47,18 @@ namespace snmalloc
   inline address_t address_cast(T* ptr)
   {
     return reinterpret_cast<address_t>(ptr);
+  }
+
+  template<typename T>
+  inline address_t address_cast(AuthPtr<T> a)
+  {
+    return reinterpret_cast<address_t>(a.unsafe_auth_ptr);
+  }
+
+  template<typename T>
+  inline address_t address_cast(FreePtr<T> a)
+  {
+    return reinterpret_cast<address_t>(a.unsafe_free_ptr);
   }
 
   /**
@@ -98,6 +117,12 @@ namespace snmalloc
     }
   }
 
+  template<size_t alignment, typename T = void>
+  inline AuthPtr<T> pointer_align_up(AuthPtr<T> p)
+  {
+    return mk_authptr<T>(pointer_align_up<alignment, T>(p.unsafe_auth_ptr));
+  }
+
   /**
    * Align a pointer down to a dynamically specified granularity, which must be
    * a power of two.
@@ -130,6 +155,12 @@ namespace snmalloc
     return reinterpret_cast<T*>(
       bits::align_up(reinterpret_cast<uintptr_t>(p), alignment));
 #endif
+  }
+
+  template<typename T = void>
+  inline AuthPtr<T> pointer_align_up(AuthPtr<T> p, size_t alignment)
+  {
+    return mk_authptr<T>(pointer_align_up<T>(p.unsafe_auth_ptr, alignment));
   }
 
   /**

--- a/src/ds/concept.h
+++ b/src/ds/concept.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 /**
  * C++20 concepts are referenced as if they were types in declarations within
  * template parameters (e.g. "template<FooConcept Foo> ...").  That is, they

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -1,57 +1,12 @@
 #pragma once
 
+#include "invalidptr.h"
+
 #include <cstdint>
 #include <type_traits>
 
 namespace snmalloc
 {
-  /**
-   * Invalid pointer class.  This is similar to `std::nullptr_t`, but allows
-   * other values.
-   */
-  template<address_t Sentinel>
-  struct InvalidPointer
-  {
-    /**
-     * Equality comparison. Two invalid pointer values with the same sentinel
-     * are always the same, invalid pointer values with different sentinels are
-     * always different.
-     */
-    template<address_t OtherSentinel>
-    constexpr bool operator==(const InvalidPointer<OtherSentinel>&)
-    {
-      return Sentinel == OtherSentinel;
-    }
-    /**
-     * Equality comparison. Two invalid pointer values with the same sentinel
-     * are always the same, invalid pointer values with different sentinels are
-     * always different.
-     */
-    template<address_t OtherSentinel>
-    constexpr bool operator!=(const InvalidPointer<OtherSentinel>&)
-    {
-      return Sentinel != OtherSentinel;
-    }
-    /**
-     * Implicit conversion, creates a pointer with the value of the sentinel.
-     * On CHERI and other provenance-tracking systems, this is a
-     * provenance-free integer and so will trap if dereferenced, on other
-     * systems the sentinel should be a value in unmapped memory.
-     */
-    template<typename T>
-    operator T*() const
-    {
-      return reinterpret_cast<T*>(Sentinel);
-    }
-    /**
-     * Implicit conversion to an address, returns the sentinel value.
-     */
-    operator address_t() const
-    {
-      return Sentinel;
-    }
-  };
-
   template<
     class T,
     class Terminator = std::nullptr_t,

--- a/src/ds/invalidptr.h
+++ b/src/ds/invalidptr.h
@@ -1,0 +1,51 @@
+#pragma once
+
+namespace snmalloc
+{
+  /**
+   * Invalid pointer class.  This is similar to `std::nullptr_t`, but allows
+   * other values.
+   */
+  template<address_t Sentinel>
+  struct InvalidPointer
+  {
+    /**
+     * Equality comparison. Two invalid pointer values with the same sentinel
+     * are always the same, invalid pointer values with different sentinels are
+     * always different.
+     */
+    template<address_t OtherSentinel>
+    constexpr bool operator==(const InvalidPointer<OtherSentinel>&)
+    {
+      return Sentinel == OtherSentinel;
+    }
+    /**
+     * Equality comparison. Two invalid pointer values with the same sentinel
+     * are always the same, invalid pointer values with different sentinels are
+     * always different.
+     */
+    template<address_t OtherSentinel>
+    constexpr bool operator!=(const InvalidPointer<OtherSentinel>&)
+    {
+      return Sentinel != OtherSentinel;
+    }
+    /**
+     * Implicit conversion, creates a pointer with the value of the sentinel.
+     * On CHERI and other provenance-tracking systems, this is a
+     * provenance-free integer and so will trap if dereferenced, on other
+     * systems the sentinel should be a value in unmapped memory.
+     */
+    template<typename T>
+    operator T*() const
+    {
+      return reinterpret_cast<T*>(Sentinel);
+    }
+    /**
+     * Implicit conversion to an address, returns the sentinel value.
+     */
+    operator address_t() const
+    {
+      return Sentinel;
+    }
+  };
+} // namespace snmalloc

--- a/src/ds/ptrwrap.h
+++ b/src/ds/ptrwrap.h
@@ -1,0 +1,142 @@
+#pragma once
+
+namespace snmalloc
+{
+  /**
+   * A convenience type that we can use to annotate internal functions
+   * which return pointers that are headed out to the application or
+   * which have come back.
+   */
+  class ReturnPtr
+  {
+  public:
+    void* unsafe_return_ptr;
+
+    ReturnPtr(const std::nullptr_t n)
+    {
+      this->unsafe_return_ptr = n;
+    }
+
+    inline bool operator==(const ReturnPtr& rhs) const
+    {
+      return this->unsafe_return_ptr == rhs.unsafe_return_ptr;
+    }
+
+    inline bool operator!=(const ReturnPtr& rhs) const
+    {
+      return this->unsafe_return_ptr != rhs.unsafe_return_ptr;
+    }
+  };
+
+  /**
+   * A convenience type used to indicate a pointer suitable for inclusion on a
+   * free list.  The pointer itself is ready to be given to a client (that is,
+   * it has restricted authority on StrictProvenance architectures), but the
+   * contents of the memory are possibly unsafe to disclose.
+   *
+   * Obtain non-null `FreePtr`s using the AAL's `ptrauth_bound` method.
+   */
+  template<typename T>
+  class FreePtr
+  {
+  public:
+    T* unsafe_free_ptr;
+
+    FreePtr(const std::nullptr_t n) : unsafe_free_ptr(n) {}
+
+    template<typename U>
+    explicit FreePtr(FreePtr<U> fp)
+    : unsafe_free_ptr(reinterpret_cast<T*>(fp.unsafe_free_ptr))
+    {}
+
+    inline bool operator==(const FreePtr& rhs) const
+    {
+      return this->unsafe_free_ptr == rhs.unsafe_free_ptr;
+    }
+
+    inline bool operator!=(const FreePtr& rhs) const
+    {
+      return this->unsafe_free_ptr != rhs.unsafe_free_ptr;
+    }
+  };
+
+  /**
+   * A convenience type used to indicate that a pointer has elevated authority
+   * and requires some special care.
+   *
+   * Most non-NULL `AuthPtr`s in the Alloc-ator proper come from amplification;
+   * see the largealloc's `ptrauth_amplify` method.
+   */
+  template<typename T>
+  class AuthPtr
+  {
+  public:
+    T* unsafe_auth_ptr;
+
+    AuthPtr() : unsafe_auth_ptr(nullptr) {}
+
+    AuthPtr(const std::nullptr_t n) : unsafe_auth_ptr(n) {}
+
+    inline bool operator==(const AuthPtr& rhs) const
+    {
+      return this->unsafe_auth_ptr == rhs.unsafe_auth_ptr;
+    }
+
+    inline bool operator!=(const AuthPtr& rhs) const
+    {
+      return this->unsafe_auth_ptr != rhs.unsafe_auth_ptr;
+    }
+
+    inline bool operator<(const AuthPtr& rhs) const
+    {
+      return this->unsafe_auth_ptr < rhs.unsafe_auth_ptr;
+    }
+  };
+
+  /**
+   * While it's always safe to view a pointer as carrying its authority, we want
+   * to be explicit when we're doing so, so this isn't a constructor for the
+   * `AuthPtr` class, which would be an implicit conversion.
+   */
+  template<typename T = void>
+  SNMALLOC_FAST_PATH static AuthPtr<T> mk_authptr(void* p)
+  {
+    return *reinterpret_cast<AuthPtr<T>*>(&p);
+  }
+
+  /**
+   * Occasionally we want to treat an `AuthPtr` as a `FreePtr` with the
+   * knowledge that it isn't actually headed out to the user.
+   */
+  template<typename T, typename U = T>
+  SNMALLOC_FAST_PATH static FreePtr<T> unsafe_mk_freeptr(AuthPtr<U> p)
+  {
+    return *reinterpret_cast<FreePtr<T>*>(&p.unsafe_auth_ptr);
+  }
+
+  template<typename T>
+  SNMALLOC_FAST_PATH static FreePtr<T> unsafe_as_freeptr(ReturnPtr p)
+  {
+    return *reinterpret_cast<FreePtr<T>*>(&p.unsafe_return_ptr);
+  }
+
+  /**
+   * `ReturnPtr`s are `FreePtr`s that have had their contents sanitized; there
+   * is no great way to explain that to the type system, so carefully use this
+   * function after that sanitization.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH static ReturnPtr unsafe_mk_returnptr(FreePtr<T> p)
+  {
+    return *reinterpret_cast<ReturnPtr*>(&p.unsafe_free_ptr);
+  }
+
+  /**
+   * `ReturnPtr`s are sometimes given back to us as `void *`.
+   */
+  SNMALLOC_FAST_PATH static ReturnPtr unsafe_as_returnptr(void* p)
+  {
+    return *reinterpret_cast<ReturnPtr*>(&p);
+  }
+
+} // namespace snmalloc

--- a/src/mem/address_space.h
+++ b/src/mem/address_space.h
@@ -13,7 +13,7 @@ namespace snmalloc
    * It cannot unreserve memory, so this does not require the
    * usual complexity of a buddy allocator.
    */
-  template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
+  template<SNMALLOC_CONCEPT(ConceptPAL) PAL, typename PrimAlloc>
   class AddressSpaceManager
   {
     /**

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1397,7 +1397,7 @@ namespace snmalloc
 
       DLList<Mediumslab>* sc = &medium_classes[medium_class];
       Mediumslab* slab = sc->get_head();
-      void* p;
+      FreePtr<void> p = nullptr;
 
       if (slab != nullptr)
       {
@@ -1433,8 +1433,7 @@ namespace snmalloc
       stats().alloc_request(size);
       stats().sizeclass_alloc(sizeclass);
       // XXX
-      return unsafe_mk_returnptr(
-        Aal::template ptrauth_bound<void>(mk_authptr<void>(p), rsize));
+      return unsafe_mk_returnptr(p);
     }
 
     void medium_dealloc(
@@ -1442,7 +1441,7 @@ namespace snmalloc
     {
       MEASURE_TIME(medium_dealloc, 4, 16);
       stats().sizeclass_dealloc(sizeclass);
-      bool was_full = slab->dealloc(p_free.unsafe_free_ptr);
+      bool was_full = slab->dealloc(p_free);
 
 #ifdef CHECK_CLIENT
       if (!is_multiple_of_sizeclass(

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -318,6 +318,15 @@ namespace snmalloc
       AuthPtr<void> p_auth = mk_authptr(p_raw);
       FreePtr<void> p_free = unsafe_as_freeptr<void>(p_ret);
 
+      dealloc_sized_auth(p_auth, p_free, size);
+#endif
+    }
+
+  private:
+    SNMALLOC_FAST_PATH
+    void
+    dealloc_sized_auth(AuthPtr<void> p_auth, FreePtr<void> p_free, size_t size)
+    {
       if (likely((size - 1) <= (sizeclass_to_size(NUM_SMALL_CLASSES - 1) - 1)))
       {
         Superslab* super = Superslab::get(p_auth);
@@ -330,7 +339,6 @@ namespace snmalloc
         return;
       }
       dealloc_sized_slow(p_auth, p_free, size);
-#endif
     }
 
     SNMALLOC_SLOW_PATH
@@ -338,7 +346,7 @@ namespace snmalloc
     dealloc_sized_slow(AuthPtr<void> p_auth, FreePtr<void> p_free, size_t size)
     {
       if (size == 0)
-        return dealloc(p_free.unsafe_free_ptr, 1);
+        return dealloc_sized_auth(p_auth, p_free, 1);
 
       if (likely(size <= sizeclass_to_size(NUM_SIZECLASSES - 1)))
       {
@@ -354,6 +362,7 @@ namespace snmalloc
       large_dealloc(p_auth, p_free, size);
     }
 
+  public:
     /*
      * Free memory of an unknown size. Must be called with an external
      * pointer.

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -944,8 +944,7 @@ namespace snmalloc
         else
         {
           SNMALLOC_ASSERT(super->get_kind() == Medium);
-          FreePtr<void> start = unsafe_mk_freeptr<void>(
-            mk_authptr(remove_cache_friendly_offset(fpf.unsafe_free_ptr, psz)));
+          FreePtr<void> start = remove_cache_friendly_offset(fpf, psz);
           medium_dealloc(Mediumslab::get(p_auth), start, psz);
         }
       }
@@ -1119,12 +1118,13 @@ namespace snmalloc
 
         fl.value = Metaslab::follow_next(head);
 
-        void* p = remove_cache_friendly_offset(head.unsafe_free_ptr, sizeclass);
+        FreePtr<void> p = remove_cache_friendly_offset(head, sizeclass);
         if constexpr (zero_mem == YesZero)
         {
-          MemoryProvider::Pal::zero(p, sizeclass_to_size(sizeclass));
+          MemoryProvider::Pal::zero(
+            p.unsafe_free_ptr, sizeclass_to_size(sizeclass));
         }
-        return unsafe_mk_returnptr(unsafe_mk_freeptr<void>(mk_authptr(p)));
+        return unsafe_mk_returnptr(p);
       }
 
       if (likely(!has_messages()))
@@ -1238,8 +1238,7 @@ namespace snmalloc
       SNMALLOC_ASSERT(ffl.value == nullptr);
       Slab::alloc_new_list(bp, ffl, rsize);
 
-      FreePtr<void> p = unsafe_mk_freeptr<void>(mk_authptr(
-        remove_cache_friendly_offset(ffl.value.unsafe_free_ptr, sizeclass)));
+      FreePtr<void> p = remove_cache_friendly_offset(ffl.value, sizeclass);
       ffl.value = Metaslab::follow_next(ffl.value);
 
       if constexpr (zero_mem == YesZero)

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -623,6 +623,19 @@ namespace snmalloc
             if (!l->empty())
             {
               // Send all slots to the target at the head of the list.
+              /*
+               * This is somewhat dubious: this chunk might be either a
+               * Superslab or a Mediumslab, but we access only the
+               * get_allocator() method of their common parent class,
+               * Allocslab, which reads the allocator field, which should
+               * have common offset.
+               */
+#ifdef __clang__
+              static_assert(
+                offsetof(Superslab, allocator) ==
+                  offsetof(Mediumslab, allocator),
+                "Allocslab derived classes have differing allocator offsets");
+#endif
               Superslab* super = Superslab::get(first);
               super->get_allocator()->message_queue.enqueue(first, l->last);
               l->clear();

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -601,8 +601,10 @@ namespace snmalloc
         l->last = r;
       }
 
-      void post(alloc_id_t id)
+      void post(LargeAlloc<MemoryProvider>* large_allocator, alloc_id_t id)
       {
+        UNUSED(large_allocator);
+
         // When the cache gets big, post lists to their target allocators.
         capacity = REMOTE_CACHE;
 
@@ -928,7 +930,7 @@ namespace snmalloc
         return;
 
       stats().remote_post();
-      remote.post(get_trunc_id());
+      remote.post(&large_allocator, get_trunc_id());
     }
 
     /**
@@ -1503,7 +1505,7 @@ namespace snmalloc
       remote.dealloc(target->trunc_id(), offseted, sizeclass);
 
       stats().remote_post();
-      remote.post(get_trunc_id());
+      remote.post(&large_allocator, get_trunc_id());
     }
 
     ChunkMap& chunkmap()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1364,7 +1364,11 @@ namespace snmalloc
           super_available.remove(super);
 
           chunkmap().clear_slab(super);
-          large_allocator.dealloc(mk_authptr(super), super, 0);
+
+          auto super_auth = mk_authptr(super);
+          auto super_free = unsafe_mk_freeptr<void>(super_auth);
+
+          large_allocator.dealloc(super_auth, super_free, 0);
           stats().superslab_push();
           break;
         }
@@ -1452,7 +1456,11 @@ namespace snmalloc
         }
 
         chunkmap().clear_slab(slab);
-        large_allocator.dealloc(mk_authptr(slab), slab, 0);
+
+        auto slab_auth = mk_authptr(slab);
+        auto slab_free = unsafe_mk_freeptr<void>(slab_auth);
+
+        large_allocator.dealloc(slab_auth, slab_free, 0);
         stats().superslab_push();
       }
       else if (was_full)
@@ -1529,7 +1537,7 @@ namespace snmalloc
       // Initialise in order to set the correct SlabKind.
       Largeslab* slab = static_cast<Largeslab*>(p_free.unsafe_free_ptr);
       slab->init();
-      large_allocator.dealloc(p_auth, slab, large_class);
+      large_allocator.dealloc(p_auth, p_free, large_class);
     }
 
     // This is still considered the fast path as all the complex code is tail

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -473,13 +473,13 @@ namespace snmalloc
     }
 
   public:
-    SNMALLOC_FAST_PATH static size_t alloc_size(const void* p)
+    SNMALLOC_FAST_PATH size_t alloc_size(const void* p)
     {
 #ifdef SNMALLOC_PASS_THROUGH
       return external_alloc::malloc_usable_size(const_cast<void*>(p));
 #else
       // This must be called on an external pointer.
-      size_t size = ChunkMap::get(address_cast(p));
+      size_t size = chunkmap().get(address_cast(p));
 
       if (likely(size == CMSuperslab))
       {

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -405,13 +405,13 @@ namespace snmalloc
     }
 
     template<Boundary location = Start>
-    static void* external_pointer(void* p)
+    void* external_pointer(void* p)
     {
 #ifdef SNMALLOC_PASS_THROUGH
       error("Unsupported");
       UNUSED(p);
 #else
-      uint8_t size = ChunkMap::get(address_cast(p));
+      uint8_t size = chunkmap().get(address_cast(p));
 
       Superslab* super = Superslab::get(p);
       if (size == CMSuperslab)
@@ -443,7 +443,7 @@ namespace snmalloc
           ss,
           -(static_cast<ptrdiff_t>(1)
             << (size - CMLargeRangeMin + SUPERSLAB_BITS)));
-        size = ChunkMap::get(ss);
+        size = chunkmap().get(ss);
       }
 
       if (size == 0)

--- a/src/mem/allocslab.h
+++ b/src/mem/allocslab.h
@@ -5,12 +5,10 @@
 
 namespace snmalloc
 {
-  class Allocslab : public Baseslab
+  struct Allocslab : public Baseslab
   {
-  protected:
     RemoteAllocator* allocator;
 
-  public:
     RemoteAllocator* get_allocator()
     {
       return allocator;

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -172,22 +172,12 @@ namespace snmalloc
   struct DefaultChunkMap
   {
     /**
-     * Get the pagemap entry corresponding to a specific address.
-     *
-     * Despite the type, the return value is an enum ChunkMapSuperslabKind
-     * or one of the reserved values described therewith.
+     * Get the pagemap entry corresponding to a specific address inside
+     * a ReturnPtr wrapper.
      */
-    static uint8_t get(address_t p)
+    static uint8_t get(ReturnPtr p)
     {
-      return PagemapProvider::pagemap().get(p);
-    }
-
-    /**
-     * Get the pagemap entry corresponding to a specific address.
-     */
-    static uint8_t get(void* p)
-    {
-      return get(address_cast(p));
+      return get(address_cast(p.unsafe_return_ptr));
     }
 
     /**
@@ -210,7 +200,7 @@ namespace snmalloc
      */
     static void clear_slab(Superslab* slab)
     {
-      SNMALLOC_ASSERT(get(slab) == CMSuperslab);
+      SNMALLOC_ASSERT(get(address_cast(slab)) == CMSuperslab);
       set(slab, static_cast<size_t>(CMNotOurs));
     }
     /**
@@ -218,7 +208,7 @@ namespace snmalloc
      */
     static void clear_slab(Mediumslab* slab)
     {
-      SNMALLOC_ASSERT(get(slab) == CMMediumslab);
+      SNMALLOC_ASSERT(get(address_cast(slab)) == CMMediumslab);
       set(slab, static_cast<size_t>(CMNotOurs));
     }
     /**
@@ -253,6 +243,17 @@ namespace snmalloc
     }
 
   private:
+    /**
+     * Get the pagemap entry corresponding to a specific address.
+     *
+     * Despite the type, the return value is an enum ChunkMapSuperslabKind
+     * or one of the reserved values described therewith.
+     */
+    static uint8_t get(address_t p)
+    {
+      return PagemapProvider::pagemap().get(p);
+    }
+
     /**
      * Helper function to set a pagemap entry.  This is not part of the public
      * interface and exists to make it easy to reuse the code in the public

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -81,7 +81,7 @@ namespace snmalloc
   using ChunkmapPagemap = std::conditional_t<
     CHUNKMAP_USE_FLATPAGEMAP,
     FlatPagemap<SUPERSLAB_BITS, uint8_t>,
-    Pagemap<SUPERSLAB_BITS, uint8_t, 0>>;
+    Pagemap<SUPERSLAB_BITS, uint8_t, 0, PrimAlloc>>;
 
   /**
    * Mixin used by `ChunkMap` to directly access the pagemap via a global

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -126,7 +126,7 @@ namespace snmalloc
           if (alloc->remote.capacity < REMOTE_CACHE)
           {
             alloc->stats().remote_post();
-            alloc->remote.post(alloc->get_trunc_id());
+            alloc->remote.post(&alloc->large_allocator, alloc->get_trunc_id());
             done = false;
           }
 

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -7,7 +7,7 @@
 namespace snmalloc
 {
   inline bool needs_initialisation(void*);
-  void* init_thread_allocator(function_ref<void*(void*)>);
+  ReturnPtr init_thread_allocator(function_ref<ReturnPtr(void*)>);
 
   template<class MemoryProvider, class Alloc>
   class AllocPool : Pool<Alloc, MemoryProvider>

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -225,6 +225,12 @@ namespace snmalloc
       size_t peak = peak_memory_used_bytes;
       return {peak - avail, peak};
     }
+
+    template<typename T = void>
+    SNMALLOC_FAST_PATH AuthPtr<T> ptrauth_amplify(ReturnPtr r)
+    {
+      return address_space.ptrauth_amplify(r);
+    }
   };
 
   using Stats = AllocStats<NUM_SIZECLASSES, NUM_LARGE_CLASSES>;
@@ -328,6 +334,12 @@ namespace snmalloc
       stats.superslab_push();
       memory_provider.available_large_chunks_in_bytes += rsize;
       memory_provider.large_stack[large_class].push(static_cast<Largeslab*>(p));
+    }
+
+    template<typename T = void>
+    SNMALLOC_FAST_PATH AuthPtr<T> ptrauth_amplify(ReturnPtr r)
+    {
+      return memory_provider.ptrauth_amplify(r);
     }
   };
 

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -308,7 +308,7 @@ namespace snmalloc
       return p;
     }
 
-    void dealloc(AuthPtr<void> p_auth, void* p, size_t large_class)
+    void dealloc(AuthPtr<void> p_auth, FreePtr<void> p_free, size_t large_class)
     {
       UNUSED(p_auth);
 
@@ -328,12 +328,14 @@ namespace snmalloc
         (large_class != 0 || decommit_strategy == DecommitSuper))
       {
         MemoryProvider::Pal::notify_not_using(
-          pointer_offset(p, OS_PAGE_SIZE), rsize - OS_PAGE_SIZE);
+          pointer_offset(p_auth.unsafe_auth_ptr, OS_PAGE_SIZE),
+          rsize - OS_PAGE_SIZE);
       }
 
       stats.superslab_push();
       memory_provider.available_large_chunks_in_bytes += rsize;
-      memory_provider.large_stack[large_class].push(static_cast<Largeslab*>(p));
+      memory_provider.large_stack[large_class].push(
+        static_cast<Largeslab*>(p_free.unsafe_free_ptr));
     }
 
     template<typename T = void>

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -302,8 +302,10 @@ namespace snmalloc
       return p;
     }
 
-    void dealloc(void* p, size_t large_class)
+    void dealloc(AuthPtr<void> p_auth, void* p, size_t large_class)
     {
+      UNUSED(p_auth);
+
       if constexpr (decommit_strategy == DecommitSuperLazy)
       {
         static_assert(

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -44,10 +44,10 @@ namespace snmalloc
       return bits::align_up(sizeof(Mediumslab), min(OS_PAGE_SIZE, SLAB_SIZE));
     }
 
-    static Mediumslab* get(const void* p)
+    template<typename T = void>
+    static Mediumslab* get(AuthPtr<T> a)
     {
-      return pointer_align_down<SUPERSLAB_SIZE, Mediumslab>(
-        const_cast<void*>(p));
+      return pointer_align_down<SUPERSLAB_SIZE, Mediumslab>(a.unsafe_auth_ptr);
     }
 
     void init(RemoteAllocator* alloc, sizeclass_t sc, size_t rsize)

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -28,7 +28,7 @@ namespace snmalloc
   {
   public:
     /**
-     *  Pointer to first free entry in this slab
+     *  Pointer to first free entry in this slab.
      *
      *  The list will be (allocated - needed - 1) long. The -1 is
      *  for the `link` element which is not in the free list.

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -8,6 +8,7 @@
 namespace snmalloc
 {
   class Slab;
+  class FreeListEntry;
 
   using SlabList = CDLLNode;
   using SlabLink = CDLLNode;

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -140,9 +140,10 @@ namespace snmalloc
       return (slab_end - allocation_start) % size == 0;
     }
 
-    static Slab* get_slab(const void* p)
+    template<typename T = void>
+    static Slab* get_slab(AuthPtr<T> a)
     {
-      return pointer_align_down<SLAB_SIZE, Slab>(const_cast<void*>(p));
+      return pointer_align_down<SLAB_SIZE, Slab>(a.unsafe_auth_ptr);
     }
 
     static bool is_short(Slab* p)
@@ -167,7 +168,7 @@ namespace snmalloc
       bool both = false;
       while (curr != nullptr)
       {
-        if (get_slab(curr) != slab)
+        if (get_slab(mk_authptr(curr)) != slab)
         {
           error("Free list corruption, not correct slab.");
         }

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -241,9 +241,9 @@ namespace snmalloc
       while (curr != nullptr)
       {
         // Check we are looking at a correctly aligned block
-        void* start =
-          remove_cache_friendly_offset(curr.unsafe_free_ptr, sizeclass);
-        SNMALLOC_ASSERT(((pointer_diff(slab, start) - offset) % size) == 0);
+        FreePtr<void> start = remove_cache_friendly_offset(curr, sizeclass);
+        SNMALLOC_ASSERT(
+          ((pointer_diff(slab, start.unsafe_free_ptr) - offset) % size) == 0);
 
         // Account for free elements in free list
         accounted_for += size;

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -2,6 +2,7 @@
 
 #include "../ds/bits.h"
 #include "../ds/helpers.h"
+#include "../ds/invalidptr.h"
 
 #include <atomic>
 #include <utility>

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -54,7 +54,11 @@ namespace snmalloc
    * static ChunkMap object, which encapsulates knowledge about the
    * pagemap's parametric type T.
    */
-  template<size_t GRANULARITY_BITS, typename T, T default_content>
+  template<
+    size_t GRANULARITY_BITS,
+    typename T,
+    T default_content,
+    typename PrimAlloc>
   class Pagemap
   {
   private:
@@ -154,8 +158,7 @@ namespace snmalloc
         if (e->compare_exchange_strong(
               value, LOCKED_ENTRY, std::memory_order_relaxed))
         {
-          auto& v = default_memory_provider();
-          value = v.alloc_chunk<PagemapEntry, OS_PAGE_SIZE>();
+          value = PrimAlloc::template alloc_chunk<PagemapEntry, OS_PAGE_SIZE>();
           e->store(value, std::memory_order_release);
         }
         else

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -22,7 +22,7 @@ namespace snmalloc
   {
   private:
     friend Pooled<T>;
-    template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
+    template<SNMALLOC_CONCEPT(ConceptPAL) PAL, typename PrimAlloc>
     friend class MemoryProviderStateMixin;
 
     std::atomic_flag lock = ATOMIC_FLAG_INIT;

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -71,4 +71,13 @@ namespace snmalloc
         ~SIZECLASS_MASK;
     }
   };
+
+  template<typename T = void>
+  SNMALLOC_FAST_PATH FreePtr<T> zero_remote(FreePtr<Remote> f)
+  {
+    void* fp = f.unsafe_free_ptr;
+    Pal::template zero<false>(fp, sizeof(Remote));
+    return unsafe_mk_freeptr<T>(mk_authptr(fp));
+  }
+
 } // namespace snmalloc

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -18,7 +18,7 @@ namespace snmalloc
     using alloc_id_t = size_t;
     union
     {
-      Remote* non_atomic_next;
+      FreePtr<Remote> non_atomic_next;
       std::atomic<Remote*> next{nullptr};
     };
 

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -149,11 +149,13 @@ namespace snmalloc
   }
 
 #ifdef CACHE_FRIENDLY_OFFSET
-  SNMALLOC_FAST_PATH static void*
-  remove_cache_friendly_offset(void* p, sizeclass_t sizeclass)
+  template<typename T>
+  SNMALLOC_FAST_PATH static FreePtr<void>
+  remove_cache_friendly_offset(FreePtr<T> p, sizeclass_t sizeclass)
   {
     size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
-    return p = (void*)((uintptr_t)p & mask);
+    return unsafe_mk_freeptr<void>(
+      mk_authptr((void*)((uintptr_t)p.unsafe_free_ptr & mask)));
   }
 
   SNMALLOC_FAST_PATH static uintptr_t
@@ -163,11 +165,12 @@ namespace snmalloc
     return relative & mask;
   }
 #else
-  SNMALLOC_FAST_PATH static void*
-  remove_cache_friendly_offset(void* p, sizeclass_t sizeclass)
+  template<typename T>
+  SNMALLOC_FAST_PATH static FreePtr<void>
+  remove_cache_friendly_offset(FreePtr<T> p, sizeclass_t sizeclass)
   {
     UNUSED(sizeclass);
-    return p;
+    return static_cast<FreePtr<void>>(p);
   }
 
   SNMALLOC_FAST_PATH static uintptr_t

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -55,9 +55,9 @@ namespace snmalloc
       meta.head = nullptr;
 
       // Return the link as the node for this allocation.
-      void* link = pointer_offset(this, meta.link);
-      FreePtr<void> p = unsafe_mk_freeptr<void>(
-        mk_authptr(remove_cache_friendly_offset(link, meta.sizeclass)));
+      FreePtr<FreeListEntry> link = unsafe_mk_freeptr<FreeListEntry>(
+        mk_authptr(pointer_offset(this, meta.link)));
+      FreePtr<void> p = remove_cache_friendly_offset(link, meta.sizeclass);
 
       // Treat stealing the free list as allocating it all.
       meta.needed = meta.allocated;

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -22,7 +22,7 @@ namespace snmalloc
   public:
     Metaslab& get_meta()
     {
-      Superslab* super = Superslab::get(this);
+      Superslab* super = Superslab::get(mk_authptr(this));
       return super->get_meta(this);
     }
 
@@ -63,7 +63,7 @@ namespace snmalloc
       meta.set_full();
       sl.get_next()->remove();
 
-      SNMALLOC_ASSERT(is_start_of_object(Superslab::get(p), p));
+      SNMALLOC_ASSERT(is_start_of_object(Superslab::get(mk_authptr(p)), p));
 
       meta.debug_slab_invariant(this);
 

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -65,10 +65,10 @@ namespace snmalloc
       StatusChange = 2
     };
 
-    static Superslab* get(const void* p)
+    template<typename T = void>
+    static Superslab* get(AuthPtr<T> a)
     {
-      return pointer_align_down<SUPERSLAB_SIZE, Superslab>(
-        const_cast<void*>(p));
+      return pointer_align_down<SUPERSLAB_SIZE, Superslab>(a.unsafe_auth_ptr);
     }
 
     static bool is_short_sizeclass(sizeclass_t sizeclass)

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -71,6 +71,16 @@ namespace snmalloc
       return pointer_align_down<SUPERSLAB_SIZE, Superslab>(a.unsafe_auth_ptr);
     }
 
+    /**
+     * Compute where the Superslab metadata would be, but without any
+     * expectation that the resulting pointer be authorized to access said
+     * metadata.  Useful almost exclusively for debugging.
+     */
+    static Superslab* get_noauth(void* p)
+    {
+      return get(mk_authptr<void>(p));
+    }
+
     static bool is_short_sizeclass(sizeclass_t sizeclass)
     {
       constexpr sizeclass_t h = size_to_sizeclass_const(sizeof(Superslab));

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -62,7 +62,8 @@ namespace snmalloc
 #    pragma warning(push)
 #    pragma warning(disable : 4702)
 #  endif
-  SNMALLOC_FAST_PATH void* init_thread_allocator(function_ref<void*(void*)> f)
+  SNMALLOC_FAST_PATH ReturnPtr
+  init_thread_allocator(function_ref<ReturnPtr(void*)> f)
   {
     error("Critical Error: This should never be called.");
     return f(nullptr);
@@ -101,7 +102,7 @@ namespace snmalloc
    */
   class ThreadAllocCommon
   {
-    friend void* init_thread_allocator(function_ref<void*(void*)>);
+    friend ReturnPtr init_thread_allocator(function_ref<ReturnPtr(void*)>);
 
   protected:
     /**
@@ -276,7 +277,8 @@ namespace snmalloc
    * path.
    * The second component of the return indicates if this TLS is being torndown.
    */
-  SNMALLOC_FAST_PATH void* init_thread_allocator(function_ref<void*(void*)> f)
+  SNMALLOC_FAST_PATH ReturnPtr
+  init_thread_allocator(function_ref<ReturnPtr(void*)> f)
   {
     auto*& local_alloc = ThreadAlloc::get_reference();
     // If someone reuses a noncachable call, then we can end up here

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -27,7 +27,7 @@ extern "C"
   void SNMALLOC_NAME_MANGLE(check_start)(void* ptr)
   {
 #if !defined(NDEBUG) && !defined(SNMALLOC_PASS_THROUGH)
-    if (Alloc::external_pointer<Start>(ptr) != ptr)
+    if (ThreadAlloc::get_noncachable()->external_pointer<Start>(ptr) != ptr)
     {
       error("Using pointer that is not to the start of an allocation");
     }
@@ -38,7 +38,7 @@ extern "C"
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(__malloc_end_pointer)(void* ptr)
   {
-    return Alloc::external_pointer<OnePastEnd>(ptr);
+    return ThreadAlloc::get_noncachable()->external_pointer<OnePastEnd>(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(malloc)(size_t size)

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -73,7 +73,7 @@ extern "C"
   size_t SNMALLOC_NAME_MANGLE(malloc_usable_size)(
     MALLOC_USABLE_SIZE_QUALIFIER void* ptr)
   {
-    return Alloc::alloc_size(ptr);
+    return ThreadAlloc::get_noncachable()->alloc_size(ptr);
   }
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(realloc)(void* ptr, size_t size)
@@ -95,7 +95,7 @@ extern "C"
 
     SNMALLOC_NAME_MANGLE(check_start)(ptr);
 
-    size_t sz = Alloc::alloc_size(ptr);
+    size_t sz = ThreadAlloc::get_noncachable()->alloc_size(ptr);
     // Keep the current allocation if the given size is in the same sizeclass.
     if (sz == round_size(size))
     {

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -24,7 +24,7 @@ using namespace snmalloc;
 int main()
 {
 #ifndef SNMALLOC_PASS_THROUGH // Depends on snmalloc specific features
-  auto& mp = *MemoryProviderStateMixin<DefaultPal>::make();
+  auto& mp = *MemoryProviderStateMixin<DefaultPal, PrimAlloc>::make();
 
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -241,8 +241,8 @@ void test_external_pointer()
     for (size_t offset = 0; offset < size; offset += 17)
     {
       void* p2 = pointer_offset(p1, offset);
-      void* p3 = Alloc::external_pointer(p2);
-      void* p4 = Alloc::external_pointer<End>(p2);
+      void* p3 = alloc->external_pointer(p2);
+      void* p4 = alloc->external_pointer<End>(p2);
       UNUSED(p3);
       UNUSED(p4);
       SNMALLOC_CHECK(p1 == p3);
@@ -257,7 +257,8 @@ void test_external_pointer()
 
 void check_offset(void* base, void* interior)
 {
-  void* calced_base = Alloc::external_pointer((void*)interior);
+  auto alloc = ThreadAlloc::get();
+  void* calced_base = alloc->external_pointer((void*)interior);
   if (calced_base != (void*)base)
     abort();
 }
@@ -335,7 +336,7 @@ void test_external_pointer_dealloc_bug()
 
   for (size_t i = 0; i < count; i++)
   {
-    Alloc::external_pointer(allocs[i]);
+    alloc->external_pointer(allocs[i]);
   }
 
   alloc->dealloc(allocs[0]);
@@ -348,7 +349,7 @@ void test_alloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc(size);
-  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -359,7 +360,7 @@ void test_calloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -373,7 +374,7 @@ void test_calloc_large_bug()
   const size_t size = (SUPERSLAB_SIZE << 3) - 7;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(alloc->external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -295,7 +295,7 @@ void test_external_pointer_large()
     // store object
     objects[i] = (size_t*)alloc->alloc(size);
     // Store allocators size for this object
-    *objects[i] = Alloc::alloc_size(objects[i]);
+    *objects[i] = alloc->alloc_size(objects[i]);
 
     check_external_pointer_large(objects[i]);
     if (i > 0)
@@ -348,7 +348,7 @@ void test_alloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc(size);
-  SNMALLOC_CHECK(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -359,7 +359,7 @@ void test_calloc_16M()
   const size_t size = 16'000'000;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_CHECK(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 
@@ -373,7 +373,7 @@ void test_calloc_large_bug()
   const size_t size = (SUPERSLAB_SIZE << 3) - 7;
 
   void* p1 = alloc->alloc<YesZero>(size);
-  SNMALLOC_CHECK(Alloc::alloc_size(Alloc::external_pointer(p1)) >= size);
+  SNMALLOC_CHECK(alloc->alloc_size(Alloc::external_pointer(p1)) >= size);
   alloc->dealloc(p1);
 }
 

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -15,7 +15,7 @@ using namespace snmalloc;
 using T = size_t;
 static constexpr size_t GRANULARITY_BITS = 9;
 static constexpr T PRIME = 251;
-Pagemap<GRANULARITY_BITS, T, 0> pagemap_test;
+Pagemap<GRANULARITY_BITS, T, 0, PrimAlloc> pagemap_test;
 
 int main(int argc, char** argv)
 {

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -33,7 +33,7 @@ int main()
 {
   setup();
 
-  MemoryProviderStateMixin<DefaultPal> mp;
+  MemoryProviderStateMixin<DefaultPal, PrimAlloc> mp;
 
   // 26 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -73,7 +73,7 @@ namespace test
         size_t size = *external_ptr;
         size_t offset = (size >> 4) * (rand & 15);
         void* interior_ptr = pointer_offset(external_ptr, offset);
-        void* calced_external = Alloc::external_pointer(interior_ptr);
+        void* calced_external = alloc->external_pointer(interior_ptr);
         if (calced_external != external_ptr)
           abort();
       }

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -33,7 +33,7 @@ namespace test
       // store object
       objects[i] = (size_t*)alloc->alloc(size);
       // Store allocators size for this object
-      *objects[i] = Alloc::alloc_size(objects[i]);
+      *objects[i] = alloc->alloc_size(objects[i]);
     }
   }
 


### PR DESCRIPTION
This is atop #265 and #266 and contains some other small changes and the next steps in preparation for CHERI / StrictProvenance tracking (with an eye towards MTE, too, but that's quite distant).  It is not yet finished -- I have a pile more changes on my desk to see it through -- but I am curious for CI's, and others', opinions.

To begin, read `docs/StrictProvenance.md` for an overview and some rationale for this proposal.

Then: are the aliases in `src/ds/ptrwrap.h` too ugly as they are?  They depend pretty heavily on inlining and SROA to avoid an indirection, and so I am quite open to suggestions to replace them with something better.

In terms of the AAL, there isn't much new, just exposing `CSetBounds` (`ptrauth_bound`) and `CSetAddress` (`ptrauth_rebound`), basically.  The AddressSpaceManager has grown a very coarse AuthMap and `ptrauth_amplify` method, which gets plumbed up to `Alloc`s via the `LargeAlloc`.

The changes to `Alloc` are just the beginning but should give a good hint as to where things are going.  I'll amend this with some more commits as I de-tangle the hideous mess I've made chasing types.