### PR TITLE
Refactor pagemap and ASM relationship

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,6 @@ int main() {
 }
 " SNMALLOC_PLATFORM_HAS_GETENTROPY)
 
-if (NOT SNMALLOC_CI_BUILD)
-  option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." Off)
-else ()
-  # This is enabled in every bit of CI to detect errors.
-  option(USE_POSIX_COMMIT_CHECKS "Instrument Posix PAL to check for access to unused blocks of memory." On)
-endif ()
-
 # Provide as macro so other projects can reuse
 macro(warnings_high)
   if(MSVC)
@@ -169,10 +162,6 @@ if(SNMALLOC_CI_BUILD)
   target_compile_definitions(snmalloc_lib INTERFACE -DSNMALLOC_CI_BUILD)
 endif()
 
-if(USE_POSIX_COMMIT_CHECKS)
-  target_compile_definitions(snmalloc_lib INTERFACE -DUSE_POSIX_COMMIT_CHECKS)
-endif()
-
 if(SNMALLOC_PLATFORM_HAS_GETENTROPY)
   target_compile_definitions(snmalloc_lib INTERFACE -DSNMALLOC_PLATFORM_HAS_GETENTROPY)
 endif()
@@ -277,13 +266,13 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
     set(SHARED_FILES src/override/new.cc)
     add_shim(snmallocshim SHARED ${SHARED_FILES})
     add_shim(snmallocshim-checks SHARED ${SHARED_FILES})
-    target_compile_definitions(snmallocshim-checks PRIVATE CHECK_CLIENT)
+    target_compile_definitions(snmallocshim-checks PRIVATE SNMALLOC_CHECK_CLIENT)
   endif()
 
   if(SNMALLOC_RUST_SUPPORT)
     add_shim(snmallocshim-rust STATIC src/override/rust.cc)
     add_shim(snmallocshim-checks-rust STATIC src/override/rust.cc)
-    target_compile_definitions(snmallocshim-checks-rust PRIVATE CHECK_CLIENT)
+    target_compile_definitions(snmallocshim-checks-rust PRIVATE SNMALLOC_CHECK_CLIENT)
   endif()
 
   enable_testing()
@@ -313,14 +302,11 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
 
         add_executable(${TESTNAME} ${SRC})
 
-        # For all tests enable commit checking.
-        target_compile_definitions(${TESTNAME} PRIVATE -DUSE_POSIX_COMMIT_CHECKS)
-
         if (${FLAVOUR} STREQUAL "malloc")
           target_compile_definitions(${TESTNAME} PRIVATE SNMALLOC_PASS_THROUGH)
         endif()
         if (${FLAVOUR} STREQUAL "check")
-          target_compile_definitions(${TESTNAME} PRIVATE CHECK_CLIENT)
+          target_compile_definitions(${TESTNAME} PRIVATE SNMALLOC_CHECK_CLIENT)
         endif()
         target_link_libraries(${TESTNAME} snmalloc_lib)
         if (${TEST} MATCHES "release-.*")

--- a/ci/scripts/test.sh
+++ b/ci/scripts/test.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 cd build
 if [ $SELF_HOST = false ]; then
-    ctest -j 4 --output-on-failure -C $BUILD_TYPE
+    ctest -j 1 --output-on-failure -C $BUILD_TYPE
 else
     sudo cp libsnmallocshim.so libsnmallocshim-checks.so /usr/local/lib/
     ninja clean

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -49,9 +49,10 @@ template<bool committed>
 static void* reserve_aligned(size_t size) noexcept;
 static std::pair<void*, size_t> reserve_at_least(size_t size) noexcept;
 ```
-Only one of these needs to be implemented, depending on whether the underlying
-system can provide strongly aligned memory regions.
-If the system guarantees only page alignment, implement the second. The Pal is 
+All platforms should provide `reserve_at_least` and can optionally provide
+`reserve_aligned` if the underlying system can provide strongly aligned 
+memory regions.
+If the system guarantees only page alignment, implement only the second. The Pal is 
 free to overallocate based on the platform's desire and snmalloc
 will find suitably aligned blocks inside the region.  `reserve_at_least` should 
 not commit memory as snmalloc will commit the range of memory it requires of what 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -47,14 +47,14 @@ pages, rather than zeroing them synchronously in this call
 ```c++
 template<bool committed>
 static void* reserve_aligned(size_t size) noexcept;
-static std::pair<void*, size_t> reserve_at_least(size_t size) noexcept;
+static void* reserve(size_t size) noexcept;
 ```
-All platforms should provide `reserve_at_least` and can optionally provide
+All platforms should provide `reserve` and can optionally provide
 `reserve_aligned` if the underlying system can provide strongly aligned 
 memory regions.
 If the system guarantees only page alignment, implement only the second. The Pal is 
 free to overallocate based on the platform's desire and snmalloc
-will find suitably aligned blocks inside the region.  `reserve_at_least` should 
+will find suitably aligned blocks inside the region.  `reserve` should 
 not commit memory as snmalloc will commit the range of memory it requires of what 
 is returned.
 

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -11,7 +11,7 @@ namespace snmalloc
    * This class implements the standard backend for handling allocations.
    * It abstracts page table management and address space management.
    */
-  template<typename PAL, bool fixed_range>
+  template<SNMALLOC_CONCEPT(ConceptPAL) PAL, bool fixed_range>
   class BackendAllocator
   {
   public:

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -19,17 +19,30 @@ namespace snmalloc
   private:
     static constexpr size_t SHIFT = GRANULARITY_BITS;
 
-    // Before init is called will contain a single entry
-    // that is the default value.  This is needed so that
-    // various calls do not have to check for nullptr.
-    //   free(nullptr)
-    // and
-    //   malloc_usable_size(nullptr)
-    // do not require an allocation to have ocurred before
-    // they are called.
+    /**
+     * Before init is called will contain a single entry
+     * that is the default value.  This is needed so that
+     * various calls do not have to check for nullptr.
+     *   free(nullptr)
+     * and
+     *   malloc_usable_size(nullptr)
+     * do not require an allocation to have ocurred before
+     * they are called.
+     */
     inline static const T default_value{};
+
+    /**
+     * The representation of the page map.
+     *
+     * Initially a single element to ensure nullptr operations
+     * work.
+     */
     T* body{const_cast<T*>(&default_value)};
 
+    /**
+     * If `has_bounds` is set, then these should contain the
+     * bounds of the heap that is being managed by this pagemap.
+     */
     address_t base{0};
     size_t size{0};
 
@@ -51,37 +64,66 @@ namespace snmalloc
   public:
     constexpr FlatPagemap() = default;
 
-    template<typename ASM, bool has_bounds_ = has_bounds>
-    std::enable_if_t<has_bounds_> init(ASM* a, address_t b, size_t s)
+    /**
+     * Initialise the pagemap with bounds.
+     *
+     * Returns usable range after pagemap has been allocated
+     */
+    template<bool has_bounds_ = has_bounds>
+    std::enable_if_t<has_bounds_, std::pair<CapPtr<void, CBChunk>, size_t>>
+    init(CapPtr<void, CBChunk> b, size_t s)
     {
       static_assert(
         has_bounds_ == has_bounds, "Don't set SFINAE template parameter!");
 #ifdef SNMALLOC_TRACING
-      std::cout << "Pagemap.init " << (void*)b << " (" << s << ")" << std::endl;
+      std::cout << "Pagemap.init " << b.unsafe_ptr() << " (" << s << ")"
+                << std::endl;
 #endif
       SNMALLOC_ASSERT(s != 0);
+      // TODO take account of pagemap size in the calculation of how big it
+      // needs to be.
+
       // Align the start and end.  We won't store for the very ends as they
       // are not aligned to a chunk boundary.
-      base = bits::align_up(b, bits::one_at_bit(GRANULARITY_BITS));
-      auto end = bits::align_down(b + s, bits::one_at_bit(GRANULARITY_BITS));
-      size = end - base;
-      body = a->template reserve<false, false>(
-                bits::next_pow2((size >> SHIFT) * sizeof(T)))
-               .template as_static<T>()
-               .unsafe_ptr();
+      auto heap_base = pointer_align_up(b, bits::one_at_bit(GRANULARITY_BITS));
+      auto end = pointer_align_down(
+        pointer_offset(b, s), bits::one_at_bit(GRANULARITY_BITS));
+      size = pointer_diff(heap_base, end);
+
+      // Put pagemap at start of range.
+      // TODO CHERI capability bound here!
+      body = b.as_reinterpret<T>().unsafe_ptr();
+
+      // Advance by size of pagemap.
+      // TODO CHERI capability bound here!
+      heap_base = pointer_align_up(
+        pointer_offset(b, (size >> SHIFT) * sizeof(T)),
+        bits::one_at_bit(GRANULARITY_BITS));
+      base = address_cast(heap_base);
+      SNMALLOC_ASSERT(
+        base == bits::align_up(base, bits::one_at_bit(GRANULARITY_BITS)));
+      return {heap_base, pointer_diff(heap_base, end)};
     }
 
-    template<typename ASM, bool has_bounds_ = has_bounds>
-    std::enable_if_t<!has_bounds_> init(ASM* a)
+    /**
+     * Initialise the pagemap without bounds.
+     */
+    template<bool has_bounds_ = has_bounds>
+    std::enable_if_t<!has_bounds_> init()
     {
       static_assert(
         has_bounds_ == has_bounds, "Don't set SFINAE template parameter!");
       static constexpr size_t COVERED_BITS =
         bits::ADDRESS_BITS - GRANULARITY_BITS;
       static constexpr size_t ENTRIES = bits::one_at_bit(COVERED_BITS);
-      auto new_body = (a->template reserve<false, false>(ENTRIES * sizeof(T)))
-                        .template as_static<T>()
-                        .unsafe_ptr();
+
+      // TODO request additional space, and move to random offset.
+
+      // TODO wasting space if size2 bigger than needed.
+      auto [new_body_untyped, size2] =
+        Pal::reserve_at_least(ENTRIES * sizeof(T));
+
+      auto new_body = reinterpret_cast<T*>(new_body_untyped);
 
       // Ensure bottom page is committed
       commit_entry(&new_body[0]);
@@ -90,8 +132,6 @@ namespace snmalloc
       new_body[0] = body[0];
 
       body = new_body;
-      // TODO this is pretty sparse, should we ignore huge pages for it?
-      //     madvise(body, size, MADV_NOHUGEPAGE);
     }
 
     /**

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -119,9 +119,7 @@ namespace snmalloc
 
       // TODO request additional space, and move to random offset.
 
-      // TODO wasting space if size2 bigger than needed.
-      auto [new_body_untyped, size2] =
-        Pal::reserve_at_least(ENTRIES * sizeof(T));
+      auto new_body_untyped = Pal::reserve(ENTRIES * sizeof(T));
 
       auto new_body = reinterpret_cast<T*>(new_body_untyped);
 

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -134,6 +134,11 @@ namespace snmalloc
 
       auto new_body_untyped = PAL::reserve(request_size);
 
+      if (new_body_untyped == nullptr)
+      {
+        PAL::error("Failed to initialisation snmalloc.");
+      }
+
 #ifdef SNMALLOC_CHECK_CLIENT
       // Begin pagemap at random offset within the additionally allocated space.
       static_assert(bits::is_pow2(sizeof(T)), "Next line assumes this.");

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -174,6 +174,13 @@ namespace snmalloc
 #endif
   }
 
+  template<typename T = void, enum capptr_bounds bounds>
+  inline CapPtr<T, bounds>
+  pointer_align_down(CapPtr<void, bounds> p, size_t alignment)
+  {
+    return CapPtr<T, bounds>(pointer_align_down<T>(p.unsafe_ptr(), alignment));
+  }
+
   /**
    * Align a pointer up to a dynamically specified granularity, which must
    * be a power of two.

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -114,12 +114,6 @@ namespace snmalloc
 #  endif
 #endif
 
-// // The CHECK_CLIENT macro is used to turn on minimal checking of the client
-// // calling the API correctly.
-// #if !defined(NDEBUG) && !defined(CHECK_CLIENT)
-// #  define CHECK_CLIENT
-// #endif
-
 inline SNMALLOC_FAST_PATH void check_client_error(const char* const str)
 {
   //[[clang::musttail]]
@@ -132,7 +126,7 @@ check_client_impl(bool test, const char* const str)
   if (unlikely(!test))
     check_client_error(str);
 }
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
 #  define check_client(test, str) check_client_impl(test, str)
 #else
 #  define check_client(test, str)

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -73,7 +73,7 @@ namespace snmalloc
     }
   };
 
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
   template<size_t length, typename T>
   class ModArray
   {

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -80,7 +80,7 @@ namespace snmalloc
   static constexpr size_t MIN_CHUNK_SIZE = bits::one_at_bit(MIN_CHUNK_BITS);
 
   // Minimum number of objects on a slab
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
   static constexpr size_t MIN_OBJECT_COUNT = 13;
 #else
   static constexpr size_t MIN_OBJECT_COUNT = 4;

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -146,7 +146,7 @@ namespace snmalloc
       FreeListBuilder<false> b;
       SNMALLOC_ASSERT(b.empty());
 
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
       // Structure to represent the temporary list elements
       struct PreAllocObject
       {
@@ -214,7 +214,7 @@ namespace snmalloc
       meta->free_queue.close(fl, key);
       void* p = finish_alloc_no_zero(fl.take(key), sizeclass);
 
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
       // Check free list is well-formed on platforms with
       // integers as pointers.
       size_t count = 1; // Already taken one above.

--- a/src/mem/entropy.h
+++ b/src/mem/entropy.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../ds/address.h"
 #include "../pal/pal.h"
 

--- a/src/mem/fixedglobalconfig.h
+++ b/src/mem/fixedglobalconfig.h
@@ -66,7 +66,7 @@ namespace snmalloc
       snmalloc::register_clean_up();
     }
 
-    static void init(CapPtr<void, CBChunk> base, size_t length)
+    static void init(void* base, size_t length)
     {
       get_backend_state().init(base, length);
     }

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -30,7 +30,7 @@ namespace snmalloc
      *
      *  Spare 32bits are used for the fields in MetaslabEnd.
      */
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
     FreeListBuilder<true> free_queue;
 #else
     FreeListBuilder<false> free_queue;
@@ -149,7 +149,7 @@ namespace snmalloc
       auto p = tmp_fl.take(key);
       fast_free_list = tmp_fl;
 
-#ifdef CHECK_CLIENT
+#ifdef SNMALLOC_CHECK_CLIENT
       entropy.refresh_bits();
 #else
       UNUSED(entropy);

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -51,6 +51,12 @@ namespace snmalloc
       p = ChunkAllocator::alloc_meta_data<T>(
         h, nullptr, std::forward<Args>(args)...);
 
+      if (p == nullptr)
+      {
+        SharedStateHandle::Backend::Pal::error(
+          "Failed to initialisation thread local allocator.");
+      }
+
       FlagLock f(pool.lock);
       p->list_next = pool.list;
       pool.list = p;

--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -166,7 +166,7 @@ namespace snmalloc
    */
   inline uint16_t threshold_for_waking_slab(sizeclass_t sizeclass)
   {
-    // #ifdef CHECK_CLIENT
+    // #ifdef SNMALLOC_CHECK_CLIENT
     return sizeclass_metadata.waking[sizeclass];
     // #else
     //     UNUSED(sizeclass);

--- a/src/pal/pal_apple.h
+++ b/src/pal/pal_apple.h
@@ -113,7 +113,7 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
 
-#  ifdef USE_POSIX_COMMIT_CHECKS
+#  if defined(SNMALLOC_CHECK_CLIENT) && !defined(NDEBUG)
       memset(p, 0x5a, size);
 #  endif
 
@@ -126,7 +126,7 @@ namespace snmalloc
       while (madvise(p, size, MADV_FREE_REUSABLE) == -1 && errno == EAGAIN)
         ;
 
-#  ifdef USE_POSIX_COMMIT_CHECKS
+#  ifdef SNMALLOC_CHECK_CLIENT
       // This must occur after `MADV_FREE_REUSABLE`.
       //
       // `mach_vm_protect` is observably slower in benchmarks.
@@ -179,7 +179,7 @@ namespace snmalloc
         }
       }
 
-#  ifdef USE_POSIX_COMMIT_CHECKS
+#  ifdef SNMALLOC_CHECK_CLIENT
       // Mark pages as writable for `madvise` below.
       //
       // `mach_vm_protect` is observably slower in benchmarks.
@@ -218,7 +218,7 @@ namespace snmalloc
       // must be initialized to 0 or addr is interepreted as a lower-bound.
       mach_vm_address_t addr = 0;
 
-#  ifdef USE_POSIX_COMMIT_CHECKS
+#  ifdef SNMALLOC_CHECK_CLIENT
       vm_prot_t prot = committed ? VM_PROT_READ | VM_PROT_WRITE : VM_PROT_NONE;
 #  else
       vm_prot_t prot = VM_PROT_READ | VM_PROT_WRITE;

--- a/src/pal/pal_bsd.h
+++ b/src/pal/pal_bsd.h
@@ -35,11 +35,11 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<OS::page_size>(p, size));
       // Call this Pal to simulate the Windows decommit in CI.
-#ifdef USE_POSIX_COMMIT_CHECKS
+#if defined(SNMALLOC_CHECK_CLIENT) && !defined(NDEBUG)
       memset(p, 0x5a, size);
 #endif
       madvise(p, size, MADV_FREE);
-#ifdef USE_POSIX_COMMIT_CHECKS
+#ifdef SNMALLOC_CHECK_CLIENT
       mprotect(p, size, PROT_NONE);
 #endif
     }

--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -50,17 +50,5 @@ namespace snmalloc
 
       return p;
     }
-
-    /**
-     * Explicitly deleted method for returning non-aligned memory.  This causes
-     * incorrect use of `constexpr if` to fail on platforms with aligned
-     * allocation.  Without this, this PAL and its subclasses exported both
-     * allocation functions and so callers would type-check if they called
-     * either in `constexpr if` branches and then fail on platforms such as
-     * Linux or Windows, which expose only unaligned or aligned allocations,
-     * respectively.
-     */
-    static std::pair<void*, size_t>
-    reserve_at_least(size_t size) noexcept = delete;
   };
 } // namespace snmalloc

--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -37,10 +37,16 @@ namespace snmalloc
 
       int log2align = static_cast<int>(bits::next_pow2_bits(size));
 
+#ifdef SNMALLOC_CHECK_CLIENT
+      auto prot = committed ? PROT_READ | PROT_WRITE : PROT_NONE;
+#else
+      auto prot = PROT_READ | PROT_WRITE;
+#endif
+
       void* p = mmap(
         nullptr,
         size,
-        PROT_READ | PROT_WRITE,
+        prot,
         MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED(log2align),
         -1,
         0);

--- a/src/pal/pal_concept.h
+++ b/src/pal/pal_concept.h
@@ -52,11 +52,10 @@ namespace snmalloc
    * Absent any feature flags, the PAL must support a crude primitive allocator
    */
   template<typename PAL>
-  concept ConceptPAL_reserve_at_least =
-    requires(PAL p, void* vp, std::size_t sz)
+  concept ConceptPAL_reserve =
+    requires(PAL p, std::size_t sz)
   {
-    { PAL::reserve_at_least(sz) } noexcept
-      -> ConceptSame<std::pair<void*, std::size_t>>;
+    { PAL::reserve(sz) } noexcept -> ConceptSame<void*>;
   };
 
   /**
@@ -102,10 +101,11 @@ namespace snmalloc
     (!pal_supports<LowMemoryNotification, PAL> ||
       ConceptPAL_mem_low_notify<PAL>) &&
     (pal_supports<NoAllocation, PAL> ||
-     (pal_supports<AlignedAllocation, PAL> &&
-        ConceptPAL_reserve_aligned<PAL>) ||
-     (!pal_supports<AlignedAllocation, PAL> &&
-          ConceptPAL_reserve_at_least<PAL>));
+     (
+       (!pal_supports<AlignedAllocation, PAL> ||
+         ConceptPAL_reserve_aligned<PAL>) &&
+      ConceptPAL_reserve<PAL>)
+    );
 
 } // namespace snmalloc
 #endif

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -185,26 +185,9 @@ namespace snmalloc
     }
 #  endif
 
-    static std::pair<void*, size_t> reserve_at_least(size_t size) noexcept
+    static void* reserve(size_t size) noexcept
     {
-      SNMALLOC_ASSERT(bits::is_pow2(size));
-
-      // Magic number for over-allocating chosen by the Pal
-      // These should be further refined based on experiments.
-      constexpr size_t min_size =
-        bits::is64() ? bits::one_at_bit(32) : bits::one_at_bit(28);
-      for (size_t size_request = bits::max(size, min_size);
-           size_request >= size;
-           size_request = size_request / 2)
-      {
-        void* ret =
-          VirtualAlloc(nullptr, size_request, MEM_RESERVE, PAGE_READWRITE);
-        if (ret != nullptr)
-        {
-          return std::pair(ret, size_request);
-        }
-      }
-      error("Failed to allocate memory\n");
+      return VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
     }
 
     /**

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -21,7 +21,8 @@ int main()
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.
   // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
-  auto [oe_base, size] = Pal::reserve_at_least(bits::one_at_bit(28));
+  auto size = bits::one_at_bit(28);
+  auto oe_base = Pal::reserve(size);
   Pal::notify_using<NoZero>(oe_base, size);
   auto oe_end = pointer_offset(oe_base, size);
   std::cout << "Allocated region " << oe_base << " - "

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -18,18 +18,14 @@ int main()
 {
 #ifndef SNMALLOC_PASS_THROUGH // Depends on snmalloc specific features
 
-  // Create a standard address space to get initial allocation
-  // this just bypasses having to understand the test platform.
-  AddressSpaceManager<DefaultPal> address_space;
-
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.
   // For 1MiB superslabs, SUPERSLAB_BITS + 4 is not big enough for the example.
-  size_t size = bits::one_at_bit(28);
-  auto oe_base = address_space.reserve<true>(size);
-  auto oe_end = pointer_offset(oe_base, size).unsafe_ptr();
-  std::cout << "Allocated region " << oe_base.unsafe_ptr() << " - "
-            << pointer_offset(oe_base, size).unsafe_ptr() << std::endl;
+  auto [oe_base, size] = Pal::reserve_at_least(bits::one_at_bit(28));
+  Pal::notify_using<NoZero>(oe_base, size);
+  auto oe_end = pointer_offset(oe_base, size);
+  std::cout << "Allocated region " << oe_base << " - "
+            << pointer_offset(oe_base, size) << std::endl;
 
   CustomGlobals fixed_handle;
   CustomGlobals::init(oe_base, size);
@@ -47,7 +43,7 @@ int main()
     if (r1 == nullptr)
       break;
 
-    if (oe_base.unsafe_ptr() > r1)
+    if (oe_base > r1)
     {
       std::cout << "Allocated: " << r1 << std::endl;
       abort();

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -68,7 +68,8 @@ void test_pagemap(bool bounded)
   // Initialise the pagemap
   if (bounded)
   {
-    auto [base, size] = Pal::reserve_at_least(bits::one_at_bit(30));
+    auto size = bits::one_at_bit(30);
+    auto base = Pal::reserve(size);
     Pal::notify_using<NoZero>(base, size);
     std::cout << "Fixed base: " << base << " (" << size << ") "
               << " end: " << pointer_offset(base, size) << std::endl;

--- a/src/test/func/two_alloc_types/alloc1.cc
+++ b/src/test/func/two_alloc_types/alloc1.cc
@@ -20,6 +20,5 @@ namespace snmalloc
 extern "C" void oe_allocator_init(void* base, void* end)
 {
   snmalloc::CustomGlobals fixed_handle;
-  fixed_handle.init(
-    CapPtr<void, CBChunk>(base), address_cast(end) - address_cast(base));
+  fixed_handle.init(base, address_cast(end) - address_cast(base));
 }

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -32,6 +32,8 @@ namespace test
         size = 16;
       // store object
       objects[i] = (size_t*)alloc.alloc(size);
+      if (objects[i] == nullptr)
+        abort();
       // Store allocators size for this object
       *objects[i] = alloc.alloc_size(objects[i]);
     }


### PR DESCRIPTION
The primary aim of this PR is to be able to enforce the invariant that all memory in the address space manager has committed pages for the corresponding entries in the pagemap.  This will improve windows support, and enable turning off pages inside the pagemap that are no currently required. 

To support this, I have made all Pals that perform allocation provide `reserve_at_least`. 