### PR TITLE
Make threshold for waking always a percentage

### DIFF
--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -100,7 +100,11 @@ namespace snmalloc
           static_cast<uint16_t>((slab_mask[sizeclass] + 1) / rsize);
 
         waking[sizeclass] =
+#ifdef SNMALLOC_CHECK_CLIENT
+          static_cast<uint16_t>(capacity[sizeclass] / 4);
+#else
           static_cast<uint16_t>(bits::min((capacity[sizeclass] / 4), 32));
+#endif
       }
 
       for (sizeclass_compress_t sizeclass = NUM_SIZECLASSES;


### PR DESCRIPTION
The threshold for waking is used to ensure that we only use a slab when
it has sufficient space that we won't hit the slow path to soon after
using this slab. In the checked version, this is also used to give some
entropy in layout.  Changing this to always be a pertcentage in the
checked case increases the effectiveness of the free list to detect OOB
write.