### PR TITLE
Fix for Mac OS X 10.14

### DIFF
--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "helpers.h"
+
 #include <cstdint>
 #include <type_traits>
 
@@ -55,7 +57,7 @@ namespace snmalloc
   template<
     class T,
     class Terminator = std::nullptr_t,
-    bool delete_on_clear = false>
+    void on_clear(T*) = ignore<T>>
   class DLList final
   {
   private:
@@ -196,10 +198,7 @@ namespace snmalloc
       {
         auto c = head;
         remove(c);
-        if (delete_on_clear)
-        {
-          delete c;
-        }
+        on_clear(c);
       }
     }
 

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -142,4 +142,10 @@ namespace snmalloc
       return (*static_cast<std::add_pointer_t<Fn>>(p))(args...);
     };
   };
+
+  template<class T>
+  void ignore(T* t)
+  {
+    UNUSED(t);
+  }
 } // namespace snmalloc


### PR DESCRIPTION
The dllist was able to call delete during a destructor if a template
flag was set.  This flag is never set in snmalloc, and was included
to enable reuse in another project.  This was triggering an error on
older mac builds.

This PR calls a templated function when the DLList is destructed.  Hence
other projects can specify the `delete` behaviour if required.