### PR TITLE
Add protection to meta-data

### DIFF
--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -204,8 +204,8 @@ namespace snmalloc
 
   struct MetaslabCache : public CDLLNode<>
   {
-    uint16_t unused;
-    uint16_t length;
+    uint16_t unused = 0;
+    uint16_t length = 0;
   };
 
 } // namespace snmalloc

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -54,7 +54,7 @@ namespace snmalloc
       if (p == nullptr)
       {
         SharedStateHandle::Backend::Pal::error(
-          "Failed to initialisation thread local allocator.");
+          "Failed to initialise thread local allocator.");
       }
 
       FlagLock f(pool.lock);

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -1,5 +1,6 @@
 #include "mem/fixedglobalconfig.h"
 #include "mem/globalconfig.h"
+#include "test/setup.h"
 
 #include <iostream>
 #include <snmalloc.h>
@@ -17,6 +18,7 @@ using FixedAlloc = LocalAllocator<CustomGlobals>;
 int main()
 {
 #ifndef SNMALLOC_PASS_THROUGH // Depends on snmalloc specific features
+  setup();
 
   // 28 is large enough to produce a nested allocator.
   // It is also large enough for the example to run in.
@@ -34,11 +36,18 @@ int main()
 
   size_t object_size = 128;
   size_t count = 0;
+  size_t i = 0;
   while (true)
   {
     auto r1 = a.alloc(object_size);
     count += object_size;
+    i++;
 
+    if (i == 1024)
+    {
+      i = 0;
+      std::cout << ".";
+    }
     // Run until we exhaust the fixed region.
     // This should return null.
     if (r1 == nullptr)

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -1,12 +1,13 @@
-#if defined(WIN32) && defined(SNMALLOC_CI_BUILD)
-#  include <ds/bits.h>
-#  include <iostream>
-#  include <pal/pal.h>
-#  include <signal.h>
-#  include <stdlib.h>
+#if defined(SNMALLOC_CI_BUILD)
+#  if defined(WIN32)
+#    include <ds/bits.h>
+#    include <iostream>
+#    include <pal/pal.h>
+#    include <signal.h>
+#    include <stdlib.h>
 // Has to come after the PAL.
-#  include <DbgHelp.h>
-#  pragma comment(lib, "dbghelp.lib")
+#    include <DbgHelp.h>
+#    pragma comment(lib, "dbghelp.lib")
 
 void print_stack_trace()
 {
@@ -94,6 +95,20 @@ void setup()
   // Disable OS level dialog boxes during CI.
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 }
+#  else
+#    include <pal/pal.h>
+#    include <signal.h>
+void error_handle(int signal)
+{
+  UNUSED(signal);
+  snmalloc::error("Seg Fault");
+  _exit(1);
+}
+void setup()
+{
+  signal(SIGSEGV, error_handle);
+}
+#  endif
 #else
 void setup() {}
 #endif


### PR DESCRIPTION
The meta-data in the `CHECK_CLIENT` mode is allocated from its own areas,
where most of the pages have been disabled, and the location within this
range is randomised.

This protects from trivial OOB read/write hitting the meta-data.
More complex controlled offsets are also mitigated due to the sparse
level of pages being turned on (i.e. not `PROT_NONE`).
