### PR TITLE
Further Randomisation

### DIFF
--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -55,6 +55,7 @@ namespace snmalloc
 
     SNMALLOC_FAST_PATH size_t clz(size_t x)
     {
+      SNMALLOC_ASSERT(x != 0); // Calling with 0 is UB on some implementations
 #if defined(_MSC_VER)
 #  ifdef USE_LZCNT
 #    ifdef SNMALLOC_VA_BITS_64
@@ -148,6 +149,8 @@ namespace snmalloc
 
     inline size_t ctz(size_t x)
     {
+      SNMALLOC_ASSERT(x != 0); // Calling with 0 is UB on some implementations
+
 #if defined(_MSC_VER)
 #  ifdef SNMALLOC_VA_BITS_64
       return _tzcnt_u64(x);
@@ -229,7 +232,9 @@ namespace snmalloc
     inline size_t next_pow2_bits(size_t x)
     {
       // Correct for numbers [1..MAX_SIZE].
-      // Returns 64 for 0. Approximately 2 cycles.
+      if (x == 1)
+        return 0;
+
       return BITS - clz(x - 1);
     }
 

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -55,7 +55,11 @@ namespace snmalloc
      *
      *  Spare 32bits are used for the fields in MetaslabEnd.
      */
-    FreeListBuilder<MetaslabEnd> free_queue;
+#ifdef CHECK_CLIENT
+    FreeListBuilder<true, MetaslabEnd> free_queue;
+#else
+    FreeListBuilder<false, MetaslabEnd> free_queue;
+#endif
 
     uint16_t& needed()
     {

--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -65,6 +65,10 @@ namespace snmalloc
           (bits::one_at_bit(bits::BITS - 1) / size[sizeclass]);
         if (!bits::is_pow2(size[sizeclass]))
           mod_mult[sizeclass]++;
+        // Shift multiplier, so that the result of division completely
+        // overflows, and thus the top SUPERSLAB_BITS will be zero if the mod is
+        // zero.
+        mod_mult[sizeclass] *= 2;
 
         if (sizeclass < NUM_SMALL_CLASSES)
         {
@@ -214,8 +218,8 @@ namespace snmalloc
       // square of the offset to be representable.
       static_assert(
         SUPERSLAB_BITS <= 24, "The following code assumes max of 24 bits");
-      static constexpr size_t MASK = (bits::one_at_bit(bits::BITS - 1) - 1) ^
-        (bits::one_at_bit(bits::BITS - 1 - SUPERSLAB_BITS) - 1);
+      static constexpr size_t MASK =
+        ~(bits::one_at_bit(bits::BITS - 1 - SUPERSLAB_BITS) - 1);
 
       return ((offset * sizeclass_metadata.mod_mult[sc]) & MASK) == 0;
     }

--- a/src/test/func/bits/bits.cc
+++ b/src/test/func/bits/bits.cc
@@ -2,8 +2,8 @@
  * Unit tests for operations in bits.h
  */
 
-#include <ds/bits.h>
 #include <iostream>
+#include <snmalloc.h>
 #include <test/setup.h>
 
 void test_ctz()


### PR DESCRIPTION
This PR implements the full randomisation of a small slab of allocations.  This uses an algorithm to build a random cycle in a slab, and then encodes that into the free list.  This provides a lot of entropy in the layout within a slab. 

The PR also refactors the FreeListBuilder, so it can be more compact and not introduce randomisation. This PR reestablishes the non-CHECK_CLIENT performance that was impacted by some of the randomisation code in previous PRs. 