### PR TITLE
Use atomics to serialize large deallocs

### DIFF
--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -271,6 +271,11 @@ namespace snmalloc
       return pagemap.template get<potentially_out_of_range>(p);
     }
 
+    static MetaEntry& get_meta_data_mut(address_t p)
+    {
+      return pagemap.get_mut(p);
+    }
+
     /**
      * Set the metadata associated with a chunk.
      */

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -239,6 +239,23 @@ namespace snmalloc
     }
 
     /**
+     * Like get, but gives mutable access to a real pagemap entry.
+     */
+    T& get_mut(address_t p)
+    {
+      if constexpr (has_bounds)
+      {
+        if (p - base > size)
+        {
+          PAL::error("Internal error: Pagemap read access out of range.");
+        }
+        p = p - base;
+      }
+
+      return body[p >> SHIFT];
+    }
+
+    /**
      * Return the starting address corresponding to a given entry within the
      * Pagemap. Also checks that the reference actually points to a valid entry.
      */

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -198,11 +198,6 @@ namespace snmalloc
 #endif
     Val v;
 
-  public:
-    /**
-     * Construct a reference to this value; use .load and .store to manipulate
-     * the value.
-     */
     SNMALLOC_FAST_PATH Ref ref()
     {
 #ifdef __cpp_lib_atomic_ref
@@ -212,10 +207,16 @@ namespace snmalloc
 #endif
     }
 
+  public:
     SNMALLOC_FAST_PATH T
-    load(std::memory_order mo = std::memory_order_seq_cst) noexcept
+    load(std::memory_order mo = std::memory_order_seq_cst) const noexcept
     {
-      return this->ref().load(mo);
+      /* Unfortunately, we can't use ref() here, since we desire const-ness. */
+#ifdef __cpp_lib_atomic_ref
+      return std::atomic_ref<const T>(this->v).load(mo);
+#else
+      return this->v.load(mo);
+#endif
     }
 
     SNMALLOC_FAST_PATH void


### PR DESCRIPTION
I'm not sure this is the right approach, and so am quite open to suggestions.  But, AFAICT, there's nothing otherwise preventing two LocalAlloc-s from attempting to thread the same large allocation (which are not considered "owned") onto their free lists in parallel, which would lead to all kinds of future excitement.