### PR TITLE
Added the ability to perform a reverse lookup in the Pagemap

### DIFF
--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -188,7 +188,7 @@ namespace snmalloc
     /**
      * Get the number of entries.
      */
-    constexpr size_t num_entries() const
+    [[nodiscard]] constexpr size_t num_entries() const
     {
       if constexpr (has_bounds)
       {
@@ -242,7 +242,7 @@ namespace snmalloc
      * Return the starting address corresponding to a given entry within the
      * Pagemap. Also checks that the reference actually points to a valid entry.
      */
-    address_t get_address(const T& t) const
+    [[nodiscard]] address_t get_address(const T& t) const
     {
       address_t entry_offset = address_cast(&t) - address_cast(body);
       address_t entry_index = entry_offset / sizeof(T);

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -246,10 +246,8 @@ namespace snmalloc
     {
       address_t entry_offset = address_cast(&t) - address_cast(body);
       address_t entry_index = entry_offset / sizeof(T);
-      if (entry_offset % sizeof(T) != 0 || entry_index >= num_entries())
-      {
-        PAL::error("Internal error: Invalid Pagemap entry for reverse lookup.");
-      }
+      SNMALLOC_ASSERT(
+        entry_offset % sizeof(T) == 0 && entry_index < num_entries());
       return base + (entry_index << GRANULARITY_BITS);
     }
 

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -186,6 +186,21 @@ namespace snmalloc
     }
 
     /**
+     * Get the number of entries.
+     */
+    constexpr size_t num_entries() const
+    {
+      if constexpr (has_bounds)
+      {
+        return size >> GRANULARITY_BITS;
+      }
+      else
+      {
+        return bits::one_at_bit(bits::ADDRESS_BITS - GRANULARITY_BITS);
+      }
+    }
+
+    /**
      * If the location has not been used before, then
      * `potentially_out_of_range` should be set to true.
      * This will ensure there is a location for the
@@ -221,6 +236,21 @@ namespace snmalloc
       }
 
       return body[p >> SHIFT];
+    }
+
+    /**
+     * Return the starting address corresponding to a given entry within the
+     * Pagemap. Also checks that the reference actually points to a valid entry.
+     */
+    address_t get_address(const T& t) const
+    {
+      address_t entry_offset = address_cast(&t) - address_cast(body);
+      address_t entry_index = entry_offset / sizeof(T);
+      if (entry_offset % sizeof(T) != 0 || entry_index >= num_entries())
+      {
+        PAL::error("Internal error: Invalid Pagemap entry for reverse lookup.");
+      }
+      return base + (entry_index << GRANULARITY_BITS);
     }
 
     void set(address_t p, T t)


### PR DESCRIPTION
Given a const reference to an entry in the Pagemap (as the one returned by get), return the base address of the range it corresponds to.