### PR TITLE
CBAllocEW, capptr_dewild, capptr_from_client

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -156,6 +156,12 @@ namespace snmalloc
       UNUSED(a);
       return CapPtr<T, BOut>(r.unsafe_capptr);
     }
+
+    static SNMALLOC_FAST_PATH CapPtr<void, CBAllocE>
+    capptr_dewild(CapPtr<void, CBAllocEW> p) noexcept
+    {
+      return CapPtr<void, CBAllocE>(p.unsafe_capptr);
+    }
   };
 } // namespace snmalloc
 

--- a/src/aal/aal_concept.h
+++ b/src/aal/aal_concept.h
@@ -40,7 +40,7 @@ namespace snmalloc
   };
 
   template<typename AAL>
-  concept ConceptAAL_capptr_methods =
+  concept ConceptAAL_capptr_bounds =
   requires(CapPtr<void, CBArena> auth, CapPtr<void, CBAlloc> ret, size_t sz)
   {
     /**
@@ -59,11 +59,19 @@ namespace snmalloc
   };
 
   template<typename AAL>
+  concept ConceptAAL_capptr_dewild =
+  requires(CapPtr<void, CBAllocEW> w)
+  {
+    { AAL::capptr_dewild(w) } noexcept -> ConceptSame<CapPtr<void, CBAllocE>>;
+  };
+
+  template<typename AAL>
   concept ConceptAAL =
     ConceptAAL_static_members<AAL> &&
     ConceptAAL_prefetch<AAL> &&
     ConceptAAL_tick<AAL> &&
-    ConceptAAL_capptr_methods<AAL>;
+    ConceptAAL_capptr_bounds<AAL> &&
+    ConceptAAL_capptr_dewild<AAL>;
 
 } // namespace snmalloc
 #endif

--- a/src/ds/ptrwrap.h
+++ b/src/ds/ptrwrap.h
@@ -50,7 +50,8 @@ namespace snmalloc
     CBChunk, /*        Chunk                                              */
     CBChunkE, /*       Chunk   (+ platform constraints)                   */
     CBAlloc, /*        Alloc                                              */
-    CBAllocE /*        Alloc   (+ platform constraints)                   */
+    CBAllocE, /*       Alloc   (+ platform constraints)                   */
+    CBAllocEW /*       Alloc,  (+ E, might be "Wild"/forged)              */
   };
 
   /**
@@ -211,6 +212,14 @@ namespace snmalloc
   SNMALLOC_FAST_PATH void* capptr_reveal(CapPtr<void, CBAllocE> p)
   {
     return p.unsafe_capptr;
+  }
+
+  /**
+   * Dually, given a void* from the client, it's fine to call it CBAllocEW.
+   */
+  SNMALLOC_FAST_PATH CapPtr<void, CBAllocEW> capptr_from_client(void* p)
+  {
+    return CapPtr<void, CBAllocEW>(p);
   }
 
   /**

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -304,6 +304,12 @@ namespace snmalloc
       return arena_map.template capptr_amplify<T, U, B>(r);
     }
 
+    template<typename T>
+    SNMALLOC_FAST_PATH CapPtr<T, CBAllocE> capptr_dewild(CapPtr<T, CBAllocEW> p)
+    {
+      return Aal::capptr_dewild(p);
+    }
+
     ArenaMap& arenamap()
     {
       return arena_map;
@@ -410,6 +416,12 @@ namespace snmalloc
     SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
     {
       return memory_provider.template capptr_amplify<T, U, B>(r);
+    }
+
+    template<typename T>
+    SNMALLOC_FAST_PATH CapPtr<T, CBAllocE> capptr_dewild(CapPtr<T, CBAllocEW> p)
+    {
+      return memory_provider.capptr_dewild(p);
     }
   };
 

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -74,6 +74,35 @@ namespace
     using NoOpMemoryProvider = MemoryProviderStateMixin<NoOpPal, ArenaMap>;
 
     /**
+     * A NoOpMemoryProvider that additionally dewilds pointers by testing
+     * whether they are in the sandbox region.  This will be used by
+     * ExternalAlloc-s but not by the InternalAlloc-s, which are presumed never
+     * to hold out-of-sandbox memory.
+     */
+    struct ExternalMemoryProvider : public NoOpMemoryProvider
+    {
+      const address_t arena_addr;
+      const address_t arena_end;
+
+      ExternalMemoryProvider(CapPtr<void, CBChunk> start, size_t len)
+      : NoOpMemoryProvider(start, len),
+        arena_addr(address_cast(start)),
+        arena_end(arena_addr + len)
+      {}
+
+      template<typename T>
+      SNMALLOC_FAST_PATH CapPtr<T, CBAllocE>
+      capptr_dewild(CapPtr<T, CBAllocEW> p)
+      {
+        address_t a = address_cast(p);
+        if ((arena_addr <= a) && (a < arena_end))
+          return Aal::capptr_dewild(p);
+        else
+          return nullptr;
+      }
+    };
+
+    /**
      * Type for the allocator that lives outside of the sandbox and allocates
      * sandbox-owned memory.
      * This Allocator, by virtue of having its amplification confined to
@@ -84,7 +113,7 @@ namespace
     using ExternalAlloc = Allocator<
       never_init,
       no_op_init,
-      NoOpMemoryProvider,
+      ExternalMemoryProvider,
       SNMALLOC_DEFAULT_CHUNKMAP,
       false>;
     /**
@@ -187,7 +216,10 @@ namespace
     /**
      * The memory provider for this sandbox.
      */
-    NoOpMemoryProvider state;
+    ExternalMemoryProvider extstate;
+
+    /* extstate, but upcast to change static dispatch */
+    NoOpMemoryProvider *state;
 
     /**
      * The allocator for callers outside the sandbox to allocate memory inside.
@@ -206,17 +238,18 @@ namespace
     : start(alloc_sandbox_heap(sb_size)),
       top(pointer_offset(start, sb_size)),
       shared_state(new (start) SharedState()),
-      state(
+      extstate(
         pointer_offset(CapPtr<void, CBChunk>(start), sizeof(SharedState)),
         sb_size - sizeof(SharedState)),
-      alloc(state, SNMALLOC_DEFAULT_CHUNKMAP(), &shared_state->queue)
+      state(&extstate),
+      alloc(extstate, SNMALLOC_DEFAULT_CHUNKMAP(), &shared_state->queue)
     {
       // Register the sandbox memory with the sandbox arenamap
-      state.arenamap().arena_root = CapPtr<void, CBArena>(start);
+      state->arenamap().arena_root = CapPtr<void, CBArena>(start);
 
       auto* state_proxy = static_cast<MemoryProviderProxy*>(
         alloc.alloc(sizeof(MemoryProviderProxy)));
-      state_proxy->real_state = &state;
+      state_proxy->real_state = state;
       // In real code, allocators should never be constructed like this, they
       // should always come from an alloc pool.  This is just to test that both
       // kinds of allocator can be created.
@@ -225,15 +258,6 @@ namespace
     }
 
     Sandbox() = delete;
-
-    /**
-     * Predicate function for querying whether an object is entirely within the
-     * sandbox.
-     */
-    bool is_in_sandbox(void* ptr, size_t sz)
-    {
-      return (ptr >= start) && (pointer_offset(ptr, sz) < top);
-    }
 
     /**
      * Predicate function for querying whether an object is entirely within the


### PR DESCRIPTION
Introduce a notion of (nominally) allocation-bounded and exported but possibly
"wild" pointers.  These may be forged by clients and so must be validated before
they may be used as CBAllocE pointers.

capptr_dewild is a largealloc/ASM/AAL hook chain for this kind of validation.
On our sandbox test, for example, we want the "ExternalAlloc" to validate that
pointers are to within sandbox memory (which we do in the ASM).  On CHERI, we
will want to check the tag and in-bounds-ness of of any capability (and, in a
CHERI sandbox, also that it is within the sandbox region).

capptr_from_client is merely a nice bit of syntax around the CapPtr ctor.