### PR TITLE
Change behaviour of USE_POSIX_COMMIT_CHECKS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,10 @@ size_t malloc_usable_size(const void* ptr) { return 0; }
 int main() { return 0; }
 " CONST_QUALIFIED_MALLOC_USABLE_SIZE)
 
-if ((CMAKE_BUILD_TYPE STREQUAL "Release") AND (NOT SNMALLOC_CI_BUILD))
+if (NOT SNMALLOC_CI_BUILD)
   option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." Off)
 else ()
+  # This is enabled in every bit of CI to detect errors.
   option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." On)
 endif ()
 
@@ -306,6 +307,10 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
         set(TESTNAME "${TEST_CATEGORY}-${TEST}-${SUPER_SLAB_SIZE}")
 
         add_executable(${TESTNAME} ${SRC})
+
+        # For all tests enable commit checking.
+        target_compile_definitions(${TESTNAME} PRIVATE -DUSE_POSIX_COMMIT_CHECKS)
+
         if (${SUPER_SLAB_SIZE} EQUAL 16)
           target_compile_definitions(${TESTNAME} PRIVATE SNMALLOC_USE_LARGE_CHUNKS)
         endif()

--- a/src/pal/pal_bsd.h
+++ b/src/pal/pal_bsd.h
@@ -34,7 +34,14 @@ namespace snmalloc
     static void notify_not_using(void* p, size_t size) noexcept
     {
       SNMALLOC_ASSERT(is_aligned_block<OS::page_size>(p, size));
+      // Call this Pal to simulate the Windows decommit in CI.
+#ifdef USE_POSIX_COMMIT_CHECKS
+      memset(p, 0x5a, size);
+#endif
       madvise(p, size, MADV_FREE);
+#ifdef USE_POSIX_COMMIT_CHECKS
+      mprotect(p, size, PROT_NONE);
+#endif
     }
   };
 } // namespace snmalloc


### PR DESCRIPTION
The previous setting applied USE_POSIX_COMMIT_CHECKS to snmalloc if it
was a non-release build.  This caused issues in CCF virtual mode, as it
was being built in RelWithDebInfo.

This commit changes the flag to be applied less, but for tests to always
apply the setting independent of build type.

This means that when snmalloc is being used as a library, it will be
off, unless explicitly requested.