### PR TITLE
Bug fix for superslab meta-data

### DIFF
--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -32,8 +32,7 @@ namespace snmalloc
     static SNMALLOC_FAST_PATH void
     alloc_new_list(void*& bumpptr, FreeListIter& fast_free_list, size_t rsize)
     {
-      void* slab_end =
-        pointer_align_up<SLAB_SIZE>(pointer_offset(bumpptr, 1));
+      void* slab_end = pointer_align_up<SLAB_SIZE>(pointer_offset(bumpptr, 1));
 
       FreeListBuilder b;
       SNMALLOC_ASSERT(b.empty());

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -33,7 +33,7 @@ namespace snmalloc
     alloc_new_list(void*& bumpptr, FreeListIter& fast_free_list, size_t rsize)
     {
       void* slab_end =
-        pointer_align_up<SLAB_SIZE>(pointer_offset(bumpptr, rsize));
+        pointer_align_up<SLAB_SIZE>(pointer_offset(bumpptr, 1));
 
       FreeListBuilder b;
       SNMALLOC_ASSERT(b.empty());

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -5,6 +5,7 @@
 #include "metaslab.h"
 
 #include <new>
+#include <iostream>
 
 namespace snmalloc
 {
@@ -73,8 +74,10 @@ namespace snmalloc
 
     static bool is_short_sizeclass(sizeclass_t sizeclass)
     {
-      constexpr sizeclass_t h = size_to_sizeclass_const(sizeof(Superslab));
-      return sizeclass <= h;
+      static_assert(SLAB_SIZE > sizeof(Superslab), "Meta data requires this.");
+      // Note that h will be the next size class above the space, so use < in comparison.
+      constexpr sizeclass_t h = size_to_sizeclass_const(SLAB_SIZE - sizeof(Superslab));
+      return sizeclass < h;
     }
 
     void init(RemoteAllocator* alloc)

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -75,7 +75,13 @@ namespace snmalloc
     static bool is_short_sizeclass(sizeclass_t sizeclass)
     {
       static_assert(SLAB_SIZE > sizeof(Superslab), "Meta data requires this.");
-      // Note that h will be the next size class above the space, so use < in comparison.
+      /*
+       * size_to_sizeclass_const rounds *up* and returns the smallest class that
+       * could contain (and so may be larger than) the free space available for the
+       * short slab.  While we could detect the exact fit case and compare `<= h`
+       * therein, it's simpler to just treat this class as a strict upper bound and
+       * only permit strictly smaller classes in short slabs.
+       */
       constexpr sizeclass_t h = size_to_sizeclass_const(SLAB_SIZE - sizeof(Superslab));
       return sizeclass < h;
     }

--- a/src/test/measuretime.h
+++ b/src/test/measuretime.h
@@ -3,12 +3,19 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
-#define DO_TIME(name, code) \
-  { \
-    auto start__ = std::chrono::high_resolution_clock::now(); \
-    code auto finish__ = std::chrono::high_resolution_clock::now(); \
-    auto diff__ = finish__ - start__; \
-    std::cout << name << ": " << std::setw(12) << diff__.count() << " ns" \
-              << std::endl; \
+class MeasureTime : public std::stringstream
+{
+  std::chrono::time_point<std::chrono::high_resolution_clock> start =
+    std::chrono::high_resolution_clock::now();
+
+public:
+  ~MeasureTime()
+  {
+    auto finish = std::chrono::high_resolution_clock::now();
+    auto diff = finish - start;
+    std::cout << str() << ": " << std::setw(12) << diff.count() << " ns"
+              << std::endl;
   }
+};

--- a/src/test/perf/contention/contention.cc
+++ b/src/test/perf/contention/contention.cc
@@ -1,4 +1,3 @@
-#include "test/measuretime.h"
 #include "test/opt.h"
 #include "test/setup.h"
 #include "test/usage.h"

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -64,7 +64,9 @@ namespace test
 #endif
     setup(r, alloc);
 
-    DO_TIME("External pointer queries ", {
+    {
+      MeasureTime m;
+      m << "External pointer queries ";
       for (size_t i = 0; i < iterations; i++)
       {
         size_t rand = (size_t)r.next();
@@ -77,7 +79,7 @@ namespace test
         if (calced_external != external_ptr)
           abort();
       }
-    });
+    }
 
     teardown(alloc);
   }

--- a/src/test/perf/low_memory/low-memory.cc
+++ b/src/test/perf/low_memory/low-memory.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <snmalloc.h>
-#include <test/measuretime.h>
 #include <test/opt.h>
 #include <test/setup.h>
 #include <unordered_set>


### PR DESCRIPTION
If the metadata is made larger, then the calculation of which classes can use the "short slab" was incorrect.  In particular, if the meta data grows above half the size of a slab, then things go very wrong.  This alters that calculation.