### PR TITLE
Cleaner implementation of signed pointers.

### DIFF
--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -9,8 +9,6 @@
 #include "sizeclasstable.h"
 #include "slaballocator.h"
 
-#include <iostream>
-
 namespace snmalloc
 {
   template<typename SharedStateHandle>

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -21,7 +21,7 @@
  *
  * If f just returns the first parameter, then this degenerates to a doubly
  * linked list.  (Note that doing the degenerate case can be useful for
- * debugging snmalloc bugs.) By making it a function of both objects, it
+ * debugging snmalloc bugs.) By making it a function of both pointers, it
  * makes it harder for an adversary to mutate prev_encoded to a valid value.
  *
  * This provides protection against the free-list being corrupted by memory
@@ -93,10 +93,13 @@ namespace snmalloc
     }
 
     /**
+     * Assign next_object and update its prev_encoded if CHECK_CLIENT.
+     *
      * Static so that it can be used on reference to a FreeObject.
      *
-     * Returns the next_object field of the next parameter, so can be used to
-     * iterate the construction.
+     * Returns a pointer to the next_object field of the next parameter as an
+     * optimization for repeated snoc operations (in which
+     * next->next_object is nullptr).
      */
     static CapPtr<FreeObject, CBAlloc>* store(
       CapPtr<FreeObject, CBAlloc>* curr,
@@ -299,7 +302,7 @@ namespace snmalloc
         if (end[1] != &head[1])
         {
           // The start token has been corrupted.
-          // TOUTOC issue, but small window here.
+          // TOCTTOU issue, but small window here.
           head[1]->check_prev(get_fake_signed_prev(1, entropy));
 
           terminate_list(1, entropy);


### PR DESCRIPTION
This encodes a back pointer in each node.  The back pointer is stored
in an encoded form so that it is hard to corrupt and trick the allocator
into following incorrect pointers.

This changes the encoding from previously being a Feistel network on
the next pointer that was using the prev as part of the key, to now
effectively using a doubly linked queue, where the back pointers are
scrambled, so it is hard to forge them.

This has the positive effects of
 - Not needing to store previous while building the list, as the append
   nows, curr and next at the point of writing into next, and does not
   need an additional previous.
 - The encoding is not affecting the actual next value, so more
   instructions can be executed in parallel by the CPU.

Future extensions, store a changing key in the FreeListBuilder so it
becomes harder to try to forge the previous token.

This approach can also be applied to the remote list, and will in a
subsequent PR.  This enables the idea to be tested.