### PR TITLE
Rewrite Apple PAL using native APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,11 +141,6 @@ if (WIN32)
   endif()
 endif()
 
-if (APPLE)
-  # SecRandomCopyBytes is exposed by Security.framework
-  target_link_libraries(snmalloc_lib INTERFACE "-framework Security")
-endif()
-
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     target_compile_options(snmalloc_lib INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-mcx16>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,11 @@ if (WIN32)
   endif()
 endif()
 
+if (APPLE)
+  # SecRandomCopyBytes is exposed by Security.framework
+  target_link_libraries(snmalloc_lib INTERFACE "-framework Security")
+endif()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     target_compile_options(snmalloc_lib INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-mcx16>)

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -120,11 +120,9 @@ namespace snmalloc
   // define `PAGE_SIZE` as a macro.  We don't use `PAGE_SIZE` as our variable
   // name, to avoid conflicts, but if we do see a macro definition then check
   // that our value matches the platform's expected value.
-#if defined(__APPLE__) && defined(PAGE_MAX_SIZE)
-  static_assert(
-    PAGE_MAX_SIZE == OS_PAGE_SIZE,
-    "Page size from system header does not match snmalloc config page size.");
-#elif defined(PAGE_SIZE)
+  // On macOS 11, system headers (mach/i386/vm_param.h and mach/arm/vm_param.h)
+  // define `PAGE_SIZE` as an extern making it unsuitable for this assertion.
+#if !defined(__APPLE__) && defined(PAGE_SIZE)
   static_assert(
     PAGE_SIZE == OS_PAGE_SIZE,
     "Page size from system header does not match snmalloc config page size.");

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -120,7 +120,11 @@ namespace snmalloc
   // define `PAGE_SIZE` as a macro.  We don't use `PAGE_SIZE` as our variable
   // name, to avoid conflicts, but if we do see a macro definition then check
   // that our value matches the platform's expected value.
-#ifdef PAGE_SIZE
+#if defined(__APPLE__) && defined(PAGE_MAX_SIZE)
+  static_assert(
+    PAGE_MAX_SIZE == OS_PAGE_SIZE,
+    "Page size from system header does not match snmalloc config page size.");
+#elif defined(PAGE_SIZE)
   static_assert(
     PAGE_SIZE == OS_PAGE_SIZE,
     "Page size from system header does not match snmalloc config page size.");

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -117,15 +117,18 @@ namespace snmalloc
     "The smallest architectural page size must divide OS_PAGE_SIZE");
 
   // Some system headers (e.g. Linux' sys/user.h, FreeBSD's machine/param.h)
-  // define `PAGE_SIZE` as a macro.  We don't use `PAGE_SIZE` as our variable
-  // name, to avoid conflicts, but if we do see a macro definition then check
-  // that our value matches the platform's expected value.
-  // On macOS 11, system headers (mach/i386/vm_param.h and mach/arm/vm_param.h)
-  // define `PAGE_SIZE` as an extern making it unsuitable for this assertion.
-#if !defined(__APPLE__) && defined(PAGE_SIZE)
+  // define `PAGE_SIZE` as a macro, while others (e.g. macOS 11's
+  // mach/machine/vm_param.h) define `PAGE_SIZE` as an extern. We don't use
+  // `PAGE_SIZE` as our variable name, to avoid conflicts, but if we do see a
+  // macro definition evaluates to a constant then check that our value matches
+  // the platform's expected value.
+#ifdef PAGE_SIZE
   static_assert(
-    PAGE_SIZE == OS_PAGE_SIZE,
+#  if __has_builtin(__builtin_constant_p)
+    !__builtin_constant_p(PAGE_SIZE) || (PAGE_SIZE == OS_PAGE_SIZE),
+#  else
+    true,
+#  endif
     "Page size from system header does not match snmalloc config page size.");
 #endif
-
 } // namespace snmalloc

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -19,7 +19,7 @@ namespace snmalloc
   /**
    * PAL implementation for Apple systems (macOS, iOS, watchOS, tvOS...).
    */
-  template<int PALAnonID = PALAnonDefaultID>
+  template<uint8_t PALAnonID = PALAnonDefaultID>
   class PALApple : public PALBSD<PALApple<>>
   {
   public:
@@ -71,10 +71,12 @@ namespace snmalloc
      */
 
     // Encoded memory tag passed to `mmap`.
-    static constexpr int anonymous_memory_fd = VM_MAKE_TAG(PALAnonID);
+    static constexpr int anonymous_memory_fd =
+      int(VM_MAKE_TAG(uint32_t(PALAnonID)));
 
     // Encoded memory tag passed to `mach_vm_map`.
-    static constexpr int default_mach_vm_map_flags = VM_MAKE_TAG(PALAnonID);
+    static constexpr int default_mach_vm_map_flags =
+      int(VM_MAKE_TAG(uint32_t(PALAnonID)));
 
     /**
      * Notify platform that we will not be using these pages.

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -4,15 +4,14 @@
 
 #  include "../ds/address.h"
 
-#  include <Security/Security.h>
-#  include <errno.h>
+#  include <CommonCrypto/CommonRandom.h>
 #  include <execinfo.h>
 #  include <mach/mach_init.h>
 #  include <mach/mach_vm.h>
-#  include <mach/vm_region.h>
 #  include <mach/vm_statistics.h>
 #  include <mach/vm_types.h>
-#  include <utility>
+#  include <stdio.h>
+#  include <unistd.h>
 
 extern "C" int puts(const char* str);
 
@@ -170,17 +169,15 @@ namespace snmalloc
     /**
      * Source of Entropy
      *
-     * Apple platforms do not have a getentropy implementation, so use
-     * SecRandomCopyBytes instead.
+     * Apple platforms do not have a public getentropy implementation, so use
+     * CCRandomGenerateBytes instead.
      */
     static uint64_t get_entropy64()
     {
       uint64_t result;
       if (
-        SecRandomCopyBytes(
-          kSecRandomDefault,
-          sizeof(result),
-          reinterpret_cast<void*>(&result)) != errSecSuccess)
+        CCRandomGenerateBytes(
+          reinterpret_cast<void*>(&result), sizeof(result)) != kCCSuccess)
       {
         error("Failed to get system randomness");
       }

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -5,7 +5,6 @@
 #  include "pal_bsd.h"
 
 #  include <CommonCrypto/CommonRandom.h>
-#  include <execinfo.h>
 #  include <mach/mach_init.h>
 #  include <mach/mach_vm.h>
 #  include <mach/vm_statistics.h>
@@ -14,8 +13,6 @@
 #  include <stdlib.h>
 #  include <sys/mman.h>
 #  include <unistd.h>
-
-extern "C" int puts(const char* str);
 
 namespace snmalloc
 {
@@ -39,17 +36,6 @@ namespace snmalloc
     static constexpr int anonymous_memory_fd = VM_MAKE_TAG(PALAnonID);
 
     static constexpr int default_mach_vm_map_flags = VM_MAKE_TAG(PALAnonID);
-
-    static void print_stack_trace()
-    {
-      constexpr int SIZE = 1024;
-      void* buffer[SIZE];
-      auto nptrs = backtrace(buffer, SIZE);
-      fflush(stdout);
-      backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO);
-      puts("");
-      fflush(stdout);
-    }
 
     /**
      * Notify platform that we will not be using these pages.

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -156,8 +156,7 @@ namespace snmalloc
       // mask has least-significant bits set
       mach_vm_offset_t mask = size - 1;
 
-      int flags =
-        VM_FLAGS_ANYWHERE | VM_FLAGS_RANDOM_ADDR | default_mach_vm_map_flags;
+      int flags = VM_FLAGS_ANYWHERE | default_mach_vm_map_flags;
 
       // must be initialized to 0 or addr is interepreted as a lower-bound.
       mach_vm_address_t addr = 0;

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -12,6 +12,7 @@
 #  include <mach/vm_statistics.h>
 #  include <mach/vm_types.h>
 #  include <stdio.h>
+#  include <stdlib.h>
 #  include <unistd.h>
 
 extern "C" int puts(const char* str);

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -1,11 +1,20 @@
 #pragma once
 
 #ifdef __APPLE__
-#  include "pal_bsd.h"
 
+#  include "../ds/address.h"
+
+#  include <Security/Security.h>
 #  include <errno.h>
+#  include <execinfo.h>
+#  include <mach/mach_init.h>
+#  include <mach/mach_vm.h>
+#  include <mach/vm_region.h>
 #  include <mach/vm_statistics.h>
+#  include <mach/vm_types.h>
 #  include <utility>
+
+extern "C" int puts(const char* str);
 
 namespace snmalloc
 {
@@ -13,80 +22,171 @@ namespace snmalloc
    * PAL implementation for Apple systems (macOS, iOS, watchOS, tvOS...).
    */
   template<int PALAnonID = PALAnonDefaultID>
-  class PALApple : public PALBSD<PALApple<>>
+  class PALApple
   {
   public:
     /**
      * The features exported by this PAL.
-     *
-     * Currently, these are identical to the generic BSD PAL.  This field is
-     * declared explicitly to remind anyone who modifies this class that they
-     * should add any required features.
      */
-    static constexpr uint64_t pal_features = PALBSD::pal_features;
+    static constexpr uint64_t pal_features =
+      AlignedAllocation | LazyCommit | Entropy;
 
-    /**
-     * Anonymous page tag ID.
-     *
-     * Darwin platform allows to gives an ID to anonymous pages via
-     * the VM_MAKE_TAG's macro, from 240 up to 255 are guaranteed
-     * to be free of usage, however eventually a lower could be taken
-     * (e.g. LLVM sanitizers has 99) so we can monitor their states
-     * via vmmap for instance. This value is provided to `mmap` as the file
-     * descriptor for the mapping.
-     */
-    static constexpr int anonymous_memory_fd = VM_MAKE_TAG(PALAnonID);
+    static constexpr size_t page_size = Aal::aal_name == ARM ? 0x4000 : 0x1000;
 
-    /**
-     * Note: The root's implementation works fine on Intel
-     * however mprotect/PROT_NONE fails on ARM
-     * especially since the 11.2 release (seems known issue
-     * spotted in various projects; might be a temporary fix).
-     */
-    template<bool page_aligned = false>
-    static void zero(void* p, size_t size) noexcept
+    static constexpr size_t minimum_alloc_size = page_size;
+
+    static void print_stack_trace()
     {
-      if constexpr (Aal::aal_name != ARM)
-        PALBSD::zero(p, size);
-      else
-        ::bzero(p, size);
+      constexpr int SIZE = 1024;
+      void* buffer[SIZE];
+      auto nptrs = backtrace(buffer, SIZE);
+      fflush(stdout);
+      backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO);
+      puts("");
+      fflush(stdout);
     }
 
-#  if defined(PLATFORM_IS_ARM)
     /**
-     * Overriding here to mark the page as reusable
-     * rolling it as much as necessary.
-     * As above, the x86 h/w worked alright without this change
-     * however now large allocations work better and more reliably
-     * with on ARM, not to mention better RSS number accuracy
-     * for tools based on task_info API.
+     * Report a fatal error and exit.
+     */
+    [[noreturn]] static void error(const char* const str) noexcept
+    {
+      puts(str);
+      print_stack_trace();
+      abort();
+    }
+
+    /**
+     * Notify platform that we will not be using these pages.
      */
     static void notify_not_using(void* p, size_t size) noexcept
     {
-      SNMALLOC_ASSERT(is_aligned_block<PALBSD::page_size>(p, size));
-#    ifdef USE_POSIX_COMMIT_CHECKS
-      memset(p, 0x5a, size);
-#    endif
-      while (madvise(p, size, MADV_FREE_REUSABLE) == -1 && errno == EAGAIN)
-        ;
+      SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
+
+      mach_vm_behavior_set(
+        mach_task_self(),
+        reinterpret_cast<mach_vm_address_t>(p),
+        mach_vm_size_t(size),
+        VM_BEHAVIOR_REUSABLE);
     }
 
     /**
-     * same remark as above but we need to mark the page as REUSE
-     * first
+     * Notify platform that we will be using these pages.
      */
     template<ZeroMem zero_mem>
     static void notify_using(void* p, size_t size) noexcept
     {
       SNMALLOC_ASSERT(
-        is_aligned_block<PALBSD::page_size>(p, size) || (zero_mem == NoZero));
-      while (madvise(p, size, MADV_FREE_REUSE) == -1 && errno == EAGAIN)
-        ;
+        is_aligned_block<page_size>(p, size) || (zero_mem == NoZero));
+
+      mach_vm_behavior_set(
+        mach_task_self(),
+        reinterpret_cast<mach_vm_address_t>(p),
+        mach_vm_size_t(size),
+        VM_BEHAVIOR_REUSE);
 
       if constexpr (zero_mem == YesZero)
+      {
         zero<true>(p, size);
+      }
     }
-#  endif
+
+    /**
+     * OS specific function for zeroing memory.
+     */
+    template<bool page_aligned = false>
+    static void zero(void* p, size_t size) noexcept
+    {
+      if (page_aligned || is_aligned_block<page_size>(p, size))
+      {
+        SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
+
+        // mask has least-significant bits set
+        mach_vm_offset_t mask = page_size - 1;
+
+        int flags =
+          VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | VM_MAKE_TAG(PALAnonID);
+
+        mach_vm_address_t addr = reinterpret_cast<mach_vm_address_t>(p);
+
+        kern_return_t kr = mach_vm_map(
+          mach_task_self(),
+          &addr,
+          size,
+          mask,
+          flags,
+          MEMORY_OBJECT_NULL,
+          0,
+          TRUE,
+          VM_PROT_READ | VM_PROT_WRITE,
+          VM_PROT_READ | VM_PROT_WRITE,
+          VM_INHERIT_COPY);
+
+        if (kr == KERN_SUCCESS)
+        {
+          return;
+        }
+      }
+
+      ::bzero(p, size);
+    }
+
+    template<bool committed>
+    static void* reserve_aligned(size_t size) noexcept
+    {
+      SNMALLOC_ASSERT(bits::is_pow2(size));
+      SNMALLOC_ASSERT(size >= minimum_alloc_size);
+
+      // mask has least-significant bits set
+      mach_vm_offset_t mask = size - 1;
+
+      int flags =
+        VM_FLAGS_ANYWHERE | VM_FLAGS_RANDOM_ADDR | VM_MAKE_TAG(PALAnonID);
+
+      // must be initialized to 0 or addr is interepreted as a lower-bound.
+      mach_vm_address_t addr = 0;
+
+      kern_return_t kr = mach_vm_map(
+        mach_task_self(),
+        &addr,
+        size,
+        mask,
+        flags,
+        MEMORY_OBJECT_NULL,
+        0,
+        TRUE,
+        VM_PROT_READ | VM_PROT_WRITE,
+        VM_PROT_READ | VM_PROT_WRITE,
+        VM_INHERIT_COPY);
+
+      if (kr != KERN_SUCCESS)
+      {
+        error("Failed to allocate memory\n");
+      }
+
+      return reinterpret_cast<void*>(addr);
+    }
+
+    /**
+     * Source of Entropy
+     *
+     * Apple platforms do not have a getentropy implementation, so use
+     * SecRandomCopyBytes instead.
+     */
+    static uint64_t get_entropy64()
+    {
+      uint64_t result;
+      if (
+        SecRandomCopyBytes(
+          kSecRandomDefault,
+          sizeof(result),
+          reinterpret_cast<void*>(&result)) != errSecSuccess)
+      {
+        error("Failed to get system randomness");
+      }
+
+      return result;
+    }
   };
 } // namespace snmalloc
 #endif

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -65,7 +65,7 @@ namespace snmalloc
   /**
    * Default Tag ID for the Apple class
    */
-  static const int PALAnonDefaultID = 241;
+  static const uint8_t PALAnonDefaultID = 241;
 
   /**
    * This struct is used to represent callbacks for notification from the


### PR DESCRIPTION
This is a rewrite of the Apple PAL that implements the `AlignedAllocation`, `Entropy`, and `LazyCommit` features through native Apple APIs.

It adds a dependency on `Security.framework` via `SecRandomCopyBytes`. Apple actively discourages use of `getentropy` and the symbol is [not allowed on the App Store](https://developer.apple.com/forums/thread/675396).


# TODO / Discussion

## `USE_POSIX_COMMIT_CHECKS`
I removed support for `USE_POSIX_COMMIT_CHECKS` because the POSIX memory management APIs are no longer used but I'd like to avoid a regression. I need some context about what the `memset` and `mprotect` calls in `pal_bsd.h` and `pal_posix.h` are supposed to accomplish. Is it supposed to emulate Windows' decommit behavior? If so, why do the pages need to be decommitted? What are the invariants?

I hope to use the mach APIs to implement the behavior if possible and prevent any M1-related bugs:

- #278 
- #280 
- #284

## Can the `size` parameter of `reserve_aligned` be greater than `4GiB`?
There are Apple equivalents of `ReclaimVirtualMemory` and `OfferVirtualMemory`, but they only work on regions that are `4GiB` and smaller. (These APIs have existed since macOS 10.6 and are present in the iOS SDK.) 

The `4GiB` limit is a hard limit in the XNU kernel even on 64-bit platforms.

## ~~`LowMemoryNotification`~~

~~I have a working implementation behind the feature `SNMALLOC_APPLE_LOWMEMORYNOTIFICATION`. I'll push the change after we resolve `USE_POSIX_COMMIT_CHECKS`.~~
