### PR TITLE
pal bsd aligned build fix due to the -Wconversion flag, it is expected

### DIFF
--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -35,7 +35,7 @@ namespace snmalloc
       SNMALLOC_ASSERT(bits::is_pow2(size));
       SNMALLOC_ASSERT(size >= minimum_alloc_size);
 
-      size_t log2align = bits::next_pow2_bits(size);
+      int log2align = static_cast<int>(bits::next_pow2_bits(size));
 
       void* p = mmap(
         nullptr,


### PR DESCRIPTION
an integer.