### PR TITLE
Correct REMOTE_MIN_ALIGN

### DIFF
--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -10,10 +10,19 @@
 
 namespace snmalloc
 {
-  // Remotes need to be aligned enough that all the
-  // small size classes can fit in the bottom bits.
-  static constexpr size_t REMOTE_MIN_ALIGN = bits::min<size_t>(
-    CACHELINE_SIZE, bits::next_pow2_const(NUM_SIZECLASSES + 1));
+  // Remotes need to be aligned enough that the bottom bits have enough room for
+  // all the size classes, both large and small.
+  //
+  // Including large classes in this calculation might seem remarkably strange,
+  // since large allocations don't have associated Remotes, that is, their
+  // remote is taken to be 0.  However, if there are very few small size
+  // classes and many large classes, the attempt to align that 0 down by the
+  // alignment of a Remote might result in a nonzero value.
+  static constexpr size_t REMOTE_MIN_ALIGN = bits::max<size_t>(
+    CACHELINE_SIZE,
+    bits::max<size_t>(
+      bits::next_pow2_const(NUM_SIZECLASSES + 1),
+      bits::next_pow2_const(NUM_LARGE_CLASSES + 1)));
 
   /**
    * Global key for all remote lists.


### PR DESCRIPTION
Take the maximum of...

* CACHELINE_SIZE (for performance)

* next_pow2(NUM_SIZECLASSES + 1) so that, when the pagemap points to a Remote,
  the (small) size class stuffed in the bottom bits can be removed by alignment

* next_pow2(NUM_LARGE_CLASSES + 1) so that, when the pagemap isn't pointing to
  a Remote, when the associated chunk is (part of) a large allocation, aligning
  the Remote* results in 0.

The last of these conditions will almost never be the deciding factor, as there
are generally many more small size classes than large ones, but it shouldn't
hurt to be safe.