### PR TITLE
Fix static-sized alloc paths, add compilation test

### DIFF
--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -139,18 +139,18 @@ namespace snmalloc
 
       if constexpr (sizeclass < NUM_SMALL_CLASSES)
       {
-        return small_alloc<zero_mem>(size);
+        return capptr_reveal(small_alloc<zero_mem>(size));
       }
       else if constexpr (sizeclass < NUM_SIZECLASSES)
       {
         handle_message_queue();
         constexpr size_t rsize = sizeclass_to_size(sizeclass);
-        return medium_alloc<zero_mem>(sizeclass, rsize, size);
+        return capptr_reveal(medium_alloc<zero_mem>(sizeclass, rsize, size));
       }
       else
       {
         handle_message_queue();
-        return large_alloc<zero_mem>(size).unsafe_capptr;
+        return capptr_reveal(large_alloc<zero_mem>(size));
       }
 #endif
     }


### PR DESCRIPTION
The CapPtr refactoring was largely compiler guided; unfortunately, it turns out
that the static-sized alloc function is not well exercised.  As such, some type
errors and unnecessary unsafety lurked behind missing template instantiation.

Correct those and add calls to the test harness to make sure we always generate
at least one instance of each small/medium/large case.  While here, it doesn't
hurt to make sure that we call all three possible dealloc() flavors as well.
This will, if nothing else, force instantiation of the static-sized dealloc
template as well.