### PR TITLE
CapPtr taxonomy changes

### DIFF
--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -129,27 +129,28 @@ namespace snmalloc
      */
     template<
       typename T,
-      enum capptr_bounds nbounds,
-      enum capptr_bounds obounds,
+      SNMALLOC_CONCEPT(capptr_bounds::c) BOut,
+      SNMALLOC_CONCEPT(capptr_bounds::c) BIn,
       typename U = T>
-    static SNMALLOC_FAST_PATH CapPtr<T, nbounds>
-    capptr_bound(CapPtr<U, obounds> a, size_t size) noexcept
+    static SNMALLOC_FAST_PATH CapPtr<T, BOut>
+    capptr_bound(CapPtr<U, BIn> a, size_t size) noexcept
     {
       // Impose constraints on bounds annotations.
-      static_assert(
-        obounds == CBArena || obounds == CBChunkD || obounds == CBChunk ||
-        obounds == CBChunkE);
-      static_assert(capptr_is_bounds_refinement<obounds, nbounds>());
+      static_assert(BIn::spatial >= capptr_bounds::spatial::Chunk);
+      static_assert(capptr_is_spatial_refinement<BIn, BOut>());
 
       UNUSED(size);
-      return CapPtr<T, nbounds>(a.template as_static<T>().unsafe_capptr);
+      return CapPtr<T, BOut>(a.template as_static<T>().unsafe_capptr);
     }
 
     /**
      * For architectures which do not enforce StrictProvenance, there's nothing
      * to be done, so just return the pointer unmodified with new annotation.
      */
-    template<typename T, capptr_bounds BOut, capptr_bounds BIn>
+    template<
+      typename T,
+      SNMALLOC_CONCEPT(capptr_bounds::c) BOut,
+      SNMALLOC_CONCEPT(capptr_bounds::c) BIn>
     static SNMALLOC_FAST_PATH CapPtr<T, BOut>
     capptr_rebound(CapPtr<void, BOut> a, CapPtr<T, BIn> r) noexcept
     {

--- a/src/aal/aal.h
+++ b/src/aal/aal.h
@@ -154,8 +154,16 @@ namespace snmalloc
     static SNMALLOC_FAST_PATH CapPtr<T, BOut>
     capptr_rebound(CapPtr<void, BOut> a, CapPtr<T, BIn> r) noexcept
     {
+      static_assert(BIn::wild == capptr_bounds::wild::Checked);
+
       UNUSED(a);
       return CapPtr<T, BOut>(r.unsafe_capptr);
+    }
+
+    static SNMALLOC_FAST_PATH CapPtr<void, CBAllocE>
+    capptr_dewild(CapPtr<void, CBAllocEW> p) noexcept
+    {
+      return CapPtr<void, CBAllocE>(p.unsafe_capptr);
     }
   };
 } // namespace snmalloc

--- a/src/aal/aal_concept.h
+++ b/src/aal/aal_concept.h
@@ -40,7 +40,7 @@ namespace snmalloc
   };
 
   template<typename AAL>
-  concept ConceptAAL_capptr_methods =
+  concept ConceptAAL_capptr_bounds =
   requires(CapPtr<void, CBArena> auth, CapPtr<void, CBAlloc> ret, size_t sz)
   {
     /**
@@ -59,11 +59,19 @@ namespace snmalloc
   };
 
   template<typename AAL>
+  concept ConceptAAL_capptr_dewild =
+  requires(CapPtr<void, CBAllocEW> w)
+  {
+    { AAL::capptr_dewild(w) } noexcept -> ConceptSame<CapPtr<void, CBAllocE>>;
+  };
+
+  template<typename AAL>
   concept ConceptAAL =
     ConceptAAL_static_members<AAL> &&
     ConceptAAL_prefetch<AAL> &&
     ConceptAAL_tick<AAL> &&
-    ConceptAAL_capptr_methods<AAL>;
+    ConceptAAL_capptr_bounds<AAL> &&
+    ConceptAAL_capptr_dewild<AAL>;
 
 } // namespace snmalloc
 #endif

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -25,7 +25,7 @@ namespace snmalloc
     return reinterpret_cast<U*>(reinterpret_cast<char*>(base) + diff);
   }
 
-  template<enum capptr_bounds bounds, typename T>
+  template<SNMALLOC_CONCEPT(capptr_bounds::c) bounds, typename T>
   inline CapPtr<void, bounds>
   pointer_offset(CapPtr<T, bounds> base, size_t diff)
   {
@@ -41,7 +41,7 @@ namespace snmalloc
     return reinterpret_cast<U*>(reinterpret_cast<char*>(base) + diff);
   }
 
-  template<enum capptr_bounds bounds, typename T>
+  template<SNMALLOC_CONCEPT(capptr_bounds::c) bounds, typename T>
   inline CapPtr<void, bounds>
   pointer_offset_signed(CapPtr<T, bounds> base, ptrdiff_t diff)
   {
@@ -66,7 +66,7 @@ namespace snmalloc
    * capptr_bound.
    */
 
-  template<typename T, enum capptr_bounds bounds>
+  template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) bounds>
   inline address_t address_cast(CapPtr<T, bounds> a)
   {
     return address_cast(a.unsafe_capptr);
@@ -112,7 +112,10 @@ namespace snmalloc
     }
   }
 
-  template<size_t alignment, typename T, capptr_bounds bounds>
+  template<
+    size_t alignment,
+    typename T,
+    SNMALLOC_CONCEPT(capptr_bounds::c) bounds>
   inline CapPtr<T, bounds> pointer_align_down(CapPtr<void, bounds> p)
   {
     return CapPtr<T, bounds>(pointer_align_down<alignment, T>(p.unsafe_capptr));
@@ -146,7 +149,10 @@ namespace snmalloc
     }
   }
 
-  template<size_t alignment, typename T = void, enum capptr_bounds bounds>
+  template<
+    size_t alignment,
+    typename T = void,
+    SNMALLOC_CONCEPT(capptr_bounds::c) bounds>
   inline CapPtr<T, bounds> pointer_align_up(CapPtr<void, bounds> p)
   {
     return CapPtr<T, bounds>(pointer_align_up<alignment, T>(p.unsafe_capptr));
@@ -192,7 +198,7 @@ namespace snmalloc
 #endif
   }
 
-  template<typename T = void, enum capptr_bounds bounds>
+  template<typename T = void, SNMALLOC_CONCEPT(capptr_bounds::c) bounds>
   inline CapPtr<T, bounds>
   pointer_align_up(CapPtr<void, bounds> p, size_t alignment)
   {
@@ -214,8 +220,8 @@ namespace snmalloc
   template<
     typename T = void,
     typename U = void,
-    enum capptr_bounds Tbounds,
-    enum capptr_bounds Ubounds>
+    SNMALLOC_CONCEPT(capptr_bounds::c) Tbounds,
+    SNMALLOC_CONCEPT(capptr_bounds::c) Ubounds>
   inline size_t pointer_diff(CapPtr<T, Tbounds> base, CapPtr<U, Ubounds> cursor)
   {
     return pointer_diff(base.unsafe_capptr, cursor.unsafe_capptr);
@@ -234,8 +240,8 @@ namespace snmalloc
   template<
     typename T = void,
     typename U = void,
-    enum capptr_bounds Tbounds,
-    enum capptr_bounds Ubounds>
+    SNMALLOC_CONCEPT(capptr_bounds::c) Tbounds,
+    SNMALLOC_CONCEPT(capptr_bounds::c) Ubounds>
   inline ptrdiff_t
   pointer_diff_signed(CapPtr<T, Tbounds> base, CapPtr<U, Ubounds> cursor)
   {

--- a/src/ds/concept.h
+++ b/src/ds/concept.h
@@ -34,9 +34,15 @@ namespace snmalloc
    */
   template<typename T, typename U>
   concept ConceptSame = std::same_as<T, U>;
+
+  template<typename D, typename B>
+  concept ConceptSubtype = std::derived_from<D, B>;
 #  else
   template<typename T, typename U>
   concept ConceptSame = std::is_same<T, U>::value;
+
+  template<typename D, typename B>
+  concept ConceptSubtype = std::is_base_of<B, D>::value;
 #  endif
 } // namespace snmalloc
 #endif

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -651,7 +651,7 @@ namespace snmalloc
 #ifdef CACHE_FRIENDLY_OFFSET
     size_t remote_offset = 0;
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     CapPtr<FreeObject, B>
     apply_cache_friendly_offset(CapPtr<void, B> p, sizeclass_t sizeclass)
     {
@@ -664,7 +664,7 @@ namespace snmalloc
         reinterpret_cast<uintptr_t>(p.unsafe_capptr) + offset));
     }
 #else
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static CapPtr<FreeObject, B>
     apply_cache_friendly_offset(CapPtr<void, B> p, sizeclass_t sizeclass)
     {

--- a/src/mem/arenamap.h
+++ b/src/mem/arenamap.h
@@ -109,12 +109,16 @@ namespace snmalloc
       }
     }
 
-    template<typename T = void, typename U, capptr_bounds B>
+    template<
+      typename T = void,
+      typename U,
+      SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
     {
       static_assert(
-        B == CBAllocE || B == CBAlloc,
+        B::spatial == capptr_bounds::spatial::Alloc,
         "Attempting to amplify an unexpectedly high pointer");
+
       return Aal::capptr_rebound(
                CapPtr<void, CBArena>(
                  PagemapProvider::pagemap().get(address_cast(r))),

--- a/src/mem/arenamap.h
+++ b/src/mem/arenamap.h
@@ -118,6 +118,9 @@ namespace snmalloc
       static_assert(
         B::spatial == capptr_bounds::spatial::Alloc,
         "Attempting to amplify an unexpectedly high pointer");
+      static_assert(
+        B::wild == capptr_bounds::wild::Checked,
+        "Attempting to amplify a wild pointer");
 
       return Aal::capptr_rebound(
                CapPtr<void, CBArena>(

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -23,7 +23,7 @@ namespace snmalloc
    * Used to turn a location into a key.  This is currently
    * just the slab address truncated to 16bits and offset by 1.
    */
-  template<typename T, capptr_bounds B>
+  template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) B>
   inline static address_t initial_key(CapPtr<T, B> slab)
   {
 #ifdef CHECK_CLIENT

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -298,7 +298,7 @@ namespace snmalloc
       return {peak - avail, peak};
     }
 
-    template<typename T, typename U, capptr_bounds B>
+    template<typename T, typename U, SNMALLOC_CONCEPT(capptr_bounds::c) B>
     SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
     {
       return arena_map.template capptr_amplify<T, U, B>(r);
@@ -406,7 +406,10 @@ namespace snmalloc
       memory_provider.push_large_stack(p, large_class);
     }
 
-    template<typename T = void, typename U, capptr_bounds B>
+    template<
+      typename T = void,
+      typename U,
+      SNMALLOC_CONCEPT(capptr_bounds::c) B>
     SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
     {
       return memory_provider.template capptr_amplify<T, U, B>(r);

--- a/src/mem/largealloc.h
+++ b/src/mem/largealloc.h
@@ -304,6 +304,12 @@ namespace snmalloc
       return arena_map.template capptr_amplify<T, U, B>(r);
     }
 
+    template<typename T>
+    SNMALLOC_FAST_PATH CapPtr<T, CBAllocE> capptr_dewild(CapPtr<T, CBAllocEW> p)
+    {
+      return Aal::capptr_dewild(p);
+    }
+
     ArenaMap& arenamap()
     {
       return arena_map;
@@ -413,6 +419,12 @@ namespace snmalloc
     SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
     {
       return memory_provider.template capptr_amplify<T, U, B>(r);
+    }
+
+    template<typename T>
+    SNMALLOC_FAST_PATH CapPtr<T, CBAllocE> capptr_dewild(CapPtr<T, CBAllocEW> p)
+    {
+      return memory_provider.capptr_dewild(p);
     }
   };
 

--- a/src/mem/mediumslab.h
+++ b/src/mem/mediumslab.h
@@ -134,13 +134,13 @@ namespace snmalloc
       return was_full;
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static bool full(CapPtr<Mediumslab, B> self)
     {
       return self->free == 0;
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static bool empty(CapPtr<Mediumslab, B> self)
     {
       return self->head == 0;

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -121,10 +121,13 @@ namespace snmalloc
       return bits::min(threshold, max);
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     SNMALLOC_FAST_PATH void set_full(CapPtr<Slab, B> slab)
     {
-      static_assert(B == CBChunkD || B == CBChunk);
+      static_assert(
+        B::spatial == capptr_bounds::spatial::ChunkD ||
+        B::spatial == capptr_bounds::spatial::Chunk);
+
       SNMALLOC_ASSERT(free_queue.empty());
 
       // Prepare for the next free queue to be built.
@@ -136,23 +139,23 @@ namespace snmalloc
       null_prev();
     }
 
-    template<typename T, capptr_bounds B>
-    static SNMALLOC_FAST_PATH CapPtr<Slab, capptr_bound_chunkd_bounds<B>()>
+    template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) B>
+    static SNMALLOC_FAST_PATH CapPtr<Slab, capptr_bound_chunkd_bounds<B>>
     get_slab(CapPtr<T, B> p)
     {
-      static_assert(B == CBArena || B == CBChunkD || B == CBChunk);
+      static_assert(B::spatial >= capptr_bounds::spatial::Chunk);
 
       return capptr_bound_chunkd(
         pointer_align_down<SLAB_SIZE, Slab>(p.as_void()), SLAB_SIZE);
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static bool is_short(CapPtr<Slab, B> p)
     {
       return pointer_align_down<SUPERSLAB_SIZE, Slab>(p.as_void()) == p;
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     SNMALLOC_FAST_PATH static bool
     is_start_of_object(CapPtr<Metaslab, B> self, address_t p)
     {
@@ -206,10 +209,12 @@ namespace snmalloc
       return capptr_export(p);
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     void debug_slab_invariant(CapPtr<Slab, B> slab, LocalEntropy& entropy)
     {
-      static_assert(B == CBChunkD || B == CBChunk);
+      static_assert(
+        B::spatial == capptr_bounds::spatial::ChunkD ||
+        B::spatial == capptr_bounds::spatial::Chunk);
 
 #if !defined(NDEBUG) && !defined(SNMALLOC_CHEAP_CHECKS)
       bool is_short = Metaslab::is_short(slab);

--- a/src/mem/ptrhelpers.h
+++ b/src/mem/ptrhelpers.h
@@ -40,6 +40,7 @@ namespace snmalloc
   {
     static_assert(B::spatial >= capptr_bounds::spatial::Chunk);
     static_assert(B::platform == capptr_bounds::platform::High);
+    static_assert(B::wild == capptr_bounds::wild::Checked);
 
     SNMALLOC_ASSERT((address_cast(p) % sz) == 0);
 

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -53,7 +53,7 @@ namespace snmalloc
     }
 
     /** Zero out a Remote tracking structure, return pointer to object base */
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     SNMALLOC_FAST_PATH static CapPtr<void, B>
     clear(CapPtr<Remote, B> self, sizeclass_t sizeclass)
     {

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -58,7 +58,7 @@ namespace snmalloc
     bits::ADDRESS_BITS - SUPERSLAB_BITS;
 
 #ifdef CACHE_FRIENDLY_OFFSET
-  template<typename T, capptr_bounds B>
+  template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) B>
   SNMALLOC_FAST_PATH static CapPtr<void, B>
   remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
   {
@@ -73,7 +73,7 @@ namespace snmalloc
     return relative & mask;
   }
 #else
-  template<typename T, capptr_bounds B>
+  template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) B>
   SNMALLOC_FAST_PATH static CapPtr<void, B>
   remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
   {

--- a/src/mem/slab.h
+++ b/src/mem/slab.h
@@ -18,10 +18,10 @@ namespace snmalloc
     }
 
   public:
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     static CapPtr<Metaslab, B> get_meta(CapPtr<Slab, B> self)
     {
-      static_assert(B == CBArena || B == CBChunkD || B == CBChunk);
+      static_assert(B::spatial >= capptr_bounds::spatial::Chunk);
 
       auto super = Superslab::get(self);
       return super->get_meta(self);

--- a/src/mem/superslab.h
+++ b/src/mem/superslab.h
@@ -59,7 +59,7 @@ namespace snmalloc
     ModArray<SLAB_COUNT, Metaslab> meta;
 
     // Used size_t as results in better code in MSVC
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     size_t slab_to_index(CapPtr<Slab, B> slab)
     {
       auto res = (pointer_diff(this, slab.unsafe_capptr) >> SLAB_BITS);
@@ -92,11 +92,11 @@ namespace snmalloc
      * return a highly-privileged pointer (i.e., CBArena) instead as these
      * pointers are not exposed from the allocator.
      */
-    template<typename T, capptr_bounds B>
-    static SNMALLOC_FAST_PATH CapPtr<Superslab, capptr_bound_chunkd_bounds<B>()>
+    template<typename T, SNMALLOC_CONCEPT(capptr_bounds::c) B>
+    static SNMALLOC_FAST_PATH CapPtr<Superslab, capptr_bound_chunkd_bounds<B>>
     get(CapPtr<T, B> p)
     {
-      static_assert(B == CBArena || B == CBChunkD || B == CBChunk);
+      static_assert(B::spatial >= capptr_bounds::spatial::Chunk);
 
       return capptr_bound_chunkd(
         pointer_align_down<SUPERSLAB_SIZE, Superslab>(p.as_void()),
@@ -195,7 +195,7 @@ namespace snmalloc
       return Full;
     }
 
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     CapPtr<Metaslab, B> get_meta(CapPtr<Slab, B> slab)
     {
       return CapPtr<Metaslab, B>(&meta[slab_to_index(slab)]);
@@ -235,10 +235,10 @@ namespace snmalloc
     }
 
     // Returns true, if this alters the value of get_status
-    template<capptr_bounds B>
+    template<SNMALLOC_CONCEPT(capptr_bounds::c) B>
     Action dealloc_slab(CapPtr<Slab, B> slab)
     {
-      static_assert(B == CBArena || B == CBChunkD || B == CBChunk);
+      static_assert(B::spatial >= capptr_bounds::spatial::Chunk);
 
       // This is not the short slab.
       uint8_t index = static_cast<uint8_t>(slab_to_index(slab));

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -54,7 +54,10 @@ namespace
       /**
        * Amplify using arena_root; that is, exclusively within the sandbox.
        */
-      template<typename T = void, typename U, capptr_bounds B>
+      template<
+        typename T = void,
+        typename U,
+        SNMALLOC_CONCEPT(capptr_bounds::c) B>
       SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
       {
         return Aal::capptr_rebound<T>(arena_root, r);
@@ -145,7 +148,10 @@ namespace
        * Amplify by appealing to the real_state, which has our sandbox
        * ArenaMap implementation.
        */
-      template<typename T = void, typename U, capptr_bounds B>
+      template<
+        typename T = void,
+        typename U,
+        SNMALLOC_CONCEPT(capptr_bounds::c) B>
       SNMALLOC_FAST_PATH CapPtr<T, CBArena> capptr_amplify(CapPtr<U, B> r)
       {
         return real_state->template capptr_amplify<T>(r);


### PR DESCRIPTION
This PR shims a conversion from `enum` to a multi-parameter template type for `capptr_bounds` underneath an equivalent to #311 .  This may be more cleanly extensible as we add dimensions (the second commit is an excellent worked example; I anticipate adding boolean zeroed and MTE-colourised dimensions in the near future).  Doubtless some of it highlights my ignorance of the loftier points of C++; commentary more than welcome (and @mjp41 retains permission to complain, as he said he might prior to my undertaking this refactoring ;) ).

There's a `concept` of bounds here, too, but CI won't save us from ourselves as we don't/can't yet use C++20 there.  I've build-tested with C++17 and 20 in both debug and release flavours, though, so hopefully haven't missed something there.