### PR TITLE
202103 CHERI prep plumbing

### DIFF
--- a/docs/StrictProvenance.md
+++ b/docs/StrictProvenance.md
@@ -1,0 +1,229 @@
+# StrictProvenance Architectures
+
+To aid support of novel architectures, such as CHERI, which explicitly track pointer *provenance* and *bounds*, `snmalloc` makes heavy use of a `CapPtr<T, B>` wrapper type around `T*` values.
+You can view the annotation `B` on a `CapPtr<T, B>` as characterising the set of operations that are supported on this pointer, such as
+
+* address arithmetic within a certain range (e.g, a `Superslab` chunk)
+* requesting manipulation of the virtual memory mappings
+
+Most architectures and platforms cannot enforce these restrictions, but CHERI enables software to constrain its future use of particular pointers and `snmalloc` imposes strong constraints on its *client(s)* use of memory it manages.
+The remainder of this document...
+
+* gives a "quick start" guide,
+* provides a summary of the constraints imposed on clients,
+* motivates and introduces the internal `ArenaMap` structure and the `capptr_amplify` function, and
+* describes the `StrictProvenance` `capptr_*` functions provided by the Architecture Abstraction Layer (AAL) and Platform Abstraction Layer (PAL).
+
+## Preface
+
+The `CapPtr<T, B>` and `capptr_*` primitives and derived functions are intended to guide developers in useful directions; they are not security mechanisms in and of themselves.
+For non-CHERI architectures, the whole edifice crumbles in the face of an overzealous `reinterpret_cast<>` or `unsafe_capptr` member access.
+On CHERI, these are likely to elicit capability violations, but may not if all subsequent access happen to be within bounds.
+
+## Quick Start Guide
+
+### How do I safely get an ordinary pointer to reveal to the client?
+
+If you are...
+
+* Adding an interface like `external_pointer`, and so you have a `CapPtr<T, CBAllocE>`, `e`, whose bounds you want to *inherit* when revealing some other `CapPtr` `p`, use `capptr_rebound(e, p)` to obtain another `CapPtr<T, CBAllocE>` with address from `p`, then go to the last step here.
+
+* Otherwise, if your object is...
+
+  * an entire `SUPERSLAB_SIZE` chunk or bigger, you should have in hand a `CapPtr<T, CBChunk>` from the large allocator.  Use `capptr_export` to make a `CapPtr<T, CBChunkE>`, then use `capptr_chunk_is_alloc` to convert that to a `CapPtr<T, CBAllocE>`, and then proceed.  (If, instead, you find yourself holding a `CapPtr<T, CBChunkD>`, use `capptr_chunk_from_chunkd` first.)
+
+  * of size `sz` and smaller than such a chunk,
+
+    * and have a `CapPtr<T, CBChunkE> p` in hand, use `Aal::capptr_bound<T, CBAllocE>(p, sz)` to get a `CapPtr<T, CBAllocE>`, and then proceed.
+
+    * an have a `CapPtr<T, CBArena> p`, `CapPtr<T, CBChunkD> p`, or `CapPtr<T, CBChunk> p` in hand, use `Aal::capptr_bound<T, CBAlloc>(p, sz)` to get a `CapPtr<T, CBAlloc>`, and then proceed.
+
+* If the above steps left you with a `CapPtr<T, CBAlloc>`, apply any platform constraints for its export with `Pal::capptr_export(p)` to obtain a `CapPtr<T, CBAllocE>`.
+
+* Use `capptr_reveal` to safely convert a `CapPtr<T, CBAllocE>` to a `T*` for the client.
+
+### How do I safely ingest an ordinary pointer from the client?
+
+For all its majesty, `CapPtr`'s coverage is merely an impediment to, rather than a complete defense against, malicious client behavior even on CHERI-enabled architectures.
+Further protection is an open research project at MSR.
+
+Nevertheless, if adding a new kind of deallocation, we suggest following the existing flows:
+
+* Begin by wrapping it with `CapPtr<T, CBAllocE>` and avoid using the raw `T*` thereafter.
+
+* An `CapPtr<T, CBArena>` can be obtained using `large_allocator.capptr_amplify()`.
+Note that this pointer and its progeny are *unsafe* beyond merely having elevated authority: it is possible to construct and dereference pointers with types that do not match memory, resulting in **undefined behavior**.
+
+* Derive the `ChunkMapSuperslabKind` associated with the putative pointer from the client, by reading the `ChunkMap`.
+In some flows, the client will have made a *claim* as to the size (class) of the object which may be tentatively used, but should be validated (unless the client is trusted).
+
+* Based on the above, for non-Large objects, `::get()` the appropriate header structure (`Superslab` or `Mediumslab`).
+
+Eventually we would like to reliably detect references to free objects as part of these flows, especially as frees can change the type of metadata found at the head of a chunk.
+When that is possible, we will add guidance that only reads of non-pointer scalar types are to be performed until after such tests have confirmed the object's liveness.
+Until then, we have stochastic defenses (e.g., `encode` in `src/mem/freelist.h`) later on.
+
+As alluded to above, `capptr_rebound` can be used to ensure that pointers manipulated within `snmalloc` inherit bounds from client-provided pointers.
+In the future, these derived pointers will inherit *temporal bounds* as well as the spatial ones described herein.
+
+### What happened to my cast operators?
+
+Because `CapPtr<T, B>` are not the kinds of pointers C++ expects to manipulate, `static_cast<>` and `reinterpret_cast<>` are not applicable.
+Instead, `CapPtr<T, B>` exposes `as_void()`, `template as_static<U>()`, and `template as_reinterpret<U>()` to perform `static_cast<void*>`, `static_cast<U*>`, and `reinterpret_cast<U*>` (respectively).
+Please use the first viable option from this list, reserving `reinterpret_cast` for more exciting circumstances.
+
+## StrictProvenance in More Detail
+
+Tracking pointer *provenance* and *bounds* enables software to constrain uses of *particular pointers* in ways that are not available with traditional protection mechanisms.
+For example, while code my *have* a pointer that spans its entire C stack, it may construct a pointer that authorizes access only to a particular stack allocation (e.g., a buffer) and use this latter pointer while copying data.
+Even if an attacker is able to control the length of the copy, the bounds imposed upon pointers involved can ensure that an overflow is impossible.
+(Of course, if the attacker can influence both the *bounds* and the copy length, an overflow may still be possible; in practice, however, the two concerns are often sufficiently separated.)
+For `malloc()` in particular, it is enormously beneficial to be able to impose bounds on returned pointers: it becomes impossible for allocator clients to use a pointer from `malloc()` to access adjacent allocations!
+
+Borrowing terminology from CHERI, we speak of the **authority** (to a subset of the address space) held by a pointer and will justify actions in terms of this authority.
+While many kinds of authority can be envisioned, herein we will mean either
+
+* *spatial* authority to read/write/execute within a single *interval* within the address space, or
+* *vmmap* authority to request modification of the virtual page mappings for a given range of addresses.
+
+We may **bound** the authority of a pointer, deriving a new pointer with a subset of its progenitor's authority; this is assumed to be an ambient action requiring no additional authority.
+Dually, given two pointers, one with a subset of the other's authority, we may **amplify** the less-authorized, constructing a pointer with the same address but with increased authority (up to the held superset authority).[^amplifier-state]
+
+## Constraints Imposed Upon Allocations
+
+`snmalloc` ensures that returned pointers are bounded to no more than the slab entry used to back each allocation.
+It may be useful, mostly for debugging, to more precisely bound returned pointers to the actual allocation size,[^bounds-precision] but this is not required for security.
+The pointers returned from `alloc()` will be stripped of their *vmmap* authority, if supported by the platform, ensuring that clients cannot manipulate the page mapping underlying `snmalloc`'s address space.
+
+`realloc()`-ation has several policies that may be sensible.
+We choose a fairly simple one for the moment: resizing in ways that do not change the backing allocation's `snmalloc` size class are left in place, while any change to the size class triggers an allocate-copy-deallocate sequence.
+Even if `realloc()` leaves the object in place, the returned pointer should have its authority bounded as if this were a new allocation (and so may have less authority than `realloc()`'s pointer argument if sub-slab-entry bounds are being applied).
+(Notably, this policy is compatible with the existence of size-parameterized deallocation functions: the result of `realloc()` is always associated with the size class corresponding to the requested size.
+By contrast, shrinking in place in ways that changed the size class would require tracking the largest size ever associated with the allocation.)
+
+## Impact of Constraints On Deallocation, or Introducing the ArenaMap
+
+Strict provenance and bounded returns from `alloc()` imply that we cannot expect things like
+
+```c++
+void dealloc(void *p)
+{
+  Superslab *super = Superslab::get(p);
+  ... super->foo ...
+}
+```
+
+to work (using the existing `Superslab::get()` implementation).
+Architecturally, `dealloc` is no different from any *allocator client* code and `Superslab::get()` is merely some pointer math.
+As such, `Superslab::get()` must either fail to construct its return value (e.g., by trapping) or construct a useless return value (e.g., one that traps on dereference).
+To proceed, we must take advantage of the fact that `snmalloc` has separate authority to the memory underlying its allocations.
+
+Ultimately, all address space manipulated by `snmalloc` comes from its Platform's primitive allocator.
+An **arena** is a region returned by that provider.
+The `AddressSpaceManager` divides arenas into large allocations and manages their life cycles.
+On `StrictProvenance` architectures, the ASM further maintains a map of all PAL-provided memory, called the `ArenaMap`, and uses this to implement `capptr_amplify`, copying the address of a low-authority pointer into a copy of the high-authority pointer provided by the PAL.
+The resulting pointer can then be used much as on non-`StrictProvenance` architectures, with integer arithmetic being used to make it point anywhere within an arena.
+`snmalloc`'s heap layouts ensure that metadata associated with any object are spread across globals and within the same arena as the object itself, and so, assuming access to globals as given, a single amplification suffices.
+
+## Object Lookup
+
+`snmalloc` extends the traditional allocator interface with the `template<Boundary> void* external_pointer(void*)` family of functions, which generate additional pointers to live allocations.
+To ensure that this function is not used as an amplification oracle, it must construct a return pointer with the same validity as its input even as it internally amplifies to access metadata; see `capptr_rebound`.
+
+XXX It may be worth requiring that the input pointer authorize the entire object?
+What are the desired security properties here?
+
+# Adapting the Implementation
+
+## Design Overview
+
+As mentioned, the `AddressSpaceManager` maintains an `ArenaMap`, a cache of pointers that span the entire heap managed by `snmalloc`.
+To keep this cache small, we request very large swaths (GiB-scale on >48-bit ASes) of address space at a time, even if we only populate those regions very slowly.
+
+Within `snmalloc`, there are several data structures that hold free memory:
+
+* the `LargeAlloc` holds all regions too big to be managed by `MediumSlab`s
+
+* `MediumSlab`s hold free lists
+
+* `Slab`s hold free lists.
+
+* `Slab`s have associated "bump pointer" regions of address space not yet used (facilitating lazy construction of free lists)
+
+* `Alloc`s themselves also hold, per small size class, up to one free list and up to one bump pointer (so that the complexity of `Slab` manipulation is amortized across many allocations)
+
+* `Alloc`s have or point to `RemoteAllocator`s, which contain queues of `Remote` objects formed from deallocated memory.
+
+* `Alloc`s have `RemoteCaches` that also hold `Remote`s.
+
+We take the position that free list entries should be suitable for return, i.e., with authority bounded to their backing slab entry.
+(However, the *contents* of free memory may be dangerous to expose to the user and require clearing prior to handing out.)
+This means that allocation fast paths are unaffected by the requirement to bound return pointers, but that deallocation paths may need to amplify twice, once on receipt of the pointer from the application and again on receipt of the pointer from another `Allocator` through the `Remote` mechanism.
+
+## Static Pointer Bound Taxonomy
+
+At the moment, we introduce six possible annotations, though the taxonomy is imperfect:
+
+* bounded only to an underlying arena without platform constraints, `CBArena`;
+* bounded to a `SUPERSLAB_SIZE` or larger chunk without platform constraints, `CBChunk`;
+* bounded to a `SUPERSLAB_SIZE` or larger chunk with platform constraints, `CBChunkE`;
+* bounded *on debug builds* to a `SUPERSLAB_SIZE` or larger chunk without platform constraints, `CBChunkD`;
+* bounded to an allocation but without platform constraints yet applied, `CBAlloc`;
+* bounded to an allocation and with platform constraints, `CBAllocE`;
+
+By "platform constraints" we mean, for example, CheriBSD's ability to remove the authority to manage the VM mappings underlying a pointer.
+Clients of malloc have no business attempting to manage the backing pages.
+
+In practice, we use the pair of the type `T` and the bounds annotation for additional light-weight verification.
+For example, we differentiate `CapPtr<Remote, CBAlloc>` from `CapPtr<void, CBAlloc>`, with the former being offset (if cache-friendly offsets are in effect) and the latter almost always pointing to the start of the object. 
+While it is possible to write code which subverts the annotation scheme, in general method signatures should provide the correct affordance.
+
+## Primitive Architectural Operations
+
+Several new functions are introduced to AALs to capture primitives of the Architecture.
+
+* `CapPtr<T, nbounds> capptr_bound(CapPtr<U, obounds> a, size_t sz)`
+  spatially bounds the pointer `a` to have authority ranging only from its current target to its current target plus `sz` bytes (which must be within `a`'s authority).
+  No imprecision in authority is permitted.
+  The `obounds` annotation is required to be either strictly higher authority than `CBAlloc` or `CBChunkE`, and the bounds annotations must obey `capptr_is_bounds_refinement`.
+
+* `CapPtr<T, BOut> capptr_rebound(CapPtr<void, BOut> a, CapPtr<T, BIn> p)` is the *architectural primitive* enabling the software amplification mechanism.
+  It combines the authority of `a` and the current target of `p`.
+  The result may be safely dereferenced iff `a` authorizes access to `p`'s target.
+  The simplest sufficient (but not necessary) condition to ensure safety is that authority of `a` is a superset of the authority of `p` and `p` points within its authority.
+
+## Primitive Platform Operations
+
+* `CapPtr<void, BO> capptr_export(CapPtr<T, BI> f)` applies any additional platform constraints required before handing permissions out to the client.
+On CheriBSD, specifically, this strips the `VMMAP` software permission, ensuring that clients cannot have the kernel manipulate heap pages.
+In future architectures, this is increasingly likely to be a no-op.
+The annotation `BO` is *computed* as a function of `BI`, which must be `CBChunk` or `CBAlloc`.
+
+## Constructed Operators
+
+* `capptr_bound_chunkd` and `capptr_chunk_from_chunkd` manage the construction and elimination of `CapPtr<T, CBChunkD>` pointers.
+
+* `capptr_chunk_is_alloc` converts a `CapPtr<T, CBChunkE>` to a `CapPtr<T, CBAllocE>` unsafely; it is intended to ease auditing.
+
+* `capptr_reveal` converts a `CapPtr<T, CBAllocE>` to a `void*`.
+
+## Amplification
+
+The `AddressSpaceManager` now exposes a method with signature `CapPtr<T, CBArena> capptr_amplify(CapPtr<void, B> p)` which uses `capptr_rebound` to construct a pointer targeting `p`'s target but bearing the authority of the primordial allocation granule (as provided by the kernel) containing this address.
+This pointer can be used to reach the `Allocslab` metadata associated with `p` (and a good bit more, besides!).
+
+# Endnotes
+
+[^mmu-perms] Pointer authority generally *intersects* with MMU-based authorization.
+For example, software using a pointer with both write and execute authority will still find that it cannot write to pages considered read-only by the MMU nor will it be able to execute non-executable pages.
+Generally speaking, `snmalloc` requires only read-write access to memory it manages and merely passes through other permissions, with the exception of *vmmap*, which it removes from any pointer it returns.
+
+[^amplifier-state] As we are largely following the fat pointer model and its evolution into CHERI capabilities, we achieve amplification through a *stateful*, *software* mechanism, rather than an architectural mechanism.
+Specifically, the amplification mechanism will retain a superset of any authority it may be asked to reconstruct.
+There have, in times past, been capability systems with architectural amplification (e.g., HYDRA's type-directed amplification), but we believe that future systems are unlikely to adopt this latter approach, necessitating the changes we propose below.
+
+[^bounds-precision] `StrictProvenance` architectures have historically differed in the precision with which authority can be represented.
+Notably, it may not be possible to achieve byte-granular authority boundaries at every size scale.
+In the case of CHERI specifically, `snmalloc`'s size classes and its alignment policies are already much coarser than existing architectural requirements for representable authority on all existing implementations.
+
+

--- a/src/aal/aal_concept.h
+++ b/src/aal/aal_concept.h
@@ -2,6 +2,7 @@
 
 #ifdef __cpp_concepts
 #  include "../ds/concept.h"
+#  include "../ds/ptrwrap.h"
 #  include "aal_consts.h"
 
 #  include <cstdint>
@@ -39,10 +40,30 @@ namespace snmalloc
   };
 
   template<typename AAL>
+  concept ConceptAAL_capptr_methods =
+  requires(CapPtr<void, CBArena> auth, CapPtr<void, CBAlloc> ret, size_t sz)
+  {
+    /**
+     * Produce a pointer with reduced authority from a more privilged pointer.
+     * The resulting pointer will have base at auth's address and length of
+     * exactly sz.  auth+sz must not exceed auth's limit.
+     */
+    { AAL::template capptr_bound<void, CBChunk>(auth, sz) } noexcept
+      -> ConceptSame<CapPtr<void, CBChunk>>;
+
+    /**
+     * Construct a copy of auth with its target set to that of ret.
+     */
+    { AAL::capptr_rebound(auth, ret) } noexcept
+      -> ConceptSame<CapPtr<void, CBArena>>;
+  };
+
+  template<typename AAL>
   concept ConceptAAL =
     ConceptAAL_static_members<AAL> &&
     ConceptAAL_prefetch<AAL> &&
-    ConceptAAL_tick<AAL>;
+    ConceptAAL_tick<AAL> &&
+    ConceptAAL_capptr_methods<AAL>;
 
 } // namespace snmalloc
 #endif

--- a/src/ds/ptrwrap.h
+++ b/src/ds/ptrwrap.h
@@ -112,8 +112,22 @@ namespace snmalloc
 
     /**
      * all other constructions must be explicit
+     *
+     * Unfortunately, MSVC gets confused if an Allocator is instantiated in a
+     * way that never needs initialization (as our sandbox test does, for
+     * example) and, in that case, declares this constructor unreachable,
+     * presumably after some heroic feat of inlining that has also lost any
+     * semblance of context.  See the blocks tagged "CapPtr-vs-MSVC" for where
+     * this has been observed.
      */
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4702)
+#endif
     explicit CapPtr(T* p) : unsafe_capptr(p) {}
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
     /**
      * Allow static_cast<>-s that preserve bounds but vary the target type.

--- a/src/ds/ptrwrap.h
+++ b/src/ds/ptrwrap.h
@@ -15,4 +15,272 @@ namespace snmalloc
 
   template<typename T>
   using AtomicPointer = std::atomic<T*>;
+
+  /**
+   * Summaries of StrictProvenance metadata.  We abstract away the particular
+   * size and any offset into the bounds.
+   *
+   * CBArena is as powerful as our pointers get: they're results from mmap(),
+   * and so confer as much authority as the kernel has given us.
+   *
+   * CBChunk is restricted to either a single chunk (SUPERSLAB_SIZE) or perhaps
+   * to several if we've requesed a large allocation (see capptr_chunk_is_alloc
+   * and its uses).
+   *
+   * CBChunkD is curious: we often use CBArena-bounded pointers to derive
+   * pointers to Allocslab metadata, and on most fast paths these pointers end
+   * up being ephemeral.  As such, on NDEBUG builds, we elide the capptr_bounds
+   * that would bound these to chunks and instead just unsafely inherit the
+   * CBArena bounds.  The use of CBChunkD thus helps to ensure that we
+   * eventually do invoke capptr_bounds when these pointers end up being longer
+   * lived!
+   *
+   * *E forms are "exported" and have had platform constraints applied.  That
+   * means, for example, on CheriBSD, that they have had their VMMAP permission
+   * stripped.
+   *
+   * Yes, I wish the start-of-comment characters were aligned below as well.
+   * I blame clang format.
+   */
+  enum capptr_bounds
+  {
+    /*                Spatial  Notes                                      */
+    CBArena, /*        Arena                                              */
+    CBChunkD, /*       Arena   Chunk-bounded in debug; internal use only! */
+    CBChunk, /*        Chunk                                              */
+    CBChunkE, /*       Chunk   (+ platform constraints)                   */
+    CBAlloc, /*        Alloc                                              */
+    CBAllocE /*        Alloc   (+ platform constraints)                   */
+  };
+
+  /**
+   * Compute the "exported" variant of a capptr_bounds annotation.  This is
+   * used by the PAL's capptr_export function to compute its return value's
+   * annotation.
+   */
+  template<capptr_bounds B>
+  constexpr capptr_bounds capptr_export_type()
+  {
+    static_assert(
+      (B == CBChunk) || (B == CBAlloc), "capptr_export_type of bad type");
+
+    switch (B)
+    {
+      case CBChunk:
+        return CBChunkE;
+      case CBAlloc:
+        return CBAllocE;
+    }
+  }
+
+  template<capptr_bounds BI, capptr_bounds BO>
+  constexpr bool capptr_is_bounds_refinement()
+  {
+    switch (BI)
+    {
+      case CBAllocE:
+        return BO == CBAllocE;
+      case CBAlloc:
+        return BO == CBAlloc;
+      case CBChunkE:
+        return BO == CBAllocE || BO == CBChunkE;
+      case CBChunk:
+        return BO == CBAlloc || BO == CBChunk || BO == CBChunkD;
+      case CBChunkD:
+        return BO == CBAlloc || BO == CBChunk || BO == CBChunkD;
+      case CBArena:
+        return BO == CBAlloc || BO == CBChunk || BO == CBChunkD ||
+          BO == CBArena;
+    }
+  }
+
+  /**
+   * A pointer annotated with a "phantom type parameter" carrying a static
+   * summary of its StrictProvenance metadata.
+   */
+  template<typename T, capptr_bounds bounds>
+  struct CapPtr
+  {
+    T* unsafe_capptr;
+
+    /**
+     * nullptr is implicitly constructable at any bounds type
+     */
+    CapPtr(const std::nullptr_t n) : unsafe_capptr(n) {}
+
+    CapPtr() : CapPtr(nullptr) {}
+
+    /**
+     * all other constructions must be explicit
+     */
+    explicit CapPtr(T* p) : unsafe_capptr(p) {}
+
+    /**
+     * Allow static_cast<>-s that preserve bounds but vary the target type.
+     */
+    template<typename U>
+    SNMALLOC_FAST_PATH CapPtr<U, bounds> as_static()
+    {
+      return CapPtr<U, bounds>(static_cast<U*>(this->unsafe_capptr));
+    }
+
+    SNMALLOC_FAST_PATH CapPtr<void, bounds> as_void()
+    {
+      return this->as_static<void>();
+    }
+
+    /**
+     * A more aggressive bounds-preserving cast, using reinterpret_cast
+     */
+    template<typename U>
+    SNMALLOC_FAST_PATH CapPtr<U, bounds> as_reinterpret()
+    {
+      return CapPtr<U, bounds>(reinterpret_cast<U*>(this->unsafe_capptr));
+    }
+
+    SNMALLOC_FAST_PATH bool operator==(const CapPtr& rhs) const
+    {
+      return this->unsafe_capptr == rhs.unsafe_capptr;
+    }
+
+    SNMALLOC_FAST_PATH bool operator!=(const CapPtr& rhs) const
+    {
+      return this->unsafe_capptr != rhs.unsafe_capptr;
+    }
+
+    SNMALLOC_FAST_PATH bool operator<(const CapPtr& rhs) const
+    {
+      return this->unsafe_capptr < rhs.unsafe_capptr;
+    }
+
+    SNMALLOC_FAST_PATH T* operator->() const
+    {
+      /*
+       * CBAllocE bounds are associated with objects coming from or going to the
+       * client; we should be doing nothing with them.
+       */
+      static_assert(bounds != CBAllocE);
+      return this->unsafe_capptr;
+    }
+  };
+
+  static_assert(sizeof(CapPtr<void, CBArena>) == sizeof(void*));
+  static_assert(alignof(CapPtr<void, CBArena>) == alignof(void*));
+
+  template<typename T>
+  using CapPtrCBArena = CapPtr<T, CBArena>;
+
+  template<typename T>
+  using CapPtrCBChunk = CapPtr<T, CBChunk>;
+
+  template<typename T>
+  using CapPtrCBChunkE = CapPtr<T, CBChunkE>;
+
+  template<typename T>
+  using CapPtrCBAlloc = CapPtr<T, CBAlloc>;
+
+  /**
+   * Sometimes (with large allocations) we really mean the entire chunk (or even
+   * several chunks) to be the allocation.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH CapPtr<T, CBAllocE>
+  capptr_chunk_is_alloc(CapPtr<T, CBChunkE> p)
+  {
+    return CapPtr<T, CBAlloc>(p.unsafe_capptr);
+  }
+
+  /**
+   * With all the bounds and constraints in place, it's safe to extract a void
+   * pointer (to reveal to the client).
+   */
+  SNMALLOC_FAST_PATH void* capptr_reveal(CapPtr<void, CBAllocE> p)
+  {
+    return p.unsafe_capptr;
+  }
+
+  /**
+   *
+   * Wrap a std::atomic<T*> with bounds annotation and speak in terms of
+   * bounds-annotated pointers at the interface.
+   *
+   * Note the membranous sleight of hand being pulled here: this class puts
+   * annotations around an un-annotated std::atomic<T*>, to appease C++, yet
+   * will expose or consume only CapPtr<T> with the same bounds annotation.
+   */
+  template<typename T, capptr_bounds bounds>
+  struct AtomicCapPtr
+  {
+    std::atomic<T*> unsafe_capptr;
+
+    /**
+     * nullptr is constructable at any bounds type
+     */
+    AtomicCapPtr(const std::nullptr_t n) : unsafe_capptr(n) {}
+
+    /**
+     * Interconversion with CapPtr
+     */
+    AtomicCapPtr(CapPtr<T, bounds> p) : unsafe_capptr(p.unsafe_capptr) {}
+
+    operator CapPtr<T, bounds>() const noexcept
+    {
+      return CapPtr<T, bounds>(this->unsafe_capptr);
+    }
+
+    // Our copy-assignment operator follows std::atomic and returns a copy of
+    // the RHS.  Clang finds this surprising; we suppress the warning.
+    // NOLINTNEXTLINE(misc-unconventional-assign-operator)
+    CapPtr<T, bounds> operator=(CapPtr<T, bounds> p) noexcept
+    {
+      this->store(p);
+      return p;
+    }
+
+    SNMALLOC_FAST_PATH CapPtr<T, bounds>
+    load(std::memory_order order = std::memory_order_seq_cst) noexcept
+    {
+      return CapPtr<T, bounds>(this->unsafe_capptr.load(order));
+    }
+
+    SNMALLOC_FAST_PATH void store(
+      CapPtr<T, bounds> desired,
+      std::memory_order order = std::memory_order_seq_cst) noexcept
+    {
+      this->unsafe_capptr.store(desired.unsafe_capptr, order);
+    }
+
+    SNMALLOC_FAST_PATH CapPtr<T, bounds> exchange(
+      CapPtr<T, bounds> desired,
+      std::memory_order order = std::memory_order_seq_cst) noexcept
+    {
+      return CapPtr<T, bounds>(
+        this->unsafe_capptr.exchange(desired.unsafe_capptr, order));
+    }
+
+    SNMALLOC_FAST_PATH bool operator==(const AtomicCapPtr& rhs) const
+    {
+      return this->unsafe_capptr == rhs.unsafe_capptr;
+    }
+
+    SNMALLOC_FAST_PATH bool operator!=(const AtomicCapPtr& rhs) const
+    {
+      return this->unsafe_capptr != rhs.unsafe_capptr;
+    }
+
+    SNMALLOC_FAST_PATH bool operator<(const AtomicCapPtr& rhs) const
+    {
+      return this->unsafe_capptr < rhs.unsafe_capptr;
+    }
+  };
+
+  template<typename T>
+  using AtomicCapPtrCBArena = AtomicCapPtr<T, CBArena>;
+
+  template<typename T>
+  using AtomicCapPtrCBChunk = AtomicCapPtr<T, CBChunk>;
+
+  template<typename T>
+  using AtomicCapPtrCBAlloc = AtomicCapPtr<T, CBAlloc>;
+
 } // namespace snmalloc

--- a/src/mem/address_space.h
+++ b/src/mem/address_space.h
@@ -103,8 +103,10 @@ namespace snmalloc
         CapPtr<void, CBChunk> bigger = remove_block(align_bits + 1);
         if (bigger != nullptr)
         {
-          auto left_over = pointer_offset(bigger, bits::one_at_bit(align_bits));
-          ranges[align_bits][0] = left_over;
+          size_t left_over_size = bits::one_at_bit(align_bits);
+          auto left_over = pointer_offset(bigger, left_over_size);
+          ranges[align_bits][0] =
+            Aal::capptr_bound<void, CBChunk>(left_over, left_over_size);
           check_block(left_over, align_bits);
         }
         check_block(bigger, align_bits + 1);

--- a/src/mem/address_space.h
+++ b/src/mem/address_space.h
@@ -35,7 +35,7 @@ namespace snmalloc
      * bits::BITS is used for simplicity, we do not use below the pointer size,
      * and large entries will be unlikely to be supported by the platform.
      */
-    std::array<std::array<CapPtr<void, CBArena>, 2>, bits::BITS> ranges = {};
+    std::array<std::array<CapPtr<void, CBChunk>, 2>, bits::BITS> ranges = {};
 
     /**
      * This is infrequently used code, a spin lock simplifies the code
@@ -46,7 +46,7 @@ namespace snmalloc
     /**
      * Checks a block satisfies its invariant.
      */
-    inline void check_block(CapPtr<void, CBArena> base, size_t align_bits)
+    inline void check_block(CapPtr<void, CBChunk> base, size_t align_bits)
     {
       SNMALLOC_ASSERT(
         base == pointer_align_up(base, bits::one_at_bit(align_bits)));
@@ -59,7 +59,7 @@ namespace snmalloc
     /**
      * Adds a block to `ranges`.
      */
-    void add_block(size_t align_bits, CapPtr<void, CBArena> base)
+    void add_block(size_t align_bits, CapPtr<void, CBChunk> base)
     {
       check_block(base, align_bits);
       SNMALLOC_ASSERT(align_bits < 64);
@@ -74,7 +74,7 @@ namespace snmalloc
       {
         // Add to linked list.
         commit_block(base, sizeof(void*));
-        *(base.template as_static<CapPtr<void, CBArena>>().unsafe_capptr) =
+        *(base.template as_static<CapPtr<void, CBChunk>>().unsafe_capptr) =
           ranges[align_bits][1];
         check_block(ranges[align_bits][1], align_bits);
       }
@@ -88,9 +88,9 @@ namespace snmalloc
      * Find a block of the correct size. May split larger blocks
      * to satisfy this request.
      */
-    CapPtr<void, CBArena> remove_block(size_t align_bits)
+    CapPtr<void, CBChunk> remove_block(size_t align_bits)
     {
-      CapPtr<void, CBArena> first = ranges[align_bits][0];
+      CapPtr<void, CBChunk> first = ranges[align_bits][0];
       if (first == nullptr)
       {
         if (align_bits == (bits::BITS - 1))
@@ -100,7 +100,7 @@ namespace snmalloc
         }
 
         // Look for larger block and split up recursively
-        CapPtr<void, CBArena> bigger = remove_block(align_bits + 1);
+        CapPtr<void, CBChunk> bigger = remove_block(align_bits + 1);
         if (bigger != nullptr)
         {
           auto left_over = pointer_offset(bigger, bits::one_at_bit(align_bits));
@@ -111,12 +111,12 @@ namespace snmalloc
         return bigger;
       }
 
-      CapPtr<void, CBArena> second = ranges[align_bits][1];
+      CapPtr<void, CBChunk> second = ranges[align_bits][1];
       if (second != nullptr)
       {
         commit_block(second, sizeof(void*));
         auto psecond =
-          second.template as_static<CapPtr<void, CBArena>>().unsafe_capptr;
+          second.template as_static<CapPtr<void, CBChunk>>().unsafe_capptr;
         auto next = *psecond;
         ranges[align_bits][1] = next;
         // Zero memory. Client assumes memory contains only zeros.
@@ -135,7 +135,7 @@ namespace snmalloc
      * Add a range of memory to the address space.
      * Divides blocks into power of two sizes with natural alignment
      */
-    void add_range(CapPtr<void, CBArena> base, size_t length)
+    void add_range(CapPtr<void, CBChunk> base, size_t length)
     {
       // Find the minimum set of maximally aligned blocks in this range.
       // Each block's alignment and size are equal.
@@ -157,7 +157,7 @@ namespace snmalloc
     /**
      * Commit a block of memory
      */
-    void commit_block(CapPtr<void, CBArena> base, size_t size)
+    void commit_block(CapPtr<void, CBChunk> base, size_t size)
     {
       // Rounding required for sub-page allocations.
       auto page_start = pointer_align_down<OS_PAGE_SIZE, char>(base);
@@ -180,7 +180,7 @@ namespace snmalloc
      * arena_map for use in subsequent amplification.
      */
     template<bool committed>
-    CapPtr<void, CBArena> reserve(size_t size, ArenaMap& arena_map)
+    CapPtr<void, CBChunk> reserve(size_t size, ArenaMap& arena_map)
     {
       SNMALLOC_ASSERT(bits::is_pow2(size));
       SNMALLOC_ASSERT(size >= sizeof(void*));
@@ -194,18 +194,18 @@ namespace snmalloc
         pal_supports<AlignedAllocation, PAL> && !aal_supports<StrictProvenance>)
       {
         if (size >= PAL::minimum_alloc_size)
-          return CapPtr<void, CBArena>(
+          return CapPtr<void, CBChunk>(
             PAL::template reserve_aligned<committed>(size));
       }
 
-      CapPtr<void, CBArena> res;
+      CapPtr<void, CBChunk> res;
       {
         FlagLock lock(spin_lock);
         res = remove_block(bits::next_pow2_bits(size));
         if (res == nullptr)
         {
           // Allocation failed ask OS for more memory
-          CapPtr<void, CBArena> block = nullptr;
+          CapPtr<void, CBChunk> block = nullptr;
           size_t block_size = 0;
           if constexpr (pal_supports<AlignedAllocation, PAL>)
           {
@@ -233,7 +233,10 @@ namespace snmalloc
 
             void* block_raw = PAL::template reserve_aligned<false>(block_size);
 
-            block = CapPtr<void, CBArena>(block_raw);
+            // It's a bit of a lie to convert without applying bounds, but the
+            // platform will have bounded block for us and it's better that the
+            // rest of our internals expect CBChunk bounds.
+            block = CapPtr<void, CBChunk>(block_raw);
 
             if constexpr (aal_supports<StrictProvenance>)
             {
@@ -254,7 +257,7 @@ namespace snmalloc
             // the PAL, and this could lead to suprious OOM.  This is
             // particularly bad if the PAL gives all the memory on first call.
             auto block_and_size = PAL::reserve_at_least(size * 2);
-            block = CapPtr<void, CBArena>(block_and_size.first);
+            block = CapPtr<void, CBChunk>(block_and_size.first);
             block_size = block_and_size.second;
 
             // Ensure block is pointer aligned.
@@ -294,7 +297,7 @@ namespace snmalloc
      * used, by smaller objects.
      */
     template<bool committed>
-    CapPtr<void, CBArena>
+    CapPtr<void, CBChunk>
     reserve_with_left_over(size_t size, ArenaMap& arena_map)
     {
       SNMALLOC_ASSERT(size >= sizeof(void*));
@@ -330,7 +333,7 @@ namespace snmalloc
      * Constructor that pre-initialises the address-space manager with a region
      * of memory.
      */
-    AddressSpaceManager(CapPtr<void, CBArena> base, size_t length)
+    AddressSpaceManager(CapPtr<void, CBChunk> base, size_t length)
     {
       add_range(base, length);
     }

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -955,9 +955,10 @@ namespace snmalloc
       if (super != nullptr)
         return super;
 
-      super =
-        reinterpret_cast<Superslab*>(large_allocator.template alloc<NoZero>(
-          0, SUPERSLAB_SIZE, SUPERSLAB_SIZE));
+      super = large_allocator
+                .template alloc<NoZero>(0, SUPERSLAB_SIZE, SUPERSLAB_SIZE)
+                .template as_reinterpret<Superslab>()
+                .unsafe_capptr;
 
       if (super == nullptr)
         return super;
@@ -1371,9 +1372,9 @@ namespace snmalloc
               sizeclass, rsize, size);
           });
         }
-        slab = CapPtr<void, CBArena>(large_allocator.template alloc<NoZero>(
-                                       0, SUPERSLAB_SIZE, SUPERSLAB_SIZE))
-                 .template as_static<Mediumslab>();
+        slab = large_allocator
+                 .template alloc<NoZero>(0, SUPERSLAB_SIZE, SUPERSLAB_SIZE)
+                 .template as_reinterpret<Mediumslab>();
 
         if (slab == nullptr)
           return nullptr;
@@ -1503,7 +1504,7 @@ namespace snmalloc
       if (large_class == 0)
         size = rsize;
 
-      void* p =
+      auto p =
         large_allocator.template alloc<zero_mem>(large_class, rsize, size);
       if (likely(p != nullptr))
       {
@@ -1512,7 +1513,7 @@ namespace snmalloc
         stats().alloc_request(size);
         stats().large_alloc(large_class);
       }
-      return p;
+      return p.unsafe_capptr;
     }
 
     void large_dealloc_unchecked(

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -218,7 +218,7 @@ namespace snmalloc
       constexpr sizeclass_t sizeclass = size_to_sizeclass_const(size);
 
       auto p_ret = CapPtr<void, CBAllocE>(p_raw);
-      auto p_auth = CapPtr<void, CBArena>(p_raw);
+      auto p_auth = large_allocator.capptr_amplify(p_ret);
 
       if (sizeclass < NUM_SMALL_CLASSES)
       {
@@ -252,7 +252,7 @@ namespace snmalloc
       SNMALLOC_ASSERT(p_raw != nullptr);
 
       auto p_ret = CapPtr<void, CBAllocE>(p_raw);
-      auto p_auth = CapPtr<void, CBArena>(p_raw);
+      auto p_auth = large_allocator.capptr_amplify(p_ret);
 
       if (likely((size - 1) <= (sizeclass_to_size(NUM_SMALL_CLASSES - 1) - 1)))
       {
@@ -295,7 +295,7 @@ namespace snmalloc
       uint8_t chunkmap_slab_kind = chunkmap().get(address_cast(p_raw));
 
       auto p_ret = CapPtr<void, CBAllocE>(p_raw);
-      auto p_auth = CapPtr<void, CBArena>(p_raw);
+      auto p_auth = large_allocator.capptr_amplify(p_ret);
 
       if (likely(chunkmap_slab_kind == CMSuperslab))
       {
@@ -370,7 +370,7 @@ namespace snmalloc
 #else
       uint8_t chunkmap_slab_kind = chunkmap().get(address_cast(p_raw));
       auto p_ret = CapPtr<void, CBAllocE>(p_raw);
-      auto p_auth = CapPtr<void, CBArena>(p_raw);
+      auto p_auth = large_allocator.capptr_amplify(p_ret);
 
       auto super = Superslab::get(p_auth);
       if (chunkmap_slab_kind == CMSuperslab)
@@ -450,7 +450,8 @@ namespace snmalloc
 #else
       // This must be called on an external pointer.
       size_t chunkmap_slab_kind = chunkmap().get(address_cast(p_raw));
-      auto p_auth = CapPtr<void, CBArena>(const_cast<void*>(p_raw));
+      auto p_ret = CapPtr<void, CBAllocE>(const_cast<void*>(p_raw));
+      auto p_auth = large_allocator.capptr_amplify(p_ret);
 
       if (likely(chunkmap_slab_kind == CMSuperslab))
       {

--- a/src/mem/arenamap.h
+++ b/src/mem/arenamap.h
@@ -1,0 +1,130 @@
+#include "../ds/ptrwrap.h"
+#include "pagemap.h"
+
+namespace snmalloc
+{
+  struct default_alloc_size_t
+  {
+    /*
+     * Just make something up for non-StrictProvenance architectures.
+     * Ultimately, this is going to flow only to FlatPagemap's template argument
+     * for the number of bits it's covering but the whole thing will be
+     * discarded by the time we resolve all the conditionals behind the
+     * AuthPagemap type.  To avoid pathologies where COVERED_BITS ends up being
+     * bit-width of the machine (meaning 1ULL << COVERED_BITS becomes undefined)
+     * and where sizeof(std::atomic<T>[ENTRIES]) is either undefined or
+     * enormous, we choose a value that dodges both endpoints and still results
+     * in a small table.
+     */
+    static constexpr size_t capptr_root_alloc_size =
+      bits::one_at_bit(bits::ADDRESS_BITS - 8);
+  };
+
+  /*
+   * Compute the block allocation size to use for AlignedAllocations.  This
+   * is either PAL::capptr_root_alloc_size, on architectures that require
+   * StrictProvenance, or the placeholder from above.
+   */
+  template<typename PAL>
+  static constexpr size_t AUTHMAP_ALLOC_SIZE = std::conditional_t<
+    aal_supports<StrictProvenance>,
+    PAL,
+    default_alloc_size_t>::capptr_root_alloc_size;
+
+  template<typename PAL>
+  static constexpr size_t
+    AUTHMAP_BITS = bits::next_pow2_bits_const(AUTHMAP_ALLOC_SIZE<PAL>);
+
+  template<typename PAL>
+  static constexpr bool
+    AUTHMAP_USE_FLATPAGEMAP = pal_supports<LazyCommit, PAL> ||
+    (PAGEMAP_NODE_SIZE >= sizeof(FlatPagemap<AUTHMAP_BITS<PAL>, void*>));
+
+  struct default_auth_pagemap
+  {
+    static SNMALLOC_FAST_PATH void* get(address_t a)
+    {
+      UNUSED(a);
+      return nullptr;
+    }
+  };
+
+  template<typename PAL, typename PrimAlloc>
+  using AuthPagemap = std::conditional_t<
+    aal_supports<StrictProvenance>,
+    std::conditional_t<
+      AUTHMAP_USE_FLATPAGEMAP<PAL>,
+      FlatPagemap<AUTHMAP_BITS<PAL>, void*>,
+      Pagemap<AUTHMAP_BITS<PAL>, void*, nullptr, PrimAlloc>>,
+    default_auth_pagemap>;
+
+  struct ForAuthmap
+  {};
+  template<typename PAL, typename PrimAlloc>
+  using GlobalAuthmap =
+    GlobalPagemapTemplate<AuthPagemap<PAL, PrimAlloc>, ForAuthmap>;
+
+  template<SNMALLOC_CONCEPT(ConceptPAL) PAL, typename PagemapProvider>
+  struct DefaultArenaMapTemplate
+  {
+    /*
+     * Without AlignedAllocation, we (below) adopt a fallback mechanism that
+     * over-allocates and then finds an aligned region within the too-large
+     * region.  The "trimmings" from either side are also registered in hopes
+     * that they can be used for later allocations.
+     *
+     * Unfortunately, that strategy does not work for this ArenaMap: trimmings
+     * may be smaller than the granularity of our backing PageMap, and so we
+     * would be unable to amplify authority.  Eventually we may arrive at a need
+     * for an ArenaMap that is compatible with this approach, but for the moment
+     * it's far simpler to assume that we can always ask for memory sufficiently
+     * aligned to cover an entire PageMap granule.
+     */
+    static_assert(
+      !aal_supports<StrictProvenance> || pal_supports<AlignedAllocation, PAL>,
+      "StrictProvenance requires platform support for aligned allocation");
+
+    static constexpr size_t alloc_size = AUTHMAP_ALLOC_SIZE<PAL>;
+
+    /*
+     * Because we assume that we can `capptr_amplify` and then
+     * `Superslab::get()` on the result to get to the Superslab metadata
+     * headers, it must be the case that provenance roots cover entire
+     * Superslabs.
+     */
+    static_assert(
+      !aal_supports<StrictProvenance> ||
+        ((alloc_size > 0) && (alloc_size % SUPERSLAB_SIZE == 0)),
+      "Provenance root granule must encompass whole superslabs");
+
+    static void register_root(CapPtr<void, CBArena> root)
+    {
+      if constexpr (aal_supports<StrictProvenance>)
+      {
+        PagemapProvider::pagemap().set(address_cast(root), root.unsafe_capptr);
+      }
+      else
+      {
+        UNUSED(root);
+      }
+    }
+
+    template<typename T = void, typename U, capptr_bounds B>
+    static SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
+    {
+      static_assert(
+        B == CBAllocE || B == CBAlloc,
+        "Attempting to amplify an unexpectedly high pointer");
+      return Aal::capptr_rebound(
+               CapPtr<void, CBArena>(
+                 PagemapProvider::pagemap().get(address_cast(r))),
+               r)
+        .template as_static<T>();
+    }
+  };
+
+  template<typename PAL, typename PrimAlloc>
+  using DefaultArenaMap =
+    DefaultArenaMapTemplate<PAL, GlobalAuthmap<PAL, PrimAlloc>>;
+
+} // namespace snmalloc

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -118,21 +118,21 @@ namespace snmalloc
      * Set a pagemap entry indicating that there is a superslab at the
      * specified index.
      */
-    static void set_slab(CapPtr<Superslab, CBArena> slab)
+    static void set_slab(CapPtr<Superslab, CBChunk> slab)
     {
       set(address_cast(slab), static_cast<size_t>(CMSuperslab));
     }
     /**
      * Add a pagemap entry indicating that a medium slab has been allocated.
      */
-    static void set_slab(CapPtr<Mediumslab, CBArena> slab)
+    static void set_slab(CapPtr<Mediumslab, CBChunk> slab)
     {
       set(address_cast(slab), static_cast<size_t>(CMMediumslab));
     }
     /**
      * Remove an entry from the pagemap corresponding to a superslab.
      */
-    static void clear_slab(CapPtr<Superslab, CBArena> slab)
+    static void clear_slab(CapPtr<Superslab, CBChunk> slab)
     {
       SNMALLOC_ASSERT(get(address_cast(slab)) == CMSuperslab);
       set(address_cast(slab), static_cast<size_t>(CMNotOurs));
@@ -140,7 +140,7 @@ namespace snmalloc
     /**
      * Remove an entry corresponding to a medium slab.
      */
-    static void clear_slab(CapPtr<Mediumslab, CBArena> slab)
+    static void clear_slab(CapPtr<Mediumslab, CBChunk> slab)
     {
       SNMALLOC_ASSERT(get(address_cast(slab)) == CMMediumslab);
       set(address_cast(slab), static_cast<size_t>(CMNotOurs));
@@ -149,7 +149,7 @@ namespace snmalloc
      * Update the pagemap to reflect a large allocation, of `size` bytes from
      * address `p`.
      */
-    static void set_large_size(CapPtr<Largeslab, CBArena> p, size_t size)
+    static void set_large_size(CapPtr<Largeslab, CBChunk> p, size_t size)
     {
       size_t size_bits = bits::next_pow2_bits(size);
       set(address_cast(p), static_cast<uint8_t>(size_bits));
@@ -167,7 +167,7 @@ namespace snmalloc
      * Update the pagemap to remove a large allocation, of `size` bytes from
      * address `p`.
      */
-    static void clear_large_size(CapPtr<void, CBArena> vp, size_t size)
+    static void clear_large_size(CapPtr<Largeslab, CBChunk> vp, size_t size)
     {
       auto p = address_cast(vp);
       size_t rounded_size = bits::next_pow2(size);

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -149,7 +149,7 @@ namespace snmalloc
      * Update the pagemap to reflect a large allocation, of `size` bytes from
      * address `p`.
      */
-    static void set_large_size(void* p, size_t size)
+    static void set_large_size(CapPtr<Largeslab, CBArena> p, size_t size)
     {
       size_t size_bits = bits::next_pow2_bits(size);
       set(address_cast(p), static_cast<uint8_t>(size_bits));

--- a/src/mem/chunkmap.h
+++ b/src/mem/chunkmap.h
@@ -115,43 +115,35 @@ namespace snmalloc
     }
 
     /**
-     * Get the pagemap entry corresponding to a specific address.
-     */
-    static uint8_t get(void* p)
-    {
-      return get(address_cast(p));
-    }
-
-    /**
      * Set a pagemap entry indicating that there is a superslab at the
      * specified index.
      */
-    static void set_slab(Superslab* slab)
+    static void set_slab(CapPtr<Superslab, CBArena> slab)
     {
-      set(slab, static_cast<size_t>(CMSuperslab));
+      set(address_cast(slab), static_cast<size_t>(CMSuperslab));
     }
     /**
      * Add a pagemap entry indicating that a medium slab has been allocated.
      */
-    static void set_slab(Mediumslab* slab)
+    static void set_slab(CapPtr<Mediumslab, CBArena> slab)
     {
-      set(slab, static_cast<size_t>(CMMediumslab));
+      set(address_cast(slab), static_cast<size_t>(CMMediumslab));
     }
     /**
      * Remove an entry from the pagemap corresponding to a superslab.
      */
-    static void clear_slab(Superslab* slab)
+    static void clear_slab(CapPtr<Superslab, CBArena> slab)
     {
-      SNMALLOC_ASSERT(get(slab) == CMSuperslab);
-      set(slab, static_cast<size_t>(CMNotOurs));
+      SNMALLOC_ASSERT(get(address_cast(slab)) == CMSuperslab);
+      set(address_cast(slab), static_cast<size_t>(CMNotOurs));
     }
     /**
      * Remove an entry corresponding to a medium slab.
      */
-    static void clear_slab(Mediumslab* slab)
+    static void clear_slab(CapPtr<Mediumslab, CBArena> slab)
     {
-      SNMALLOC_ASSERT(get(slab) == CMMediumslab);
-      set(slab, static_cast<size_t>(CMNotOurs));
+      SNMALLOC_ASSERT(get(address_cast(slab)) == CMMediumslab);
+      set(address_cast(slab), static_cast<size_t>(CMNotOurs));
     }
     /**
      * Update the pagemap to reflect a large allocation, of `size` bytes from
@@ -160,7 +152,7 @@ namespace snmalloc
     static void set_large_size(void* p, size_t size)
     {
       size_t size_bits = bits::next_pow2_bits(size);
-      set(p, static_cast<uint8_t>(size_bits));
+      set(address_cast(p), static_cast<uint8_t>(size_bits));
       // Set redirect slide
       auto ss = address_cast(p) + SUPERSLAB_SIZE;
       for (size_t i = 0; i < size_bits - SUPERSLAB_BITS; i++)
@@ -175,7 +167,7 @@ namespace snmalloc
      * Update the pagemap to remove a large allocation, of `size` bytes from
      * address `p`.
      */
-    static void clear_large_size(void* vp, size_t size)
+    static void clear_large_size(CapPtr<void, CBArena> vp, size_t size)
     {
       auto p = address_cast(vp);
       size_t rounded_size = bits::next_pow2(size);
@@ -190,9 +182,9 @@ namespace snmalloc
      * interface and exists to make it easy to reuse the code in the public
      * methods in other pagemap adaptors.
      */
-    static void set(void* p, uint8_t x)
+    static void set(address_t p, uint8_t x)
     {
-      PagemapProvider::pagemap().set(address_cast(p), x);
+      PagemapProvider::pagemap().set(p, x);
     }
   };
 

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -142,6 +142,15 @@ namespace snmalloc
     }
 
     /**
+     * Construct a FreeObject for local slabs from a Remote message.
+     */
+    static CapPtr<FreeObject, CBArena> make(CapPtr<Remote, CBArena> p)
+    {
+      // TODO: Zero the difference between a FreeObject and a Remote
+      return p.template as_reinterpret<FreeObject>();
+    }
+
+    /**
      * Read the next pointer handling any required decoding of the pointer
      */
     CapPtr<FreeObject, CBArena> read_next(uint16_t key, LocalEntropy& entropy)

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -325,7 +325,8 @@ namespace snmalloc
      * Start building a new free list.
      * Provide pointer to the slab to initialise the system.
      */
-    void open(CapPtr<void, CBArena> p)
+    template<capptr_bounds B> // TODO: CBChunk-only
+    void open(CapPtr<void, B> p)
     {
       SNMALLOC_ASSERT(empty());
       for (size_t i = 0; i < LENGTH; i++)

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -325,8 +325,7 @@ namespace snmalloc
      * Start building a new free list.
      * Provide pointer to the slab to initialise the system.
      */
-    template<capptr_bounds B> // TODO: CBChunk-only
-    void open(CapPtr<void, B> p)
+    void open(CapPtr<void, CBChunk> p)
     {
       SNMALLOC_ASSERT(empty());
       for (size_t i = 0; i < LENGTH; i++)

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -115,11 +115,11 @@ namespace snmalloc
      * class specified by `large_class`.  Always succeeds.
      */
     SNMALLOC_FAST_PATH void
-    push_large_stack(Largeslab* slab, size_t large_class)
+    push_large_stack(CapPtr<Largeslab, CBArena> slab, size_t large_class)
     {
       const size_t rsize = bits::one_at_bit(SUPERSLAB_BITS) << large_class;
       available_large_chunks_in_bytes += rsize;
-      large_stack[large_class].push(slab);
+      large_stack[large_class].push(slab.unsafe_capptr);
     }
 
     /**
@@ -342,7 +342,7 @@ namespace snmalloc
       return p;
     }
 
-    void dealloc(void* p, size_t large_class)
+    void dealloc(CapPtr<Largeslab, CBArena> p, size_t large_class)
     {
       if constexpr (decommit_strategy == DecommitSuperLazy)
       {
@@ -360,11 +360,11 @@ namespace snmalloc
         (large_class != 0 || decommit_strategy == DecommitSuper))
       {
         MemoryProvider::Pal::notify_not_using(
-          pointer_offset(p, OS_PAGE_SIZE), rsize - OS_PAGE_SIZE);
+          pointer_offset(p, OS_PAGE_SIZE).unsafe_capptr, rsize - OS_PAGE_SIZE);
       }
 
       stats.superslab_push();
-      memory_provider.push_large_stack(static_cast<Largeslab*>(p), large_class);
+      memory_provider.push_large_stack(p, large_class);
     }
   };
 

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -88,7 +88,7 @@ namespace snmalloc
     }
 
     template<ZeroMem zero_mem, SNMALLOC_CONCEPT(ConceptPAL) PAL>
-    static CapPtr<void, CBArena>
+    static CapPtr<void, CBAllocE>
     alloc(CapPtr<Mediumslab, CBArena> self, size_t size)
     {
       SNMALLOC_ASSERT(!full(self));
@@ -102,7 +102,7 @@ namespace snmalloc
       else
         UNUSED(size);
 
-      return p;
+      return capptr_export(Aal::capptr_bound<void, CBAlloc>(p, size));
     }
 
     static bool

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -122,7 +122,7 @@ namespace snmalloc
     }
 
     static bool
-    dealloc(CapPtr<Mediumslab, CBChunkD> self, CapPtr<void, CBArena> p)
+    dealloc(CapPtr<Mediumslab, CBChunkD> self, CapPtr<void, CBAlloc> p)
     {
       SNMALLOC_ASSERT(self->head > 0);
 

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -158,7 +158,7 @@ namespace snmalloc
      * `fast_free_list` for further allocations.
      */
     template<ZeroMem zero_mem, SNMALLOC_CONCEPT(ConceptPAL) PAL>
-    static SNMALLOC_FAST_PATH void* alloc(
+    static SNMALLOC_FAST_PATH CapPtr<void, CBArena> alloc(
       CapPtr<Metaslab, CBArena> self,
       FreeListIter& fast_free_list,
       size_t rsize,
@@ -194,7 +194,7 @@ namespace snmalloc
         UNUSED(rsize);
       }
 
-      return p;
+      return CapPtr<void, CBArena>(p);
     }
 
     void debug_slab_invariant(CapPtr<Slab, CBArena> slab, LocalEntropy& entropy)

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -176,8 +176,7 @@ namespace snmalloc
       self->remove();
       self->set_full(Metaslab::get_slab(n));
 
-      void* p =
-        remove_cache_friendly_offset(n.unsafe_capptr, self->sizeclass());
+      auto p = remove_cache_friendly_offset(n, self->sizeclass());
       SNMALLOC_ASSERT(is_start_of_object(self, address_cast(p)));
 
       self->debug_slab_invariant(Metaslab::get_slab(n), entropy);
@@ -194,7 +193,7 @@ namespace snmalloc
         UNUSED(rsize);
       }
 
-      return CapPtr<void, CBArena>(p);
+      return p;
     }
 
     void debug_slab_invariant(CapPtr<Slab, CBArena> slab, LocalEntropy& entropy)

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -158,7 +158,7 @@ namespace snmalloc
      * `fast_free_list` for further allocations.
      */
     template<ZeroMem zero_mem, SNMALLOC_CONCEPT(ConceptPAL) PAL>
-    static SNMALLOC_FAST_PATH CapPtr<void, CBArena> alloc(
+    static SNMALLOC_FAST_PATH CapPtr<void, CBAllocE> alloc(
       CapPtr<Metaslab, CBArena> self,
       FreeListIter& fast_free_list,
       size_t rsize,
@@ -193,7 +193,7 @@ namespace snmalloc
         UNUSED(rsize);
       }
 
-      return p;
+      return capptr_export(Aal::capptr_bound<void, CBAlloc>(p, rsize));
     }
 
     void debug_slab_invariant(CapPtr<Slab, CBArena> slab, LocalEntropy& entropy)

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -22,7 +22,7 @@ namespace snmalloc
   {
   private:
     friend Pooled<T>;
-    template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
+    template<SNMALLOC_CONCEPT(ConceptPAL) PAL, typename ArenaMap>
     friend class MemoryProviderStateMixin;
     friend SNMALLOC_DEFAULT_MEMORY_PROVIDER;
 

--- a/src/mem/ptrhelpers.h
+++ b/src/mem/ptrhelpers.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "../aal/aal.h"
+#include "../ds/ptrwrap.h"
+#include "allocconfig.h"
+
+namespace snmalloc
+{
+  /*
+   * At various points, we do pointer math on high-authority pointers to find
+   * some metadata.  `capptr_bound_chunkd` and `capptr_chunk_from_chunkd`
+   * encapsulate the notion that the result of these accesses is left unbounded
+   * in non-debug builds, because most codepaths do not reveal these pointers or
+   * any progeny to the application.  However, in some cases we have already
+   * (partially) bounded these high-authority pointers (to CBChunk) and wish to
+   * preserve this annotation (rather than always returning a CBChunkD-annotated
+   * pointer); `capptr_bound_chunkd_bounds` does the computation for us and is
+   * used in the signatures of below and in those of wrappers around them.
+   */
+
+  template<capptr_bounds B>
+  constexpr capptr_bounds capptr_bound_chunkd_bounds()
+  {
+    switch (B)
+    {
+      case CBArena:
+        return CBChunkD;
+      case CBChunkD:
+        return CBChunkD;
+      case CBChunk:
+        return CBChunk;
+    }
+  }
+
+  /**
+   * Construct an CapPtr<T, CBChunkD> from an CapPtr<T, CBArena> or
+   * CapPtr<T, CBChunkD> input.  For an CapPtr<T, CBChunk> input, simply pass
+   * it through (preserving the static notion of bounds).
+   *
+   * Applies bounds on debug builds, otherwise is just sleight of hand.
+   *
+   * Requires that `p` point at a multiple of `sz` (that is, at the base of a
+   * highly-aligned object) to avoid representability issues.
+   */
+  template<typename T, capptr_bounds B>
+  SNMALLOC_FAST_PATH CapPtr<T, capptr_bound_chunkd_bounds<B>()>
+  capptr_bound_chunkd(CapPtr<T, B> p, size_t sz)
+  {
+    static_assert(B == CBArena || B == CBChunkD || B == CBChunk);
+    SNMALLOC_ASSERT((address_cast(p) % sz) == 0);
+
+#ifndef NDEBUG
+    // On Debug builds, apply bounds if not already there
+    if constexpr (B == CBArena)
+      return Aal::capptr_bound<T, CBChunkD>(p, sz);
+    else // quiesce MSVC's warnings about unreachable code below
+#endif
+    {
+      UNUSED(sz);
+      return CapPtr<T, capptr_bound_chunkd_bounds<B>()>(p.unsafe_capptr);
+    }
+  }
+
+  /**
+   * Apply bounds that might not have been applied when constructing an
+   * CapPtr<T, CBChunkD>.  That is, on non-debug builds, apply bounds; debug
+   * builds have already had them applied.
+   *
+   * Requires that `p` point at a multiple of `sz` (that is, at the base of a
+   * highly-aligned object) to avoid representability issues.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH CapPtr<T, CBChunk>
+  capptr_chunk_from_chunkd(CapPtr<T, CBChunkD> p, size_t sz)
+  {
+    SNMALLOC_ASSERT((address_cast(p) % sz) == 0);
+
+#ifndef NDEBUG
+    // On debug builds, CBChunkD are already bounded as if CBChunk.
+    UNUSED(sz);
+    return CapPtr<T, CBChunk>(p.unsafe_capptr);
+#else
+    // On non-debug builds, apply bounds now, as they haven't been already.
+    return Aal::capptr_bound<T, CBChunk>(p, sz);
+#endif
+  }
+
+  /**
+   * Very rarely, while debugging, it's both useful and acceptable to forget
+   * that we have applied chunk bounds to something.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH CapPtr<T, CBChunkD>
+  capptr_debug_chunkd_from_chunk(CapPtr<T, CBChunk> p)
+  {
+    return CapPtr<T, CBChunkD>(p.unsafe_capptr);
+  }
+} // namespace snmalloc

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -18,8 +18,8 @@ namespace snmalloc
     using alloc_id_t = size_t;
     union
     {
-      CapPtr<Remote, CBArena> non_atomic_next;
-      AtomicCapPtr<Remote, CBArena> next{nullptr};
+      CapPtr<Remote, CBAlloc> non_atomic_next;
+      AtomicCapPtr<Remote, CBAlloc> next{nullptr};
     };
 
     /*
@@ -72,7 +72,7 @@ namespace snmalloc
     // Store the message queue on a separate cacheline. It is mutable data that
     // is read by other threads.
     alignas(CACHELINE_SIZE)
-      MPSCQ<Remote, CapPtrCBArena, AtomicCapPtrCBArena> message_queue;
+      MPSCQ<Remote, CapPtrCBAlloc, AtomicCapPtrCBAlloc> message_queue;
 
     alloc_id_t trunc_id()
     {

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -58,29 +58,31 @@ namespace snmalloc
     bits::ADDRESS_BITS - SUPERSLAB_BITS;
 
 #ifdef CACHE_FRIENDLY_OFFSET
-  SNMALLOC_FAST_PATH static void*
-  remove_cache_friendly_offset(void* p, sizeclass_t sizeclass)
+  template<typename T, capptr_bounds B>
+  SNMALLOC_FAST_PATH static CapPtr<void, B>
+  remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
   {
     size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
-    return p = (void*)((uintptr_t)p & mask);
+    return CapPtr<void, B>((void*)((uintptr_t)p.unsafe_capptr & mask));
   }
 
-  SNMALLOC_FAST_PATH static uintptr_t
-  remove_cache_friendly_offset(uintptr_t relative, sizeclass_t sizeclass)
+  SNMALLOC_FAST_PATH static address_t
+  remove_cache_friendly_offset(address_t relative, sizeclass_t sizeclass)
   {
     size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
     return relative & mask;
   }
 #else
-  SNMALLOC_FAST_PATH static void*
-  remove_cache_friendly_offset(void* p, sizeclass_t sizeclass)
+  template<typename T, capptr_bounds B>
+  SNMALLOC_FAST_PATH static CapPtr<void, B>
+  remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
   {
     UNUSED(sizeclass);
-    return p;
+    return p.as_void();
   }
 
-  SNMALLOC_FAST_PATH static uintptr_t
-  remove_cache_friendly_offset(uintptr_t relative, sizeclass_t sizeclass)
+  SNMALLOC_FAST_PATH static address_t
+  remove_cache_friendly_offset(address_t relative, sizeclass_t sizeclass)
   {
     UNUSED(sizeclass);
     return relative;

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -34,7 +34,7 @@ namespace snmalloc
      * page.
      */
     static SNMALLOC_FAST_PATH void alloc_new_list(
-      CapPtr<void, CBArena>& bumpptr,
+      CapPtr<void, CBChunk>& bumpptr,
       FreeListIter& fast_free_list,
       size_t rsize,
       LocalEntropy& entropy)
@@ -60,7 +60,7 @@ namespace snmalloc
 
       // Note the wide bounds on curr relative to each of the ->next fields;
       // curr is not persisted once the list is built.
-      CapPtr<PreAllocObject, CBArena> curr =
+      CapPtr<PreAllocObject, CBChunk> curr =
         pointer_offset(bumpptr, 0).template as_static<PreAllocObject>();
       curr->next = Aal::capptr_bound<PreAllocObject, CBAlloc>(curr, rsize);
 

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -70,6 +70,30 @@ namespace snmalloc
   static constexpr size_t OS_PAGE_SIZE = Pal::page_size;
 
   /**
+   * Perform platform-specific adjustment of return pointers.
+   *
+   * This is here, rather than in every PAL proper, merely to minimize
+   * disruption to PALs for platforms that do not support StrictProvenance AALs.
+   */
+  template<typename PAL = Pal, typename AAL = Aal, typename T, capptr_bounds B>
+  static SNMALLOC_FAST_PATH typename std::enable_if_t<
+    !aal_supports<StrictProvenance, AAL>,
+    CapPtr<T, capptr_export_type<B>()>>
+  capptr_export(CapPtr<T, B> p)
+  {
+    return CapPtr<T, capptr_export_type<B>()>(p.unsafe_capptr);
+  }
+
+  template<typename PAL = Pal, typename AAL = Aal, typename T, capptr_bounds B>
+  static SNMALLOC_FAST_PATH typename std::enable_if_t<
+    aal_supports<StrictProvenance, AAL>,
+    CapPtr<T, capptr_export_type<B>()>>
+  capptr_export(CapPtr<T, B> p)
+  {
+    return PAL::capptr_export(p);
+  }
+
+  /**
    * A convenience wrapper that avoids the need to litter unsafe accesses with
    * every call to PAL::zero.
    *

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -109,13 +109,6 @@ namespace snmalloc
     PAL::template zero<page_aligned>(p.unsafe_capptr, sz);
   }
 
-  // TODO: Remove once CapPtr<>s plumbed everywhere they need to be
-  template<typename PAL, bool page_aligned = false>
-  static SNMALLOC_FAST_PATH void pal_zero(void* p, size_t sz)
-  {
-    PAL::template zero<page_aligned>(p, sz);
-  }
-
   static_assert(
     bits::is_pow2(OS_PAGE_SIZE), "OS_PAGE_SIZE must be a power of two");
   static_assert(

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -40,7 +40,7 @@ int main()
   // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
   size_t large_class = 28 - SUPERSLAB_BITS;
   size_t size = bits::one_at_bit(SUPERSLAB_BITS + large_class);
-  void* oe_base = mp.reserve<true>(large_class);
+  void* oe_base = mp.reserve<true>(large_class).unsafe_capptr;
   void* oe_end = (uint8_t*)oe_base + size;
   PALOpenEnclave::setup_initial_range(oe_base, oe_end);
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -33,7 +33,9 @@ using namespace snmalloc;
 int main()
 {
 #ifndef SNMALLOC_PASS_THROUGH // Depends on snmalloc specific features
-  auto& mp = *MemoryProviderStateMixin<DefaultPal>::make();
+  auto& mp = *MemoryProviderStateMixin<
+    DefaultPal,
+    DefaultArenaMap<DefaultPal, DefaultPrimAlloc>>::make();
 
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -19,6 +19,8 @@ namespace
   /**
    * Helper for Alloc that is never used as a thread-local allocator and so is
    * always initialised.
+   *
+   * CapPtr-vs-MSVC triggering; xref CapPtr's constructor
    */
   bool never_init(void*)
   {
@@ -26,6 +28,8 @@ namespace
   }
   /**
    * Helper for Alloc that never needs lazy initialisation.
+   *
+   * CapPtr-vs-MSVC triggering; xref CapPtr's constructor
    */
   void* no_op_init(function_ref<void*(void*)>)
   {

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -86,7 +86,7 @@ namespace
        *
        * This method must be implemented for `LargeAlloc` to work.
        */
-      void push_large_stack(Largeslab* slab, size_t large_class)
+      void push_large_stack(CapPtr<Largeslab, CBArena> slab, size_t large_class)
       {
         real_state->push_large_stack(slab, large_class);
       }

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -75,7 +75,7 @@ namespace
        *
        * This method must be implemented for `LargeAlloc` to work.
        */
-      void* pop_large_stack(size_t large_class)
+      CapPtr<Largeslab, CBArena> pop_large_stack(size_t large_class)
       {
         return real_state->pop_large_stack(large_class);
       };
@@ -98,7 +98,7 @@ namespace
        * This method must be implemented for `LargeAlloc` to work.
        */
       template<bool committed>
-      void* reserve(size_t large_class) noexcept
+      CapPtr<Largeslab, CBArena> reserve(size_t large_class) noexcept
       {
         return real_state->template reserve<committed>(large_class);
       }
@@ -159,7 +159,7 @@ namespace
       top(pointer_offset(start, sb_size)),
       shared_state(new (start) SharedState()),
       state(
-        pointer_offset(start, sizeof(SharedState)),
+        pointer_offset(CapPtr<void, CBArena>(start), sizeof(SharedState)),
         sb_size - sizeof(SharedState)),
       alloc(state, SNMALLOC_DEFAULT_CHUNKMAP(), &shared_state->queue)
     {

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -113,7 +113,7 @@ namespace
        *
        * This method must be implemented for `LargeAlloc` to work.
        */
-      CapPtr<Largeslab, CBArena> pop_large_stack(size_t large_class)
+      CapPtr<Largeslab, CBChunk> pop_large_stack(size_t large_class)
       {
         return real_state->pop_large_stack(large_class);
       };
@@ -124,7 +124,7 @@ namespace
        *
        * This method must be implemented for `LargeAlloc` to work.
        */
-      void push_large_stack(CapPtr<Largeslab, CBArena> slab, size_t large_class)
+      void push_large_stack(CapPtr<Largeslab, CBChunk> slab, size_t large_class)
       {
         real_state->push_large_stack(slab, large_class);
       }
@@ -136,7 +136,7 @@ namespace
        * This method must be implemented for `LargeAlloc` to work.
        */
       template<bool committed>
-      CapPtr<Largeslab, CBArena> reserve(size_t large_class) noexcept
+      CapPtr<Largeslab, CBChunk> reserve(size_t large_class) noexcept
       {
         return real_state->template reserve<committed>(large_class);
       }
@@ -207,7 +207,7 @@ namespace
       top(pointer_offset(start, sb_size)),
       shared_state(new (start) SharedState()),
       state(
-        pointer_offset(CapPtr<void, CBArena>(start), sizeof(SharedState)),
+        pointer_offset(CapPtr<void, CBChunk>(start), sizeof(SharedState)),
         sb_size - sizeof(SharedState)),
       alloc(state, SNMALLOC_DEFAULT_CHUNKMAP(), &shared_state->queue)
     {

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -41,7 +41,10 @@ int main()
 {
   setup();
 
-  MemoryProviderStateMixin<DefaultPal> mp;
+  MemoryProviderStateMixin<
+    DefaultPal,
+    DefaultArenaMap<DefaultPal, DefaultPrimAlloc>>
+    mp;
 
   // 26 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -48,7 +48,7 @@ int main()
   // For 1MiB superslabs, SUPERSLAB_BITS + 2 is not big enough for the example.
   size_t large_class = 26 - SUPERSLAB_BITS;
   size_t size = bits::one_at_bit(SUPERSLAB_BITS + large_class);
-  void* oe_base = mp.reserve<true>(large_class);
+  void* oe_base = mp.reserve<true>(large_class).unsafe_capptr;
   void* oe_end = (uint8_t*)oe_base + size;
   oe_allocator_init(oe_base, oe_end);
   std::cout << "Allocated region " << oe_base << " - " << oe_end << std::endl;


### PR DESCRIPTION
Take.. I dunno, five? six?  This supersedes #267.  I have not yet actually seen this version through to completion -- that is, I haven't glued the CHERI AAL and CheriBSD PAL onto it, yet, but it's been sufficiently slow going that I don't want to delay any longer before getting initial reviews.

The most salient feature is that there's just one pointer wrapper type, now.  An `AuthPtr<T, bounds>` points at `T` and has an indicated static approximation of its bounds.  Those come in several flavours: arena (awesome power, use carefully), slab (generally 1M or 16M chunks, but perhaps larger as part of large allocations), and alloc (a single allocation), and additionally carry indication of whether the `VMMAP` permission has been stripped (more generally, any "platform constraints" the PAL wants to apply).  In the future, I expect to enlarge the taxonomy with a notion of "has had its contents zeroed" as well.

Despite this building on my box, I am quite, quite certain that CI will be unhappy.  This is also going to conflict with #294, which should go first.  Expect minor changes as the CHERIfication actually happens, but hopefully the static typing has caught most of it.