### PR TITLE
pagemap: don't eagerly commit on LazyCommit PALs

### DIFF
--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -129,7 +129,7 @@ namespace snmalloc
       }
 
       //  This means external pointer on Windows will be slow.
-      if constexpr (potentially_out_of_range)
+      if constexpr (potentially_out_of_range && !pal_supports<LazyCommit, PAL>)
       {
         commit_entry(&body[p >> SHIFT]);
       }


### PR DESCRIPTION
This dramatically improves the runtime of at least `perf-external_pointer` tests, which call `get` with `potentially_out_of_range = true` quite a lot, at least on my Linux box.