### PR TITLE
Threshold freelist wakeup

### DIFF
--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -105,10 +105,12 @@ namespace snmalloc
 
           return super->dealloc_slab(self);
         }
-        SNMALLOC_ASSERT(meta.free_queue.empty());
-        meta.free_queue.open(p);
+
         meta.free_queue.add(p);
-        meta.needed() = allocated - 1;
+        //  Remove trigger threshold from how many we need before we have fully
+        //  freed the slab.
+        meta.needed() =
+          allocated - meta.threshold_for_waking_slab(Metaslab::is_short(self));
 
         // Push on the list of slabs for this sizeclass.
         sl->insert_prev(&meta);


### PR DESCRIPTION
When a slab has been fully allocated, then we no longer
check it has entries until something returns an allocation to this slab.
However, it is possible that only a single allocation is available, and
then we can end up frequently on the slow path.

This change only considers free lists that cover at least 1/8 of a slab.
This means that we will hit the slow path less frequently.  This also
means that the randomisation changes will have more entropy: with a
single element free list there is only one order.

For large small sizes it can still be a single element, as 1/8 is of the
slab capacity is below 1.