### PR TITLE
Refactorings for encoding remote deallocation next pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ option(SNMALLOC_RUST_SUPPORT "Build static library for rust" OFF)
 option(SNMALLOC_STATIC_LIBRARY   "Build static libraries" ON)
 option(SNMALLOC_QEMU_WORKAROUND "Disable using madvise(DONT_NEED) to zero memory on Linux" Off)
 option(SNMALLOC_OPTIMISE_FOR_CURRENT_MACHINE "Compile for current machine architecture" Off)
-set(CACHE_FRIENDLY_OFFSET OFF CACHE STRING "Base offset to place linked-list nodes.")
 set(SNMALLOC_STATIC_LIBRARY_PREFIX "sn_" CACHE STRING "Static library function prefix")
 option(SNMALLOC_USE_CXX20 "Build as C++20, not C++17; experimental as yet" OFF)
 
@@ -155,10 +154,6 @@ endif()
 
 if(SNMALLOC_CI_BUILD)
   target_compile_definitions(snmalloc_lib INTERFACE -DSNMALLOC_CI_BUILD)
-endif()
-
-if(CACHE_FRIENDLY_OFFSET)
-  target_compile_definitions(snmalloc_lib INTERFACE -DCACHE_FRIENDLY_OFFSET=${CACHE_FRIENDLY_OFFSET})
 endif()
 
 if(USE_POSIX_COMMIT_CHECKS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,14 +92,6 @@ jobs:
         CMakeArgs: ''
         Image: snmallocciteam/build_linux_x64:latest
 
-      64-bit Cache Friendly:
-        CC: clang-7
-        CXX: clang++-7
-        BuildType: Debug
-        SelfHost: false
-        CMakeArgs: '-DCACHE_FRIENDLY_OFFSET=64'
-        Image: snmallocciteam/build_linux_x64:latest
-
       32-bit Clang-9 Debug:
         CC: clang-9
         CXX: clang++-9

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -96,6 +96,8 @@ namespace snmalloc
                       ChunkMap,
                       IsQueueInline>>
   {
+    friend RemoteCache;
+
     LargeAlloc<MemoryProvider> large_allocator;
     ChunkMap chunk_map;
     LocalEntropy entropy;
@@ -504,139 +506,6 @@ namespace snmalloc
   private:
     using alloc_id_t = typename Remote::alloc_id_t;
 
-    /*
-     * A singly-linked list of Remote objects, supporting append and
-     * take-all operations.  Intended only for the private use of this
-     * allocator; the Remote objects here will later be taken and pushed
-     * to the inter-thread message queues.
-     */
-    struct RemoteList
-    {
-      /*
-       * A stub Remote object that will always be the head of this list;
-       * never taken for further processing.
-       */
-      Remote head{};
-
-      CapPtr<Remote, CBAlloc> last{&head};
-
-      void clear()
-      {
-        last = CapPtr<Remote, CBAlloc>(&head);
-      }
-
-      bool empty()
-      {
-        return address_cast(last) == address_cast(&head);
-      }
-    };
-
-    struct RemoteCache
-    {
-      /**
-       * The total amount of memory we are waiting for before we will dispatch
-       * to other allocators. Zero or negative mean we should dispatch on the
-       * next remote deallocation. This is initialised to the 0 so that we
-       * always hit a slow path to start with, when we hit the slow path and
-       * need to dispatch everything, we can check if we are a real allocator
-       * and lazily provide a real allocator.
-       */
-      int64_t capacity{0};
-      std::array<RemoteList, REMOTE_SLOTS> list{};
-
-      /// Used to find the index into the array of queues for remote
-      /// deallocation
-      /// r is used for which round of sending this is.
-      inline size_t get_slot(size_t id, size_t r)
-      {
-        constexpr size_t allocator_size = sizeof(Allocator<
-                                                 NeedsInitialisation,
-                                                 InitThreadAllocator,
-                                                 MemoryProvider,
-                                                 ChunkMap,
-                                                 IsQueueInline>);
-        constexpr size_t initial_shift =
-          bits::next_pow2_bits_const(allocator_size);
-        static_assert(
-          initial_shift >= 8,
-          "Can't embed sizeclass_t into allocator ID low bits");
-        SNMALLOC_ASSERT((initial_shift + (r * REMOTE_SLOT_BITS)) < 64);
-        return (id >> (initial_shift + (r * REMOTE_SLOT_BITS))) & REMOTE_MASK;
-      }
-
-      SNMALLOC_FAST_PATH void dealloc(
-        alloc_id_t target_id,
-        CapPtr<FreeObject, CBAlloc> p,
-        sizeclass_t sizeclass)
-      {
-        this->capacity -= sizeclass_to_size(sizeclass);
-        auto r = p.template as_reinterpret<Remote>();
-
-        r->set_info(target_id, sizeclass);
-
-        RemoteList* l = &list[get_slot(target_id, 0)];
-        l->last->non_atomic_next = r;
-        l->last = r;
-      }
-
-      void post(LargeAlloc<MemoryProvider>* large_allocator, alloc_id_t id)
-      {
-        // When the cache gets big, post lists to their target allocators.
-        capacity = REMOTE_CACHE;
-
-        size_t post_round = 0;
-
-        while (true)
-        {
-          auto my_slot = get_slot(id, post_round);
-
-          for (size_t i = 0; i < REMOTE_SLOTS; i++)
-          {
-            if (i == my_slot)
-              continue;
-
-            RemoteList* l = &list[i];
-            CapPtr<Remote, CBAlloc> first = l->head.non_atomic_next;
-
-            if (!l->empty())
-            {
-              // Send all slots to the target at the head of the list.
-              auto first_auth =
-                large_allocator->template capptr_amplify<Remote>(first);
-              auto super = Superslab::get(first_auth);
-              super->get_allocator()->message_queue.enqueue(first, l->last);
-              l->clear();
-            }
-          }
-
-          RemoteList* resend = &list[my_slot];
-          if (resend->empty())
-            break;
-
-          // Entries could map back onto the "resend" list,
-          // so take copy of the head, mark the last element,
-          // and clear the original list.
-          CapPtr<Remote, CBAlloc> r = resend->head.non_atomic_next;
-          resend->last->non_atomic_next = nullptr;
-          resend->clear();
-
-          post_round++;
-
-          while (r != nullptr)
-          {
-            // Use the next N bits to spread out remote deallocs in our own
-            // slot.
-            size_t slot = get_slot(r->trunc_target_id(), post_round);
-            RemoteList* l = &list[slot];
-            l->last->non_atomic_next = r;
-            l->last = r;
-
-            r = r->non_atomic_next;
-          }
-        }
-      }
-    };
-
     SlabList small_classes[NUM_SMALL_CLASSES];
     DLList<Mediumslab, CapPtrCBChunkE> medium_classes[NUM_MEDIUM_CLASSES];
 
@@ -881,7 +750,7 @@ namespace snmalloc
       {
         // Merely routing; despite the cast here, p is going to be cast right
         // back to a Remote.
-        remote.dealloc(
+        remote.dealloc<Allocator>(
           p->trunc_target_id(),
           p.template as_reinterpret<FreeObject>(),
           p->sizeclass());
@@ -959,7 +828,7 @@ namespace snmalloc
         return;
 
       stats().remote_post();
-      remote.post(&large_allocator, get_trunc_id());
+      remote.post<Allocator>(this, get_trunc_id());
     }
 
     /**
@@ -1675,7 +1544,7 @@ namespace snmalloc
       {
         stats().remote_free(sizeclass);
         auto offseted = apply_cache_friendly_offset(p, sizeclass);
-        remote.dealloc(target->trunc_id(), offseted, sizeclass);
+        remote.dealloc<Allocator>(target->trunc_id(), offseted, sizeclass);
         return;
       }
 
@@ -1714,10 +1583,10 @@ namespace snmalloc
 
       stats().remote_free(sizeclass);
       auto offseted = apply_cache_friendly_offset(p_auth, sizeclass);
-      remote.dealloc(target->trunc_id(), offseted, sizeclass);
+      remote.dealloc<Allocator>(target->trunc_id(), offseted, sizeclass);
 
       stats().remote_post();
-      remote.post(&large_allocator, get_trunc_id());
+      remote.post<Allocator>(this, get_trunc_id());
     }
 
     ChunkMap& chunkmap()

--- a/src/mem/alloc.h
+++ b/src/mem/alloc.h
@@ -1140,7 +1140,7 @@ namespace snmalloc
       sizeclass_t sizeclass)
     {
       check_client(
-        Metaslab::is_start_of_object(Slab::get_meta(slab), address_cast(p_ret)),
+        Slab::get_meta(slab)->is_start_of_object(address_cast(p_ret)),
         "Not deallocating start of an object");
 
       small_dealloc_start(super, slab, p_auth, p_ret, sizeclass);

--- a/src/mem/allocslab.h
+++ b/src/mem/allocslab.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "baseslab.h"
-#include "remoteallocator.h"
 
 namespace snmalloc
 {
+  struct RemoteAllocator;
+
   class Allocslab : public Baseslab
   {
   protected:

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -128,9 +128,6 @@ namespace snmalloc
    * Free objects within each slab point directly to the next.
    * The next_object pointer can be encoded to detect
    * corruption caused by writes in a UAF or a double free.
-   *
-   * If cache-friendly offsets are used, then the FreeObject is
-   * potentially offset from the start of the object.
    */
   class FreeObject
   {

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -123,6 +123,7 @@ namespace snmalloc
     }
   };
 
+  struct Remote;
   /**
    * Free objects within each slab point directly to the next.
    * The next_object pointer can be encoded to detect

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -123,10 +123,10 @@ namespace snmalloc
 
           // Post all remotes, including forwarded ones. If any allocator posts,
           // repeat the loop.
-          if (alloc->remote.capacity < REMOTE_CACHE)
+          if (alloc->remote_cache.capacity < REMOTE_CACHE)
           {
             alloc->stats().remote_post();
-            alloc->remote.post(alloc, alloc->get_trunc_id());
+            alloc->remote_cache.post(alloc, alloc->get_trunc_id());
             done = false;
           }
 

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -126,7 +126,7 @@ namespace snmalloc
           if (alloc->remote.capacity < REMOTE_CACHE)
           {
             alloc->stats().remote_post();
-            alloc->remote.post(&alloc->large_allocator, alloc->get_trunc_id());
+            alloc->remote.post(alloc, alloc->get_trunc_id());
             done = false;
           }
 

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -152,12 +152,10 @@ namespace snmalloc
       return pointer_align_down<SUPERSLAB_SIZE, Slab>(p.as_void()) == p;
     }
 
-    template<capptr_bounds B>
-    SNMALLOC_FAST_PATH static bool
-    is_start_of_object(CapPtr<Metaslab, B> self, address_t p)
+    SNMALLOC_FAST_PATH bool is_start_of_object(address_t p)
     {
       return is_multiple_of_sizeclass(
-        self->sizeclass(), SLAB_SIZE - (p - address_align_down<SLAB_SIZE>(p)));
+        sizeclass(), SLAB_SIZE - (p - address_align_down<SLAB_SIZE>(p)));
     }
 
     /**
@@ -187,7 +185,7 @@ namespace snmalloc
       self->set_full(meta);
 
       auto p = remove_cache_friendly_offset(n, self->sizeclass());
-      SNMALLOC_ASSERT(is_start_of_object(self, address_cast(p)));
+      SNMALLOC_ASSERT(self->is_start_of_object(address_cast(p)));
 
       self->debug_slab_invariant(meta, entropy);
 

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -174,9 +174,9 @@ namespace snmalloc
       SNMALLOC_ASSERT(!self->is_full());
 
       self->free_queue.close(fast_free_list, entropy);
-      auto n = fast_free_list.take(entropy);
-      auto n_slab = Aal::capptr_rebound(self.as_void(), n);
-      auto meta = Metaslab::get_slab(n_slab);
+      auto p = fast_free_list.take(entropy);
+      auto slab = Aal::capptr_rebound(self.as_void(), p);
+      auto meta = Metaslab::get_slab(slab);
 
       entropy.refresh_bits();
 
@@ -184,7 +184,6 @@ namespace snmalloc
       self->remove();
       self->set_full(meta);
 
-      auto p = remove_cache_friendly_offset(n, self->sizeclass());
       SNMALLOC_ASSERT(self->is_start_of_object(address_cast(p)));
 
       self->debug_slab_invariant(meta, entropy);
@@ -201,7 +200,8 @@ namespace snmalloc
         UNUSED(rsize);
       }
 
-      return capptr_export(p);
+      // TODO: Should this be zeroing the FreeObject state?
+      return capptr_export(p.as_void());
     }
 
     template<capptr_bounds B>

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -75,7 +75,8 @@ namespace snmalloc
      * Return allocator for this object.  This may perform amplification.
      */
     template<typename LargeAlloc>
-    static alloc_id_t trunc_target_id(CapPtr<Remote, CBAlloc> r, LargeAlloc* large_allocator)
+    static alloc_id_t
+    trunc_target_id(CapPtr<Remote, CBAlloc> r, LargeAlloc* large_allocator)
     {
 #ifdef SNMALLOC_DONT_CACHE_ALLOCATOR_PTR
       // Rederive allocator id.
@@ -248,7 +249,8 @@ namespace snmalloc
           // Use the next N bits to spread out remote deallocs in our own
           // slot.
           size_t slot = get_slot<Alloc>(
-            Remote::trunc_target_id(r, &allocator->large_allocator), post_round);
+            Remote::trunc_target_id(r, &allocator->large_allocator),
+            post_round);
           RemoteList* l = &list[slot];
           l->last->non_atomic_next = r;
           l->last = r;

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -100,11 +100,10 @@ namespace snmalloc
 
     /** Zero out a Remote tracking structure, return pointer to object base */
     template<capptr_bounds B>
-    SNMALLOC_FAST_PATH static CapPtr<void, B>
-    clear(CapPtr<Remote, B> self, sizeclass_t sizeclass)
+    SNMALLOC_FAST_PATH static CapPtr<void, B> clear(CapPtr<Remote, B> self)
     {
       pal_zero<Pal>(self, sizeof(Remote));
-      return remove_cache_friendly_offset(self, sizeclass);
+      return self.as_void();
     }
   };
 
@@ -187,7 +186,7 @@ namespace snmalloc
     template<typename Alloc>
     SNMALLOC_FAST_PATH void dealloc(
       Remote::alloc_id_t target_id,
-      CapPtr<FreeObject, CBAlloc> p,
+      CapPtr<void, CBAlloc> p,
       sizeclass_t sizeclass)
     {
       this->capacity -= sizeclass_to_size(sizeclass);

--- a/src/mem/sizeclass.h
+++ b/src/mem/sizeclass.h
@@ -17,10 +17,6 @@ namespace snmalloc
   constexpr static uint16_t get_slab_capacity(sizeclass_t sc, bool is_short);
 
   constexpr static size_t sizeclass_to_size(sizeclass_t sizeclass);
-  constexpr static size_t
-  sizeclass_to_cache_friendly_mask(sizeclass_t sizeclass);
-  constexpr static size_t
-  sizeclass_to_inverse_cache_friendly_mask(sizeclass_t sc);
   constexpr static uint16_t medium_slab_free(sizeclass_t sizeclass);
   static sizeclass_t size_to_sizeclass(size_t size);
 
@@ -56,38 +52,6 @@ namespace snmalloc
   // Large classes range from [SUPERSLAB, ADDRESS_SPACE).
   static constexpr size_t NUM_LARGE_CLASSES =
     bits::ADDRESS_BITS - SUPERSLAB_BITS;
-
-#ifdef CACHE_FRIENDLY_OFFSET
-  template<typename T, capptr_bounds B>
-  SNMALLOC_FAST_PATH static CapPtr<void, B>
-  remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
-  {
-    size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
-    return CapPtr<void, B>((void*)((uintptr_t)p.unsafe_capptr & mask));
-  }
-
-  SNMALLOC_FAST_PATH static address_t
-  remove_cache_friendly_offset(address_t relative, sizeclass_t sizeclass)
-  {
-    size_t mask = sizeclass_to_inverse_cache_friendly_mask(sizeclass);
-    return relative & mask;
-  }
-#else
-  template<typename T, capptr_bounds B>
-  SNMALLOC_FAST_PATH static CapPtr<void, B>
-  remove_cache_friendly_offset(CapPtr<T, B> p, sizeclass_t sizeclass)
-  {
-    UNUSED(sizeclass);
-    return p.as_void();
-  }
-
-  SNMALLOC_FAST_PATH static address_t
-  remove_cache_friendly_offset(address_t relative, sizeclass_t sizeclass)
-  {
-    UNUSED(sizeclass);
-    return relative;
-  }
-#endif
 
   SNMALLOC_FAST_PATH static size_t aligned_size(size_t alignment, size_t size)
   {

--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -25,8 +25,6 @@ namespace snmalloc
   {
     sizeclass_t sizeclass_lookup[sizeclass_lookup_size] = {{}};
     ModArray<NUM_SIZECLASSES, size_t> size;
-    ModArray<NUM_SIZECLASSES, size_t> cache_friendly_mask;
-    ModArray<NUM_SIZECLASSES, size_t> inverse_cache_friendly_mask;
     ModArray<NUM_SMALL_CLASSES, uint16_t> initial_offset_ptr;
     ModArray<NUM_SMALL_CLASSES, uint16_t> short_initial_offset_ptr;
     ModArray<NUM_SMALL_CLASSES, uint16_t> capacity;
@@ -39,8 +37,6 @@ namespace snmalloc
 
     constexpr SizeClassTable()
     : size(),
-      cache_friendly_mask(),
-      inverse_cache_friendly_mask(),
       initial_offset_ptr(),
       short_initial_offset_ptr(),
       capacity(),
@@ -77,11 +73,6 @@ namespace snmalloc
             sizeclass_lookup[sizeclass_lookup_index(curr)] = sizeclass;
           }
         }
-
-        size_t alignment = bits::min(
-          bits::one_at_bit(bits::ctz_const(size[sizeclass])), OS_PAGE_SIZE);
-        cache_friendly_mask[sizeclass] = (alignment - 1);
-        inverse_cache_friendly_mask[sizeclass] = ~(alignment - 1);
       }
 
       size_t header_size = sizeof(Superslab);
@@ -136,18 +127,6 @@ namespace snmalloc
   constexpr static inline size_t sizeclass_to_size(sizeclass_t sizeclass)
   {
     return sizeclass_metadata.size[sizeclass];
-  }
-
-  constexpr static inline size_t
-  sizeclass_to_cache_friendly_mask(sizeclass_t sizeclass)
-  {
-    return sizeclass_metadata.cache_friendly_mask[sizeclass];
-  }
-
-  constexpr static SNMALLOC_FAST_PATH size_t
-  sizeclass_to_inverse_cache_friendly_mask(sizeclass_t sizeclass)
-  {
-    return sizeclass_metadata.inverse_cache_friendly_mask[sizeclass];
   }
 
   static inline sizeclass_t size_to_sizeclass(size_t size)


### PR DESCRIPTION
The remote deallocation next pointers are not protected in the same way that free list pointers are. This PR provides refactorings to make it easier to add those changes.  