### PR TITLE
Small tweaks to make the sandbox mode happy.

### DIFF
--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -368,7 +368,18 @@ namespace snmalloc
     }
   };
 
-  using GlobalVirtual = MemoryProviderStateMixin<Pal>;
+#ifndef SNMALLOC_DEFAULT_MEMORY_PROVIDER
+#  define SNMALLOC_DEFAULT_MEMORY_PROVIDER MemoryProviderStateMixin<Pal>
+#endif
+
+  /**
+   * The type of the default memory allocator.  This can be changed by defining
+   * `SNMALLOC_DEFAULT_MEMORY_PROVIDER` before including this file.  By default
+   * it is `MemoryProviderStateMixin<Pal>` a class that allocates directly from
+   * the platform abstraction layer.
+   */
+  using GlobalVirtual = SNMALLOC_DEFAULT_MEMORY_PROVIDER;
+
   /**
    * The memory provider that will be used if no other provider is explicitly
    * passed as an argument.

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -24,6 +24,7 @@ namespace snmalloc
     friend Pooled<T>;
     template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
     friend class MemoryProviderStateMixin;
+    friend SNMALLOC_DEFAULT_MEMORY_PROVIDER;
 
     std::atomic_flag lock = ATOMIC_FLAG_INIT;
     MPMCStack<T, PreZeroed> stack;


### PR DESCRIPTION
Allow replacing the type of GlobalVirtual at compile time.
Make that type a friend of Pool so that it can allocate things.