### PR TITLE
Allow disabling the Debug-mode check in the ABA code

### DIFF
--- a/src/ds/aba.h
+++ b/src/ds/aba.h
@@ -13,7 +13,7 @@
  */
 namespace snmalloc
 {
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(SNMALLOC_DISABLE_ABA_VERIFY)
   // LL/SC typically can only perform one operation at a time
   // check this on other platforms using a thread_local.
   inline thread_local bool operation_in_flight = false;
@@ -75,7 +75,7 @@ namespace snmalloc
 
     Cmp read()
     {
-#  ifndef NDEBUG
+#  if !defined(NDEBUG) && !defined(SNMALLOC_DISABLE_ABA_VERIFY)
       if (operation_in_flight)
         error("Only one inflight ABA operation at a time is allowed.");
       operation_in_flight = true;
@@ -127,7 +127,7 @@ namespace snmalloc
 
       ~Cmp()
       {
-#  ifndef NDEBUG
+#  if !defined(NDEBUG) && !defined(SNMALLOC_DISABLE_ABA_VERIFY)
         operation_in_flight = false;
 #  endif
       }
@@ -170,7 +170,7 @@ namespace snmalloc
       while (lock.test_and_set(std::memory_order_acquire))
         Aal::pause();
 
-#  ifndef NDEBUG
+#  if !defined(NDEBUG) && !defined(SNMALLOC_DISABLE_ABA_VERIFY)
       if (operation_in_flight)
         error("Only one inflight ABA operation at a time is allowed.");
       operation_in_flight = true;
@@ -198,7 +198,7 @@ namespace snmalloc
       ~Cmp()
       {
         parent->lock.clear(std::memory_order_release);
-#  ifndef NDEBUG
+#  if !defined(NDEBUG) && !defined(SNMALLOC_DISABLE_ABA_VERIFY)
         operation_in_flight = false;
 #  endif
       }


### PR DESCRIPTION
The check relies on a thread_local variable which might not be available when using SlowAllocator on custom platforms.