### PR TITLE
Improved support for MSVC with C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ endif()
 add_library(snmalloc_lib INTERFACE)
 target_include_directories(snmalloc_lib INTERFACE src/)
 
+if(SNMALLOC_USE_CXX17)
+  target_compile_definitions(snmalloc_lib INTERFACE -DSNMALLOC_USE_CXX17)
+endif()
+
 if(NOT MSVC)
   find_package(Threads REQUIRED COMPONENTS snmalloc_lib)
   target_link_libraries(snmalloc_lib INTERFACE ${CMAKE_THREAD_LIBS_INIT})

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -7,7 +7,7 @@
 #  define unlikely(x) !!(x)
 #  define SNMALLOC_SLOW_PATH NOINLINE
 #  define SNMALLOC_FAST_PATH ALWAYSINLINE
-#  if _MSC_VER >= 1927
+#  if _MSC_VER >= 1927 && !defined(SNMALLOC_USE_CXX17)
 #    define SNMALLOC_FAST_PATH_LAMBDA [[msvc::forceinline]]
 #  else
 #    define SNMALLOC_FAST_PATH_LAMBDA


### PR DESCRIPTION
When C++17 mode is requested MSVC does not recognize forceinline, even if the compiler version is new enough. This change propagates the request to the definitions and filters on it.