### PR TITLE
Move link out of object space.

### DIFF
--- a/src/ds/cdllist.h
+++ b/src/ds/cdllist.h
@@ -110,6 +110,17 @@ namespace snmalloc
 #endif
     }
 
+    /**
+     * Nulls the previous pointer
+     *
+     * The Meta-slab uses nullptr in prev to mean that it is not part of a
+     * size class list.
+     **/
+    void null_prev()
+    {
+      prev = nullptr;
+    }
+
     SNMALLOC_FAST_PATH CDLLNode* get_prev()
     {
       return prev;

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1074,18 +1074,14 @@ namespace snmalloc
       size_t rsize = sizeclass_to_size(sizeclass);
       auto& sl = small_classes[sizeclass];
 
-      Slab* slab;
-
       if (likely(!sl.is_empty()))
       {
         stats().alloc_request(size);
         stats().sizeclass_alloc(sizeclass);
 
-        SlabLink* link = sl.get_next();
-        slab = get_slab(link);
+        auto meta = reinterpret_cast<Metaslab*>(sl.get_next());
         auto& ffl = small_fast_free_lists[sizeclass];
-        return slab->alloc<zero_mem, typename MemoryProvider::Pal>(
-          sl, ffl, rsize);
+        return meta->alloc<zero_mem, typename MemoryProvider::Pal>(ffl, rsize);
       }
       return small_alloc_rare<zero_mem, allow_reserve>(sizeclass, size);
     }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1214,7 +1214,7 @@ namespace snmalloc
       Superslab* super, Slab* slab, void* p, sizeclass_t sizeclass)
     {
 #ifdef CHECK_CLIENT
-      if (!slab->is_start_of_object(super, p))
+      if (!slab->get_meta().is_start_of_object(p))
       {
         error("Not deallocating start of an object");
       }

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -150,6 +150,13 @@ namespace snmalloc
       return pointer_align_down<SUPERSLAB_SIZE>(p) == p;
     }
 
+    bool is_start_of_object(void* p)
+    {
+      return is_multiple_of_sizeclass(
+        sizeclass_to_size(sizeclass),
+        pointer_diff(p, pointer_align_up<SLAB_SIZE>(pointer_offset(p, 1))));
+    }
+
     /**
      * Check bump-free-list-segment for cycles
      *

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -63,7 +63,7 @@ namespace snmalloc
       meta.set_full();
       sl.get_next()->remove();
 
-      SNMALLOC_ASSERT(is_start_of_object(Superslab::get(p), p));
+      SNMALLOC_ASSERT(meta.is_start_of_object(p));
 
       meta.debug_slab_invariant(this);
 
@@ -108,14 +108,6 @@ namespace snmalloc
 
       Metaslab::store_next(bumpptr, nullptr);
       bumpptr = newbumpptr;
-    }
-
-    bool is_start_of_object(Superslab* super, void* p)
-    {
-      Metaslab& meta = super->get_meta(this);
-      return is_multiple_of_sizeclass(
-        sizeclass_to_size(meta.sizeclass),
-        pointer_diff(p, pointer_offset(this, SLAB_SIZE)));
     }
 
     // Returns true, if it deallocation can proceed without changing any status

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -173,8 +173,7 @@ namespace snmalloc
       meta[0].allocated = static_cast<uint16_t>(
         (SLAB_SIZE - get_initial_offset(sizeclass, true)) /
         sizeclass_to_size(sizeclass));
-      meta[0].link = 1;
-      meta[0].needed = 1;
+      meta[0].set_full();
       meta[0].sizeclass = static_cast<uint8_t>(sizeclass);
 
       used++;
@@ -198,8 +197,7 @@ namespace snmalloc
       meta[h].allocated = static_cast<uint16_t>(
         (SLAB_SIZE - get_initial_offset(sizeclass, false)) /
         sizeclass_to_size(sizeclass));
-      meta[h].needed = 1;
-      meta[h].link = 1;
+      meta[h].set_full();
       meta[h].sizeclass = static_cast<uint8_t>(sizeclass);
 
       head = h + n + 1;


### PR DESCRIPTION
The link object was previously stored in a disused object.  This is
good for reducing meta-data, but if we want to reduce the meta-data
corruption potential, then this is not a good design choice.

This commit moves it into the Metaslab.

The overall change improves performance slightly in a couple of cases.