### PR TITLE
Force global pagemaps into BSS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,9 @@ jobs:
       if: ${{ matrix.build-only != 'yes' }}
       working-directory: ${{github.workspace}}/build
       run: ctest --output-on-failure -j 4
+    - name: Test file size of binaries is sane
+      working-directory: ${{github.workspace}}/build
+      run: [ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]
     - name: Selfhost
       if: ${{ matrix.self-host }}
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       run: NINJA_STATUS="%p [%f:%s/%t] %o/s, %es" ninja
     - name: Test file size of binaries is sane
       working-directory: ${{github.workspace}}/build
-      run: 'ls -l func-first_operation-1 ; [ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]'
+      run: "ls -l func-first_operation-1 ; [ $(ls -l func-first_operation-1 | awk '{ print $5}') -lt 10000000 ]"
       # If the tests are enabled for this job, run them
     - name: Test
       if: ${{ matrix.build-only != 'yes' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,14 +66,14 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       run: NINJA_STATUS="%p [%f:%s/%t] %o/s, %es" ninja
+    - name: Test file size of binaries is sane
+      working-directory: ${{github.workspace}}/build
+      run: 'ls -l func-first_operation-1 ; [ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]'
       # If the tests are enabled for this job, run them
     - name: Test
       if: ${{ matrix.build-only != 'yes' }}
       working-directory: ${{github.workspace}}/build
       run: ctest --output-on-failure -j 4
-    - name: Test file size of binaries is sane
-      working-directory: ${{github.workspace}}/build
-      run: '[ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]'
     - name: Selfhost
       if: ${{ matrix.self-host }}
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
       run: ctest --output-on-failure -j 4
     - name: Test file size of binaries is sane
       working-directory: ${{github.workspace}}/build
-      run: [ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]
+      run: '[ $(ls -l func-first_operation-1 | cut -f 5 -w -) -lt 10000000 ]'
     - name: Selfhost
       if: ${{ matrix.self-host }}
       working-directory: ${{github.workspace}}/build

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -44,6 +44,14 @@
 #  endif
 #endif
 
+#ifdef __APPLE__
+#  define SNMALLOC_FORCE_BSS __attribute__((section("__DATA,__bss")))
+#elif defined(__ELF__)
+#  define SNMALLOC_FORCE_BSS __attribute__((section(".bss")))
+#else
+#  define SNMALLOC_FORCE_BSS
+#endif
+
 #ifndef __has_builtin
 #  define __has_builtin(x) 0
 #endif

--- a/src/mem/pagemap.h
+++ b/src/mem/pagemap.h
@@ -464,6 +464,7 @@ namespace snmalloc
      * The global pagemap variable.  The name of this symbol will include the
      * type of `T` and `U`.
      */
+    SNMALLOC_FORCE_BSS
     inline static T global_pagemap;
 
   public:


### PR DESCRIPTION
Also add a check that the test programs are under about ten megabytes
(they're currently around one on platforms that put inline statics full
of zeroes into BSS and around 270 on ones that don't).

Fixes #339