### PR TITLE
Changes to integrate snmalloc2 into Verona

### DIFF
--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -13,7 +13,7 @@ namespace snmalloc
    * initialised.  This singleton class is designed to not depend on the
    * runtime.
    */
-  template<class Object, Object init() noexcept>
+  template<class Object, void init(Object*) noexcept>
   class Singleton
   {
     inline static std::atomic_flag flag;
@@ -36,7 +36,7 @@ namespace snmalloc
         FlagLock lock(flag);
         if (!initialised)
         {
-          obj = init();
+          init(&obj);
           initialised.store(true, std::memory_order_release);
           if (first != nullptr)
             *first = true;

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -786,6 +786,9 @@ namespace snmalloc
     }
   };
 
+  /**
+   * Use this alias to access the pool of allocators throughout snmalloc.
+   */
   template<typename SharedStateHandle>
   using AllocPool = Pool<
     CoreAllocator<SharedStateHandle>,

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -785,4 +785,10 @@ namespace snmalloc
       return debug_is_empty_impl(result);
     }
   };
+
+  template<typename SharedStateHandle>
+  using AllocPool = Pool<
+    CoreAllocator<SharedStateHandle>,
+    SharedStateHandle,
+    SharedStateHandle::pool>;
 } // namespace snmalloc

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -4,7 +4,7 @@
 #include "allocconfig.h"
 #include "localcache.h"
 #include "metaslab.h"
-#include "pooled.h"
+#include "pool.h"
 #include "remotecache.h"
 #include "sizeclasstable.h"
 #include "slaballocator.h"

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -11,7 +11,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto* alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
     while (alloc != nullptr)
@@ -20,7 +20,7 @@ namespace snmalloc
       if (a != nullptr)
         stats.add(*a);
       stats.add(alloc->stats());
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
     }
   }
@@ -32,7 +32,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
     while (alloc != nullptr)
@@ -40,7 +40,7 @@ namespace snmalloc
       auto stats = alloc->stats();
       if (stats != nullptr)
         stats->template print<decltype(alloc)>(o, dumpid, alloc->id());
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
     }
   }
@@ -64,7 +64,7 @@ namespace snmalloc
     // allocators that are not currently in use by any thread.
     // One atomic operation to extract the stack, another to restore it.
     // Handling the message queue for each stack is non-atomic.
-    auto* first = Pool<CoreAllocator<SharedStateHandle>>::extract();
+    auto* first = AllocPool<CoreAllocator<SharedStateHandle>>::extract();
     auto* alloc = first;
     decltype(alloc) last;
 
@@ -74,10 +74,10 @@ namespace snmalloc
       {
         alloc->flush();
         last = alloc;
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::extract(alloc);
+        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::extract(alloc);
       }
 
-      Pool<CoreAllocator<SharedStateHandle>>::restore(first, last);
+      AllocPool<CoreAllocator<SharedStateHandle>>::restore(first, last);
     }
 #endif
   }
@@ -96,7 +96,7 @@ namespace snmalloc
       "Global status is available only for pool-allocated configurations");
     // This is a debugging function. It checks that all memory from all
     // allocators has been freed.
-    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto* alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
 #  ifdef SNMALLOC_TRACING
@@ -111,7 +111,7 @@ namespace snmalloc
       std::cout << "debug_check_empty: Check all allocators!" << std::endl;
 #  endif
       done = true;
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>();
       okay = true;
 
@@ -134,7 +134,7 @@ namespace snmalloc
 #  ifdef SNMALLOC_TRACING
         std::cout << "debug check empty: okay = " << okay << std::endl;
 #  endif
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
           SharedStateHandle>(alloc);
       }
     }
@@ -148,12 +148,12 @@ namespace snmalloc
     // Redo check so abort is on allocator with allocation left.
     if (!okay)
     {
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>();
       while (alloc != nullptr)
       {
         alloc->debug_is_empty(nullptr);
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
           SharedStateHandle>(alloc);
       }
     }
@@ -168,7 +168,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global status is available only for pool-allocated configurations");
-    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
     while (alloc != nullptr)
     {
@@ -180,7 +180,7 @@ namespace snmalloc
         }
         count--;
       }
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
 
       if (count != 0)

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -11,8 +11,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto* alloc =
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+    auto* alloc = AllocPool<SharedStateHandle>::iterate();
 
     while (alloc != nullptr)
     {
@@ -20,9 +19,7 @@ namespace snmalloc
       if (a != nullptr)
         stats.add(*a);
       stats.add(alloc->stats());
-      alloc =
-        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
-          alloc);
+      alloc = AllocPool<SharedStateHandle>::iterate(alloc);
     }
   }
 
@@ -33,17 +30,14 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto alloc =
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+    auto alloc = AllocPool<SharedStateHandle>::iterate();
 
     while (alloc != nullptr)
     {
       auto stats = alloc->stats();
       if (stats != nullptr)
         stats->template print<decltype(alloc)>(o, dumpid, alloc->id());
-      alloc =
-        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
-          alloc);
+      alloc = AllocPool<SharedStateHandle>::iterate(alloc);
     }
   }
 #else
@@ -66,8 +60,7 @@ namespace snmalloc
     // allocators that are not currently in use by any thread.
     // One atomic operation to extract the stack, another to restore it.
     // Handling the message queue for each stack is non-atomic.
-    auto* first =
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::extract();
+    auto* first = AllocPool<SharedStateHandle>::extract();
     auto* alloc = first;
     decltype(alloc) last;
 
@@ -77,13 +70,10 @@ namespace snmalloc
       {
         alloc->flush();
         last = alloc;
-        alloc =
-          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::extract(
-            alloc);
+        alloc = AllocPool<SharedStateHandle>::extract(alloc);
       }
 
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::restore(
-        first, last);
+      AllocPool<SharedStateHandle>::restore(first, last);
     }
 #endif
   }
@@ -102,8 +92,7 @@ namespace snmalloc
       "Global status is available only for pool-allocated configurations");
     // This is a debugging function. It checks that all memory from all
     // allocators has been freed.
-    auto* alloc =
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+    auto* alloc = AllocPool<SharedStateHandle>::iterate();
 
 #  ifdef SNMALLOC_TRACING
     std::cout << "debug check empty: first " << alloc << std::endl;
@@ -117,8 +106,7 @@ namespace snmalloc
       std::cout << "debug_check_empty: Check all allocators!" << std::endl;
 #  endif
       done = true;
-      alloc =
-        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+      alloc = AllocPool<SharedStateHandle>::iterate();
       okay = true;
 
       while (alloc != nullptr)
@@ -140,9 +128,7 @@ namespace snmalloc
 #  ifdef SNMALLOC_TRACING
         std::cout << "debug check empty: okay = " << okay << std::endl;
 #  endif
-        alloc =
-          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
-            alloc);
+        alloc = AllocPool<SharedStateHandle>::iterate(alloc);
       }
     }
 
@@ -155,14 +141,11 @@ namespace snmalloc
     // Redo check so abort is on allocator with allocation left.
     if (!okay)
     {
-      alloc =
-        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+      alloc = AllocPool<SharedStateHandle>::iterate();
       while (alloc != nullptr)
       {
         alloc->debug_is_empty(nullptr);
-        alloc =
-          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
-            alloc);
+        alloc = AllocPool<SharedStateHandle>::iterate(alloc);
       }
     }
 #else
@@ -176,8 +159,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global status is available only for pool-allocated configurations");
-    auto alloc =
-      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
+    auto alloc = AllocPool<SharedStateHandle>::iterate();
     while (alloc != nullptr)
     {
       if (alloc->debug_is_in_use())
@@ -188,9 +170,7 @@ namespace snmalloc
         }
         count--;
       }
-      alloc =
-        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
-          alloc);
+      alloc = AllocPool<SharedStateHandle>::iterate(alloc);
 
       if (count != 0)
       {

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -11,7 +11,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto* alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
     while (alloc != nullptr)
@@ -20,7 +20,7 @@ namespace snmalloc
       if (a != nullptr)
         stats.add(*a);
       stats.add(alloc->stats());
-      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
     }
   }
@@ -32,7 +32,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
     while (alloc != nullptr)
@@ -40,7 +40,7 @@ namespace snmalloc
       auto stats = alloc->stats();
       if (stats != nullptr)
         stats->template print<decltype(alloc)>(o, dumpid, alloc->id());
-      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
     }
   }
@@ -64,7 +64,7 @@ namespace snmalloc
     // allocators that are not currently in use by any thread.
     // One atomic operation to extract the stack, another to restore it.
     // Handling the message queue for each stack is non-atomic.
-    auto* first = AllocPool<CoreAllocator<SharedStateHandle>>::extract();
+    auto* first = Pool<CoreAllocator<SharedStateHandle>>::extract();
     auto* alloc = first;
     decltype(alloc) last;
 
@@ -74,10 +74,10 @@ namespace snmalloc
       {
         alloc->flush();
         last = alloc;
-        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::extract(alloc);
+        alloc = Pool<CoreAllocator<SharedStateHandle>>::extract(alloc);
       }
 
-      AllocPool<CoreAllocator<SharedStateHandle>>::restore(first, last);
+      Pool<CoreAllocator<SharedStateHandle>>::restore(first, last);
     }
 #endif
   }
@@ -96,7 +96,7 @@ namespace snmalloc
       "Global status is available only for pool-allocated configurations");
     // This is a debugging function. It checks that all memory from all
     // allocators has been freed.
-    auto* alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
 
 #  ifdef SNMALLOC_TRACING
@@ -111,7 +111,7 @@ namespace snmalloc
       std::cout << "debug_check_empty: Check all allocators!" << std::endl;
 #  endif
       done = true;
-      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>();
       okay = true;
 
@@ -134,7 +134,7 @@ namespace snmalloc
 #  ifdef SNMALLOC_TRACING
         std::cout << "debug check empty: okay = " << okay << std::endl;
 #  endif
-        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
           SharedStateHandle>(alloc);
       }
     }
@@ -148,12 +148,12 @@ namespace snmalloc
     // Redo check so abort is on allocator with allocation left.
     if (!okay)
     {
-      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>();
       while (alloc != nullptr)
       {
         alloc->debug_is_empty(nullptr);
-        alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
           SharedStateHandle>(alloc);
       }
     }
@@ -168,7 +168,7 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global status is available only for pool-allocated configurations");
-    auto alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
       SharedStateHandle>();
     while (alloc != nullptr)
     {
@@ -180,7 +180,7 @@ namespace snmalloc
         }
         count--;
       }
-      alloc = AllocPool<CoreAllocator<SharedStateHandle>>::template iterate<
+      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
         SharedStateHandle>(alloc);
 
       if (count != 0)

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -11,8 +11,8 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-      SharedStateHandle>();
+    auto* alloc =
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
 
     while (alloc != nullptr)
     {
@@ -20,8 +20,9 @@ namespace snmalloc
       if (a != nullptr)
         stats.add(*a);
       stats.add(alloc->stats());
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-        SharedStateHandle>(alloc);
+      alloc =
+        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
+          alloc);
     }
   }
 
@@ -32,16 +33,17 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global statistics are available only for pool-allocated configurations");
-    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-      SharedStateHandle>();
+    auto alloc =
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
 
     while (alloc != nullptr)
     {
       auto stats = alloc->stats();
       if (stats != nullptr)
         stats->template print<decltype(alloc)>(o, dumpid, alloc->id());
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-        SharedStateHandle>(alloc);
+      alloc =
+        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
+          alloc);
     }
   }
 #else
@@ -64,7 +66,8 @@ namespace snmalloc
     // allocators that are not currently in use by any thread.
     // One atomic operation to extract the stack, another to restore it.
     // Handling the message queue for each stack is non-atomic.
-    auto* first = Pool<CoreAllocator<SharedStateHandle>>::extract();
+    auto* first =
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::extract();
     auto* alloc = first;
     decltype(alloc) last;
 
@@ -74,10 +77,13 @@ namespace snmalloc
       {
         alloc->flush();
         last = alloc;
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::extract(alloc);
+        alloc =
+          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::extract(
+            alloc);
       }
 
-      Pool<CoreAllocator<SharedStateHandle>>::restore(first, last);
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::restore(
+        first, last);
     }
 #endif
   }
@@ -96,8 +102,8 @@ namespace snmalloc
       "Global status is available only for pool-allocated configurations");
     // This is a debugging function. It checks that all memory from all
     // allocators has been freed.
-    auto* alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-      SharedStateHandle>();
+    auto* alloc =
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
 
 #  ifdef SNMALLOC_TRACING
     std::cout << "debug check empty: first " << alloc << std::endl;
@@ -111,8 +117,8 @@ namespace snmalloc
       std::cout << "debug_check_empty: Check all allocators!" << std::endl;
 #  endif
       done = true;
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-        SharedStateHandle>();
+      alloc =
+        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
       okay = true;
 
       while (alloc != nullptr)
@@ -134,8 +140,9 @@ namespace snmalloc
 #  ifdef SNMALLOC_TRACING
         std::cout << "debug check empty: okay = " << okay << std::endl;
 #  endif
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-          SharedStateHandle>(alloc);
+        alloc =
+          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
+            alloc);
       }
     }
 
@@ -148,13 +155,14 @@ namespace snmalloc
     // Redo check so abort is on allocator with allocation left.
     if (!okay)
     {
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-        SharedStateHandle>();
+      alloc =
+        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
       while (alloc != nullptr)
       {
         alloc->debug_is_empty(nullptr);
-        alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-          SharedStateHandle>(alloc);
+        alloc =
+          Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
+            alloc);
       }
     }
 #else
@@ -168,8 +176,8 @@ namespace snmalloc
     static_assert(
       SharedStateHandle::Options.CoreAllocIsPoolAllocated,
       "Global status is available only for pool-allocated configurations");
-    auto alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-      SharedStateHandle>();
+    auto alloc =
+      Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate();
     while (alloc != nullptr)
     {
       if (alloc->debug_is_in_use())
@@ -180,8 +188,9 @@ namespace snmalloc
         }
         count--;
       }
-      alloc = Pool<CoreAllocator<SharedStateHandle>>::template iterate<
-        SharedStateHandle>(alloc);
+      alloc =
+        Pool<CoreAllocator<SharedStateHandle>, SharedStateHandle>::iterate(
+          alloc);
 
       if (count != 0)
       {

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -380,7 +380,7 @@ namespace snmalloc
       // Initialise the global allocator structures
       ensure_init();
       // Grab an allocator for this thread.
-      init(AllocPool<CoreAlloc>::template acquire<SharedStateHandle>(
+      init(Pool<CoreAlloc>::template acquire<SharedStateHandle>(
         &(this->local_cache)));
     }
 
@@ -403,7 +403,7 @@ namespace snmalloc
         // Return underlying allocator to the system.
         if constexpr (SharedStateHandle::Options.CoreAllocOwnsLocalState)
         {
-          AllocPool<CoreAlloc>::template release<SharedStateHandle>(core_alloc);
+          Pool<CoreAlloc>::template release<SharedStateHandle>(core_alloc);
         }
 
         // Set up thread local allocator to look like

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -380,8 +380,7 @@ namespace snmalloc
       // Initialise the global allocator structures
       ensure_init();
       // Grab an allocator for this thread.
-      init(Pool<CoreAlloc>::template acquire<SharedStateHandle>(
-        &(this->local_cache)));
+      init(Pool<CoreAlloc, SharedStateHandle>::acquire(&(this->local_cache)));
     }
 
     // Return all state in the fast allocator and release the underlying
@@ -403,7 +402,7 @@ namespace snmalloc
         // Return underlying allocator to the system.
         if constexpr (SharedStateHandle::Options.CoreAllocOwnsLocalState)
         {
-          Pool<CoreAlloc>::template release<SharedStateHandle>(core_alloc);
+          Pool<CoreAlloc, SharedStateHandle>::release(core_alloc);
         }
 
         // Set up thread local allocator to look like

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -345,7 +345,7 @@ namespace snmalloc
   public:
     constexpr LocalAllocator() = default;
     LocalAllocator(const LocalAllocator&) = delete;
-    LocalAllocator& operator= (const LocalAllocator&) = delete;
+    LocalAllocator& operator=(const LocalAllocator&) = delete;
 
     /**
      * Initialise the allocator.  For allocators that support local

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -344,6 +344,8 @@ namespace snmalloc
 
   public:
     constexpr LocalAllocator() = default;
+    LocalAllocator(const LocalAllocator&) = delete;
+    LocalAllocator& operator= (const LocalAllocator&) = delete;
 
     /**
      * Initialise the allocator.  For allocators that support local

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -58,9 +58,12 @@ namespace snmalloc
   template<class SharedStateHandle>
   class LocalAllocator
   {
-    using CoreAlloc = CoreAllocator<SharedStateHandle>;
+  public:
+    using StateHandle = SharedStateHandle;
 
   private:
+    using CoreAlloc = CoreAllocator<SharedStateHandle>;
+
     // Free list per small size class.  These are used for
     // allocation on the fast path. This part of the code is inspired by
     // mimalloc.
@@ -375,7 +378,7 @@ namespace snmalloc
       // Initialise the global allocator structures
       ensure_init();
       // Grab an allocator for this thread.
-      init(Pool<CoreAlloc>::template acquire<SharedStateHandle>(
+      init(AllocPool<CoreAlloc>::template acquire<SharedStateHandle>(
         &(this->local_cache)));
     }
 
@@ -398,7 +401,7 @@ namespace snmalloc
         // Return underlying allocator to the system.
         if constexpr (SharedStateHandle::Options.CoreAllocOwnsLocalState)
         {
-          Pool<CoreAlloc>::template release<SharedStateHandle>(core_alloc);
+          AllocPool<CoreAlloc>::template release<SharedStateHandle>(core_alloc);
         }
 
         // Set up thread local allocator to look like

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -380,7 +380,7 @@ namespace snmalloc
       // Initialise the global allocator structures
       ensure_init();
       // Grab an allocator for this thread.
-      init(Pool<CoreAlloc, SharedStateHandle>::acquire(&(this->local_cache)));
+      init(AllocPool<SharedStateHandle>::acquire(&(this->local_cache)));
     }
 
     // Return all state in the fast allocator and release the underlying
@@ -402,7 +402,7 @@ namespace snmalloc
         // Return underlying allocator to the system.
         if constexpr (SharedStateHandle::Options.CoreAllocOwnsLocalState)
         {
-          Pool<CoreAlloc, SharedStateHandle>::release(core_alloc);
+          AllocPool<SharedStateHandle>::release(core_alloc);
         }
 
         // Set up thread local allocator to look like

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -21,7 +21,7 @@ namespace snmalloc
   template<class T>
   class PoolState
   {
-    template<typename TT>
+    template<typename TT, typename SharedStateHandle>
     friend class Pool;
 
   private:
@@ -55,11 +55,11 @@ namespace snmalloc
     }
   };
 
-  template<typename T>
+  template<typename T, typename SharedStateHandle>
   class Pool
   {
   public:
-    template<typename SharedStateHandle, typename... Args>
+    template<typename... Args>
     static T* acquire(Args&&... args)
     {
       PoolState<T>& pool = SharedStateHandle::pool();
@@ -93,7 +93,6 @@ namespace snmalloc
      *
      * Do not return objects from `extract`.
      */
-    template<typename SharedStateHandle>
     static void release(T* p)
     {
       // The object's destructor is not run. If the object is "reallocated", it
@@ -103,7 +102,6 @@ namespace snmalloc
       SharedStateHandle::pool().stack.push(p);
     }
 
-    template<typename SharedStateHandle>
     static T* extract(T* p = nullptr)
     {
       // Returns a linked list of all objects in the stack, emptying the stack.
@@ -118,7 +116,6 @@ namespace snmalloc
      *
      * Do not return objects from `acquire`.
      */
-    template<typename SharedStateHandle>
     static void restore(T* first, T* last)
     {
       // Pushes a linked list of objects onto the stack. Use to put a linked
@@ -126,7 +123,6 @@ namespace snmalloc
       SharedStateHandle::pool().stack.push(first, last);
     }
 
-    template<typename SharedStateHandle>
     static T* iterate(T* p = nullptr)
     {
       if (p == nullptr)

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -9,7 +9,7 @@
 namespace snmalloc
 {
   /**
-   * Pool of Allocators.
+   * Pool of a particular type of object.
    *
    * This pool will never return objects to the OS.  It maintains a list of all
    * objects ever allocated that can be iterated (not concurrency safe).  Pooled
@@ -112,6 +112,11 @@ namespace snmalloc
     }
   };
 
+  /**
+   * Collection of static wrappers for the allocator pool.
+   * The PoolState for this particular pool type is owned by the
+   * SharedStateHandle, so there is no object state in this class.
+   */
   template<typename T>
   class AllocPool
   {

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -49,17 +49,27 @@ namespace snmalloc
      * SFINAE helper.  Matched only if `T` implements `ensure_init`.  Calls it
      * if it exists.
      */
-    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle*, int)
-      -> decltype(SharedStateHandle::ensure_init())
+    template<typename SharedStateHandle_>
+    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle_*, int)
+      -> decltype(SharedStateHandle_::ensure_init())
     {
-      SharedStateHandle::ensure_init();
+      static_assert(
+        std::is_same<SharedStateHandle, SharedStateHandle_>::value,
+        "SFINAE parameter, should only be used with SharedStateHandle");
+      SharedStateHandle_::ensure_init();
     }
 
     /**
      * SFINAE helper.  Matched only if `T` does not implement `ensure_init`.
      * Does nothing if called.
      */
-    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle*, long) {}
+    template<typename SharedStateHandle_>
+    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle_*, long)
+    {
+      static_assert(
+        std::is_same<SharedStateHandle, SharedStateHandle_>::value,
+        "SFINAE parameter, should only be used with SharedStateHandle");
+    }
 
     /**
      * Call `SharedStateHandle::ensure_init()` if it is implemented, do nothing
@@ -67,7 +77,7 @@ namespace snmalloc
      */
     SNMALLOC_FAST_PATH static void ensure_init()
     {
-      call_ensure_init(nullptr, 0);
+      call_ensure_init<SharedStateHandle>(nullptr, 0);
     }
 
     static void make_pool(PoolState<T>*) noexcept

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -8,7 +8,7 @@ namespace snmalloc
   class Pooled
   {
   private:
-    template<class TT>
+    template<class TT, typename SharedStateHandle>
     friend class Pool;
     template<class a, Construction c>
     friend class MPMCStack;

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -5,10 +5,16 @@
 namespace snmalloc
 {
   template<class T>
+  class PoolState;
+
+  template<class T>
   class Pooled
   {
-  private:
-    template<class TT, typename SharedStateHandle>
+  public:
+    template<
+      typename TT,
+      typename SharedStateHandle,
+      PoolState<TT>& get_state()>
     friend class Pool;
     template<class a, Construction c>
     friend class MPMCStack;

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -8,8 +8,10 @@ namespace snmalloc
   class Pooled
   {
   private:
-    template<class TT>
+    template<class TT, class SharedStateHandle>
     friend class Pool;
+    template<class TT>
+    friend class AllocPool;
     template<class a, Construction c>
     friend class MPMCStack;
 

--- a/src/mem/pooled.h
+++ b/src/mem/pooled.h
@@ -8,10 +8,8 @@ namespace snmalloc
   class Pooled
   {
   private:
-    template<class TT, class SharedStateHandle>
-    friend class Pool;
     template<class TT>
-    friend class AllocPool;
+    friend class Pool;
     template<class a, Construction c>
     friend class MPMCStack;
 

--- a/src/mem/threadalloc.h
+++ b/src/mem/threadalloc.h
@@ -106,11 +106,9 @@ namespace snmalloc
   /**
    * Used to give correct signature to the pthread call for the Singleton class.
    */
-  inline pthread_key_t pthread_create() noexcept
+  inline void pthread_create(pthread_key_t* key) noexcept
   {
-    pthread_key_t key;
-    pthread_key_create(&key, &pthread_cleanup);
-    return key;
+    pthread_key_create(key, &pthread_cleanup);
   }
   /**
    * Performs thread local teardown for the allocator using the pthread library.

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -19,7 +19,7 @@ struct PoolBEntry : Pooled<PoolBEntry>
   int field;
 
   PoolBEntry() : field(0){};
-  PoolBEntry(size_t f) : field(f){};
+  PoolBEntry(int f) : field(f){};
 };
 
 using PoolB = Pool<PoolBEntry, Alloc::StateHandle>;

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -1,0 +1,117 @@
+#include <snmalloc.h>
+#include <test/opt.h>
+#include <test/setup.h>
+#include <unordered_set>
+
+using namespace snmalloc;
+
+struct PoolAEntry : Pooled<PoolAEntry>
+{
+  size_t field;
+
+  PoolAEntry() : field(1){};
+};
+
+using PoolA = Pool<PoolAEntry, Alloc::StateHandle>;
+
+struct PoolBEntry : Pooled<PoolBEntry>
+{
+  size_t field;
+
+  PoolBEntry() : field(0){};
+  PoolBEntry(size_t f) : field(f){};
+};
+
+using PoolB = Pool<PoolBEntry, Alloc::StateHandle>;
+
+void test_alloc()
+{
+  auto ptr = PoolA::acquire();
+  SNMALLOC_CHECK(ptr != nullptr);
+  // Pool allocations should not be visible to debug_check_empty.
+  snmalloc::debug_check_empty<Alloc::StateHandle>();
+}
+
+void test_constructor()
+{
+  auto ptr1 = PoolA::acquire();
+  SNMALLOC_CHECK(ptr1 != nullptr);
+  SNMALLOC_CHECK(ptr1->field == 1);
+
+  auto ptr2 = PoolB::acquire();
+  SNMALLOC_CHECK(ptr2 != nullptr);
+  SNMALLOC_CHECK(ptr2->field == 0);
+
+  auto ptr3 = PoolB::acquire(1);
+  SNMALLOC_CHECK(ptr3 != nullptr);
+  SNMALLOC_CHECK(ptr3->field == 1);
+}
+
+void test_alloc_many()
+{
+  constexpr size_t count = 16'000'000 / MIN_CHUNK_SIZE;
+
+  std::unordered_set<PoolAEntry*> allocated;
+
+  for (size_t i = 0; i < count; ++i)
+  {
+    auto ptr = PoolA::acquire();
+    SNMALLOC_CHECK(ptr != nullptr);
+    allocated.insert(ptr);
+  }
+
+  for (auto ptr : allocated)
+  {
+    PoolA::release(ptr);
+  }
+}
+
+void test_alloc_dealloc()
+{
+  auto ptr = PoolA::acquire();
+  SNMALLOC_CHECK(ptr != nullptr);
+  PoolA::release(ptr);
+}
+
+void test_double_alloc()
+{
+  auto ptr1 = PoolA::acquire();
+  SNMALLOC_CHECK(ptr1 != nullptr);
+  auto ptr2 = PoolA::acquire();
+  SNMALLOC_CHECK(ptr2 != nullptr);
+  SNMALLOC_CHECK(ptr1 != ptr2);
+  PoolA::release(ptr2);
+  auto ptr3 = PoolA::acquire();
+  SNMALLOC_CHECK(ptr2 == ptr3);
+}
+
+void test_different_alloc()
+{
+  auto ptr1 = PoolA::acquire();
+  SNMALLOC_CHECK(ptr1 != nullptr);
+  PoolA::release(ptr1);
+  auto ptr2 = PoolB::acquire();
+  SNMALLOC_CHECK(ptr2 != nullptr);
+  SNMALLOC_CHECK(static_cast<void*>(ptr1) != static_cast<void*>(ptr2));
+}
+
+int main(int argc, char** argv)
+{
+  setup();
+#ifdef USE_SYSTEMATIC_TESTING
+  opt::Opt opt(argc, argv);
+  size_t seed = opt.is<size_t>("--seed", 0);
+  Virtual::systematic_bump_ptr() += seed << 17;
+#else
+  UNUSED(argc);
+  UNUSED(argv);
+#endif
+
+  test_alloc();
+  test_constructor();
+  test_alloc_many();
+  test_alloc_dealloc();
+  test_double_alloc();
+  test_different_alloc();
+  return 0;
+}


### PR DESCRIPTION
The primary change is to allow a generic usage of the Pool type, which does not just get its pool state from the SharedStateHandle (this being necessary for the pool of allocators). The SharedStateHandle template parameter is promoted to the class as all methods need it. Also the Pool class now takes a function as parameter which is the accessor to the pool state. There is a helper class to create a singleton global pool state for arbitrary types.
For ease of use I have also added an alias AllocPool<typename SharedStateHandle> for the allocator pool.
If people agree with the overall design, then I will add a test for this functionality.

An additional small change is to delete the copy constructor and copy assignment operator for LocalAllocator. This is to avoid the misuse of the ThreadAlloc::get API using the pattern `auto alloc = ThreadAlloc::get`.

Something else that I discovered, was that the new `snmalloc::debug_check_empty` API can result in corruption, if a thread is being destroyed in parallel (CoreAllocator::attached_cache is manipulated both by the thread being destroyed and the called of the global method).
When used with Verona scheduler threads, their state should be stable when invoking this API so I did not make an attempt to fix the race condition, but this is something to consider. One test in Verona does use external threads and it triggers this issue, so I had to extend the lifetime of the external thread to fix it.