### PR TITLE
Remove globalconfig.h includes.

### DIFF
--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../ds/helpers.h"
-#include "globalconfig.h"
 #include "localalloc.h"
 
 #if defined(SNMALLOC_EXTERNAL_THREAD_ALLOC)

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -2,6 +2,7 @@
 #include "../snmalloc_core.h"
 
 #ifndef SNMALLOC_PROVIDE_OWN_CONFIG
+#  include "../mem/globalconfig.h"
 // The default configuration for snmalloc is used if alternative not defined
 namespace snmalloc
 {

--- a/src/snmalloc.h
+++ b/src/snmalloc.h
@@ -3,6 +3,9 @@
 // Core implementation of snmalloc independent of the configuration mode
 #include "snmalloc_core.h"
 
+// Default implementation of global state
+#include "mem/globalconfig.h"
+
 // The default configuration for snmalloc
 namespace snmalloc
 {

--- a/src/snmalloc_core.h
+++ b/src/snmalloc_core.h
@@ -1,4 +1,3 @@
 #pragma once
 
 #include "mem/globalalloc.h"
-#include "mem/globalconfig.h"

--- a/src/test/func/fixed_region/fixed_region.cc
+++ b/src/test/func/fixed_region/fixed_region.cc
@@ -1,5 +1,4 @@
 #include "mem/fixedglobalconfig.h"
-#include "mem/globalconfig.h"
 #include "test/setup.h"
 
 #include <iostream>

--- a/src/test/func/thread_alloc_external/thread_alloc_external.cc
+++ b/src/test/func/thread_alloc_external/thread_alloc_external.cc
@@ -3,6 +3,9 @@
 
 // Specify using own
 #define SNMALLOC_EXTERNAL_THREAD_ALLOC
+
+#include "mem/globalconfig.h"
+
 namespace snmalloc
 {
   using Alloc = snmalloc::LocalAllocator<snmalloc::Globals>;


### PR DESCRIPTION
This reduces the number of places that `globalconfig.h` is compiled to add building alternative backends.