### PR TITLE
Fix the build with GCC and libc cleanup.

### DIFF
--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -254,14 +254,6 @@ namespace snmalloc
   };
 
 #  ifdef SNMALLOC_USE_THREAD_CLEANUP
-  /**
-   * Entry point that allows libc to call into the allocator for per-thread
-   * cleanup.
-   */
-  extern "C" void _malloc_thread_cleanup()
-  {
-    ThreadAllocLibcCleanup::inner_release();
-  }
   using ThreadAlloc = ThreadAllocLibcCleanup;
 #  else
   using ThreadAlloc = ThreadAllocThreadDestructor;
@@ -306,3 +298,13 @@ namespace snmalloc
   }
 #endif
 } // namespace snmalloc
+#ifdef SNMALLOC_USE_THREAD_CLEANUP
+/**
+ * Entry point that allows libc to call into the allocator for per-thread
+ * cleanup.
+ */
+void _malloc_thread_cleanup()
+{
+  snmalloc::ThreadAllocLibcCleanup::inner_release();
+}
+#endif


### PR DESCRIPTION
GCC is a lot more picky about extern "C" definitions in namespaces than
clang and so the `friend` declaration wasn't picked up by the version of
the function declared in the `snmalloc` namespace.  Move it out to where
GCC is happy with it.