### PR TITLE
Enable passthrough to an underlying allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ if(NOT DEFINED SNMALLOC_ONLY_HEADER_LIBRARY)
         # NetBSD, OpenBSD and DragonFlyBSD do not support malloc*size calls.
         set(FLAVOURS fast;check)
       else()
-        set(FLAVOURS fast;check) #malloc - TODO-need to add pass through back
+        set(FLAVOURS fast;check;malloc)
       endif()
       foreach(FLAVOUR ${FLAVOURS})
         unset(SRC)


### PR DESCRIPTION
This passes though to an underlying allocator rather than using
snmalloc.  This is required for using ASAN in Verona.  Verona takes a
close coupling with snmalloc, but to use with ASAN would require a
more work, so we pass to the system allocator in this case.

This is required to unblock https://github.com/microsoft/verona/pull/476
