### PR TITLE
Improved OEPal integration with the new snmalloc architecture

### DIFF
--- a/src/mem/fixedglobalconfig.h
+++ b/src/mem/fixedglobalconfig.h
@@ -11,20 +11,21 @@ namespace snmalloc
   /**
    * A single fixed address range allocator configuration
    */
+  template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
   class FixedGlobals : public CommonConfig
   {
   public:
-    using Backend = BackendAllocator<PALNoAlloc<Pal>, true>;
+    using Backend = BackendAllocator<PAL, true>;
 
   private:
-    inline static Backend::GlobalState backend_state;
+    inline static typename Backend::GlobalState backend_state;
 
     inline static ChunkAllocatorState slab_allocator_state;
 
     inline static PoolState<CoreAllocator<FixedGlobals>> alloc_pool;
 
   public:
-    static Backend::GlobalState& get_backend_state()
+    static typename Backend::GlobalState& get_backend_state()
     {
       return backend_state;
     }

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -16,11 +16,11 @@
 #  include "pal_haiku.h"
 #  include "pal_linux.h"
 #  include "pal_netbsd.h"
-#  include "pal_noalloc.h"
 #  include "pal_openbsd.h"
 #  include "pal_solaris.h"
 #  include "pal_windows.h"
 #endif
+#include "pal_noalloc.h"
 #include "pal_plain.h"
 
 namespace snmalloc

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -56,7 +56,7 @@ namespace snmalloc
 #if defined(SNMALLOC_MEMORY_PROVIDER)
     PALPlainMixin<SNMALLOC_MEMORY_PROVIDER>;
 #elif defined(OPEN_ENCLAVE)
-    PALPlainMixin<PALOpenEnclave>;
+    PALOpenEnclave;
 #else
     DefaultPal;
 #endif

--- a/src/pal/pal_noalloc.h
+++ b/src/pal/pal_noalloc.h
@@ -17,17 +17,18 @@ namespace snmalloc
    * address-space manager is initialised with all of the memory that it will
    * ever use.
    *
-   * It takes an error handler delegate as a template argument. This is
+   * It takes an underlying PAL delegate as a template argument. This is
    * expected to forward to the default PAL in most cases.
    */
-  template<typename ErrorHandler>
+  template<SNMALLOC_CONCEPT(ConceptPAL) UnderlyingPAL>
   struct PALNoAlloc
   {
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = NoAllocation;
+    static constexpr uint64_t pal_features = NoAllocation |
+      ((UnderlyingPAL::pal_features & Entropy) != 0 ? Entropy : 0);
 
     static constexpr size_t page_size = Aal::smallest_page_size;
 
@@ -36,7 +37,7 @@ namespace snmalloc
      */
     static void print_stack_trace()
     {
-      ErrorHandler::print_stack_trace();
+      UnderlyingPAL::print_stack_trace();
     }
 
     /**
@@ -44,7 +45,7 @@ namespace snmalloc
      */
     [[noreturn]] static void error(const char* const str) noexcept
     {
-      ErrorHandler::error(str);
+      UnderlyingPAL::error(str);
     }
 
     /**
@@ -82,7 +83,13 @@ namespace snmalloc
     template<bool page_aligned = false>
     static void zero(void* p, size_t size) noexcept
     {
-      memset(p, 0, size);
+      UnderlyingPAL::zero(p, size);
+    }
+
+    static std::enable_if_t<(pal_features & Entropy) != 0, uint64_t>
+    get_entropy64()
+    {
+      return UnderlyingPAL::get_entropy64();
     }
   };
 } // namespace snmalloc

--- a/src/pal/pal_noalloc.h
+++ b/src/pal/pal_noalloc.h
@@ -17,18 +17,17 @@ namespace snmalloc
    * address-space manager is initialised with all of the memory that it will
    * ever use.
    *
-   * It takes an underlying PAL delegate as a template argument. This is
+   * It takes an error handler delegate as a template argument. This is
    * expected to forward to the default PAL in most cases.
    */
-  template<SNMALLOC_CONCEPT(ConceptPAL) UnderlyingPAL>
+  template<typename ErrorHandler>
   struct PALNoAlloc
   {
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = NoAllocation |
-      ((UnderlyingPAL::pal_features & Entropy) != 0 ? Entropy : 0);
+    static constexpr uint64_t pal_features = NoAllocation;
 
     static constexpr size_t page_size = Aal::smallest_page_size;
 
@@ -37,7 +36,7 @@ namespace snmalloc
      */
     static void print_stack_trace()
     {
-      UnderlyingPAL::print_stack_trace();
+      ErrorHandler::print_stack_trace();
     }
 
     /**
@@ -45,7 +44,7 @@ namespace snmalloc
      */
     [[noreturn]] static void error(const char* const str) noexcept
     {
-      UnderlyingPAL::error(str);
+      ErrorHandler::error(str);
     }
 
     /**
@@ -83,13 +82,7 @@ namespace snmalloc
     template<bool page_aligned = false>
     static void zero(void* p, size_t size) noexcept
     {
-      UnderlyingPAL::zero(p, size);
-    }
-
-    static std::enable_if_t<(pal_features & Entropy) != 0, uint64_t>
-    get_entropy64()
-    {
-      return UnderlyingPAL::get_entropy64();
+      memset(p, 0, size);
     }
   };
 } // namespace snmalloc

--- a/src/pal/pal_open_enclave.h
+++ b/src/pal/pal_open_enclave.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "ds/address.h"
-#include "ds/flaglock.h"
 #include "pal_plain.h"
 
-#include <array>
 #ifdef OPEN_ENCLAVE
 extern "C" void* oe_memset_s(void* p, size_t p_size, int c, size_t size);
 extern "C" int oe_random(void* data, size_t size);
@@ -14,31 +11,12 @@ namespace snmalloc
 {
   class PALOpenEnclave
   {
-    /// Base of OE heap
-    static inline void* heap_base = nullptr;
-
-    /// Size of OE heap
-    static inline size_t heap_size;
-
-    // This is infrequently used code, a spin lock simplifies the code
-    // considerably, and should never be on the fast path.
-    static inline std::atomic_flag spin_lock;
-
   public:
-    /**
-     * This will be called by oe_allocator_init to set up enclave heap bounds.
-     */
-    static void setup_initial_range(void* base, void* end)
-    {
-      heap_size = pointer_diff(base, end);
-      heap_base = base;
-    }
-
     /**
      * Bitmap of PalFeatures flags indicating the optional features that this
      * PAL supports.
      */
-    static constexpr uint64_t pal_features = Entropy;
+    static constexpr uint64_t pal_features = NoAllocation | Entropy;
 
     static constexpr size_t page_size = Aal::smallest_page_size;
 
@@ -46,20 +24,6 @@ namespace snmalloc
     {
       UNUSED(str);
       oe_abort();
-    }
-
-    static std::pair<void*, size_t>
-    reserve_at_least(size_t request_size) noexcept
-    {
-      // First call returns the entire address space
-      // subsequent calls return {nullptr, 0}
-      FlagLock lock(spin_lock);
-      if (request_size > heap_size)
-        return {nullptr, 0};
-
-      auto result = std::make_pair(heap_base, heap_size);
-      heap_size = 0;
-      return result;
     }
 
     template<bool page_aligned = false>

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -11,7 +11,8 @@
 
 using namespace snmalloc;
 
-using FixedAlloc = LocalAllocator<FixedGlobals>;
+using CustomGlobals = FixedGlobals<PALNoAlloc<DefaultPal>>;
+using FixedAlloc = LocalAllocator<CustomGlobals>;
 
 int main()
 {
@@ -30,8 +31,8 @@ int main()
   std::cout << "Allocated region " << oe_base.unsafe_ptr() << " - "
             << pointer_offset(oe_base, size).unsafe_ptr() << std::endl;
 
-  FixedGlobals fixed_handle;
-  FixedGlobals::init(oe_base, size);
+  CustomGlobals fixed_handle;
+  CustomGlobals::init(oe_base, size);
   FixedAlloc a(fixed_handle);
 
   size_t object_size = 128;

--- a/src/test/func/two_alloc_types/alloc1.cc
+++ b/src/test/func/two_alloc_types/alloc1.cc
@@ -10,7 +10,8 @@
 #define SNMALLOC_PROVIDE_OWN_CONFIG
 namespace snmalloc
 {
-  using Alloc = LocalAllocator<FixedGlobals>;
+  using CustomGlobals = FixedGlobals<PALNoAlloc<DefaultPal>>;
+  using Alloc = LocalAllocator<CustomGlobals>;
 }
 
 #define SNMALLOC_NAME_MANGLE(a) enclave_##a
@@ -18,7 +19,7 @@ namespace snmalloc
 
 extern "C" void oe_allocator_init(void* base, void* end)
 {
-  snmalloc::FixedGlobals fixed_handle;
+  snmalloc::CustomGlobals fixed_handle;
   fixed_handle.init(
     CapPtr<void, CBChunk>(base), address_cast(end) - address_cast(base));
 }


### PR DESCRIPTION
PalNoAlloc forwards the Entropy setting of the underlying PAL as well as using its zeroing function.
Removed the unused parts of the PalOpenEnclave after the refactor.
`PalOpenEnclave::setup_initial_range` should be replace by:
`snmalloc::FixedGlobals fixed_handle;
fixed_handle.init(snmalloc::CapPtr<void, snmalloc::CBChunk>(heap_start), heap_size);`