### PR TITLE
Extended TrivialInitAtomic

### DIFF
--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -219,6 +219,21 @@ namespace snmalloc
     {
       return this->ref().compare_exchange_strong(exp, des, mo);
     }
+
+    SNMALLOC_FAST_PATH T
+    exchange(T des, std::memory_order mo = std::memory_order_seq_cst) noexcept
+    {
+      return this->ref().exchange(des, mo);
+    }
+
+    template<typename Q>
+    SNMALLOC_FAST_PATH
+      typename std::enable_if<std::is_integral<Q>::value, Q>::type
+      fetch_add(
+        Q arg, std::memory_order mo = std::memory_order_seq_cst) noexcept
+    {
+      return this->ref().fetch_add(arg, mo);
+    }
   };
 
   static_assert(sizeof(TrivialInitAtomic<char>) == sizeof(char));


### PR DESCRIPTION
Extended the TrivialInitAtomic interface with exchange and fetch_add.
These are not used by snmalloc itself, but can be used by downstream projects which use the helpers.
For fetch_add I tried to keep the error messages for non-integral types as readable as possible without having to do a full template instantiation:
-fetch_add(integral_type) will give and error "no member named 'fetch_add' in 'std::__1::atomic<template_type>'"
-fetch_add(non_integral_type) will give and error "no matching member function for call to 'fetch_add'"

@nwf @mjp41 Does this make sense for an extension and is this correct C++?