### PR TITLE
XOR encoded next_object

### DIFF
--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -131,3 +131,12 @@ check_client_impl(bool test, const char* const str)
 #else
 #  define check_client(test, str)
 #endif
+
+namespace snmalloc
+{
+#ifdef SNMALLOC_CHECK_CLIENT
+  static constexpr bool CHECK_CLIENT = true;
+#else
+  static constexpr bool CHECK_CLIENT = false;
+#endif
+} // namespace snmalloc

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -141,7 +141,7 @@ namespace snmalloc
     {
       auto slab_end = pointer_offset(bumpptr, slab_size + 1 - rsize);
 
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       FreeListBuilder<false> b;
       SNMALLOC_ASSERT(b.empty());
@@ -209,7 +209,7 @@ namespace snmalloc
 
     ChunkRecord* clear_slab(Metaslab* meta, sizeclass_t sizeclass)
     {
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
       FreeListIter fl;
       meta->free_queue.close(fl, key);
       void* p = finish_alloc_no_zero(fl.take(key), sizeclass);
@@ -475,7 +475,7 @@ namespace snmalloc
 
       auto cp = CapPtr<FreeObject, CBAlloc>(reinterpret_cast<FreeObject*>(p));
 
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       // Update the head and the next pointer in the free list.
       meta->free_queue.add(cp, key, entropy);
@@ -538,7 +538,7 @@ namespace snmalloc
       // Set meta slab to empty.
       meta->initialise(sizeclass);
 
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       // take an allocation from the free list
       auto p = fast_free_list.take(key);

--- a/src/mem/globalconfig.h
+++ b/src/mem/globalconfig.h
@@ -6,6 +6,8 @@
 #include "../mem/slaballocator.h"
 #include "commonconfig.h"
 
+#include <iostream>
+
 namespace snmalloc
 {
   // Forward reference to thread local cleanup.
@@ -73,8 +75,10 @@ namespace snmalloc
       if (initialised)
         return;
 
+      LocalEntropy entropy;
+      entropy.init<Pal>();
       // Initialise key for remote deallocation lists
-      key_global = FreeListKey(get_entropy64<Backend::Pal>());
+      key_global = FreeListKey(entropy.get_free_list_key());
 
       // Need to initialise pagemap.
       backend_state.init();

--- a/src/mem/localcache.h
+++ b/src/mem/localcache.h
@@ -76,7 +76,7 @@ namespace snmalloc
       typename SharedStateHandle>
     bool flush(DeallocFun dealloc, SharedStateHandle handle)
     {
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       // Return all the free lists to the allocator.
       // Used during thread teardown
@@ -98,7 +98,7 @@ namespace snmalloc
     template<ZeroMem zero_mem, typename SharedStateHandle, typename Slowpath>
     SNMALLOC_FAST_PATH void* alloc(size_t size, Slowpath slowpath)
     {
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       sizeclass_t sizeclass = size_to_sizeclass(size);
       stats.alloc_request(size);

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -142,7 +142,7 @@ namespace snmalloc
       LocalEntropy& entropy,
       sizeclass_t sizeclass)
     {
-      FreeListKey key(entropy.get_constant_key());
+      auto& key = entropy.get_free_list_key();
 
       FreeListIter tmp_fl;
       meta->free_queue.close(tmp_fl, key);

--- a/src/mem/remotecache.h
+++ b/src/mem/remotecache.h
@@ -67,7 +67,7 @@ namespace snmalloc
     SNMALLOC_FAST_PATH void dealloc(
       RemoteAllocator::alloc_id_t target_id,
       CapPtr<void, CBAlloc> p,
-      FreeListKey& key)
+      const FreeListKey& key)
     {
       SNMALLOC_ASSERT(initialised);
       auto r = p.template as_reinterpret<FreeObject>();
@@ -79,7 +79,7 @@ namespace snmalloc
     bool post(
       SharedStateHandle handle,
       RemoteAllocator::alloc_id_t id,
-      FreeListKey& key)
+      const FreeListKey& key)
     {
       SNMALLOC_ASSERT(initialised);
       size_t post_round = 0;
@@ -96,7 +96,7 @@ namespace snmalloc
 
           if (!list[i].empty())
           {
-            auto [first, last] = list[i].extract_segment();
+            auto [first, last] = list[i].extract_segment(key);
             MetaEntry entry = SharedStateHandle::Backend::get_meta_data(
               handle.get_backend_state(), address_cast(first));
             entry.get_remote()->enqueue(first, last, key);


### PR DESCRIPTION
This commit adds a simple XOR encoding to the next_object pointer in
FreeObjects.  This removes the trivial way of getting hold of a physical
address from the system by observing the free list pointers in
deallocated objects.