### PR TITLE
Add cross CI for Ubuntu powerpc64el

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         build-type: [ Release, Debug ]
-        arch: [ arm64, armhf ]
+        arch: [ arm64, armhf, ppc64el ]
         include:
           - arch: armhf
             system-processor: arm
@@ -97,6 +97,10 @@ jobs:
             system-processor: aarch64
             triple: aarch64-linux-gnu
             rtld: ld-linux-aarch64.so.1
+          - arch: ppc64el
+            system-processor: powerpc64le
+            triple: powerpc64le-linux-gnu
+            rtld: ld64.so.2
       # Don't abort runners if a single one fails
       fail-fast: false
     runs-on: ubuntu-latest


### PR DESCRIPTION
The naming is more than a little confusing.  AIUI, in Ubuntu's terminology, the
`powerpc` packages are for 32-bit machines, the `ppc64-powerpc` packages are for
Big Endian 64-bit machines, and the `ppc64el` packages are for Little Endian
64-bit machines.

Everyone seems to have agreed that the long-term answer for 64-bit PowerPC is
Little Endian (Debian maintains an unofficial BE port, but Canonical/Ubuntu,
RedHat, and SUSE all seem to have standardized on LE).

For maximal confusion, the appropriate triple's first component is, however,
`powerpc64le`.