### PR TITLE
Move bits/address_bits to AAL/PAL

### DIFF
--- a/src/aal/aal_concept.h
+++ b/src/aal/aal_concept.h
@@ -12,13 +12,15 @@ namespace snmalloc
 {
   /**
    * AALs must advertise the bit vector of supported features, their name,
-   * 
+   * machine word size, and an upper bound on the address space size
    */
   template<typename AAL>
   concept ConceptAAL_static_members = requires()
   {
     typename std::integral_constant<uint64_t, AAL::aal_features>;
     typename std::integral_constant<int, AAL::aal_name>;
+    typename std::integral_constant<std::size_t, AAL::bits>;
+    typename std::integral_constant<std::size_t, AAL::address_bits>;
   };
 
   /**

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -83,7 +83,7 @@ namespace snmalloc
     {
       static_assert(
         has_bounds_ == has_bounds, "Don't set SFINAE template parameter!");
-      constexpr size_t COVERED_BITS = bits::ADDRESS_BITS - GRANULARITY_BITS;
+      constexpr size_t COVERED_BITS = PAL::address_bits - GRANULARITY_BITS;
       constexpr size_t ENTRIES = bits::one_at_bit(COVERED_BITS);
       return ENTRIES * sizeof(T);
     }
@@ -204,7 +204,7 @@ namespace snmalloc
       }
       else
       {
-        return bits::one_at_bit(bits::ADDRESS_BITS - GRANULARITY_BITS);
+        return bits::one_at_bit(PAL::address_bits - GRANULARITY_BITS);
       }
     }
 

--- a/src/ds/bits.h
+++ b/src/ds/bits.h
@@ -30,12 +30,7 @@ namespace snmalloc
 
   namespace bits
   {
-    static constexpr size_t BITS = sizeof(size_t) * 8;
-
-    static constexpr bool is64()
-    {
-      return BITS == 64;
-    }
+    static constexpr size_t BITS = Aal::bits;
 
     /**
      * Returns a value of type T that has a single bit set,
@@ -51,8 +46,6 @@ namespace snmalloc
       SNMALLOC_ASSERT(sizeof(T) * 8 > static_cast<size_t>(shift));
       return (static_cast<T>(1)) << shift;
     }
-
-    static constexpr size_t ADDRESS_BITS = is64() ? 48 : 32;
 
     inline SNMALLOC_FAST_PATH size_t clz(size_t x)
     {

--- a/src/mem/slaballocator.h
+++ b/src/mem/slaballocator.h
@@ -24,7 +24,7 @@ namespace snmalloc
   /**
    * How many slab sizes that can be provided.
    */
-  constexpr size_t NUM_SLAB_SIZES = bits::ADDRESS_BITS - MIN_CHUNK_BITS;
+  constexpr size_t NUM_SLAB_SIZES = Pal::address_bits - MIN_CHUNK_BITS;
 
   /**
    * Used to ensure the per slab meta data is large enough for both use cases.

--- a/src/pal/pal_concept.h
+++ b/src/pal/pal_concept.h
@@ -26,11 +26,12 @@ namespace snmalloc
   };
 
   /**
-   * PALs must advertise their page size
+   * PALs must advertise the size of the address space and their page size
    */
   template<typename PAL>
   concept ConceptPAL_static_sizes = requires()
   {
+    typename std::integral_constant<std::size_t, PAL::address_bits>;
     typename std::integral_constant<std::size_t, PAL::page_size>;
   };
 

--- a/src/pal/pal_concept.h
+++ b/src/pal/pal_concept.h
@@ -8,17 +8,29 @@
 
 namespace snmalloc
 {
+
+  /*
+   * These concepts enforce that these are indeed constants that fit in the
+   * desired types.  (This is subtly different from saying that they are the
+   * required types; C++ may handle constants without much regard for their
+   * claimed type.)
+   */
+
   /**
-   * PALs must advertize the bit vector of their supported features and the
-   * platform's page size.  This concept enforces that these are indeed
-   * constants that fit in the desired types.  (This is subtly different from
-   * saying that they are the required types; C++ may handle constants without
-   * much regard for their claimed type.)
+   * PALs must advertize the bit vector of their supported features.
    */
   template<typename PAL>
-  concept ConceptPAL_static_members = requires()
+  concept ConceptPAL_static_features = requires()
   {
     typename std::integral_constant<uint64_t, PAL::pal_features>;
+  };
+
+  /**
+   * PALs must advertise their page size
+   */
+  template<typename PAL>
+  concept ConceptPAL_static_sizes = requires()
+  {
     typename std::integral_constant<std::size_t, PAL::page_size>;
   };
 
@@ -93,7 +105,8 @@ namespace snmalloc
    */
   template<typename PAL>
   concept ConceptPAL =
-    ConceptPAL_static_members<PAL> &&
+    ConceptPAL_static_features<PAL> &&
+    ConceptPAL_static_sizes<PAL> &&
     ConceptPAL_error<PAL> &&
     ConceptPAL_memops<PAL> &&
     (!pal_supports<Entropy, PAL> ||

--- a/src/pal/pal_noalloc.h
+++ b/src/pal/pal_noalloc.h
@@ -37,6 +37,8 @@ namespace snmalloc
 
     static constexpr size_t page_size = BasePAL::page_size;
 
+    static constexpr size_t address_bits = Aal::address_bits;
+
     /**
      * Print a stack trace.
      */

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -132,6 +132,18 @@ namespace snmalloc
 
     static constexpr size_t page_size = Aal::smallest_page_size;
 
+    /**
+     * Address bits are potentially mediated by some POSIX OSes, but generally
+     * default to the architecture's.
+     *
+     * Unlike the AALs, which are composited by explicitly delegating to their
+     * template parameters and so play a SFINAE-based game to achieve similar
+     * ends, for the PALPOSIX<> classes we instead use more traditional
+     * inheritance (e.g., PALLinux is subtype of PALPOSIX<PALLinux>) and so we
+     * can just use that mechanism here, too.
+     */
+    static constexpr size_t address_bits = Aal::address_bits;
+
     static void print_stack_trace()
     {
 #ifdef SNMALLOC_BACKTRACE_HEADER

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -63,6 +63,11 @@ namespace snmalloc
     static constexpr size_t page_size = 0x1000;
 
     /**
+     * Windows always inherits its underlying architecture's full address range.
+     */
+    static constexpr size_t address_bits = Aal::address_bits;
+
+    /**
      * Check whether the low memory state is still in effect.  This is an
      * expensive operation and should not be on any fast paths.
      */

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -292,7 +292,7 @@ void test_external_pointer_large()
 
   auto& alloc = ThreadAlloc::get();
 
-  constexpr size_t count_log = snmalloc::bits::is64() ? 5 : 3;
+  constexpr size_t count_log = Pal::address_bits > 32 ? 5 : 3;
   constexpr size_t count = 1 << count_log;
   // Pre allocate all the objects
   size_t* objects[count];

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -19,7 +19,7 @@ namespace test
     {
       size_t rand = (size_t)r.next();
       size_t offset = bits::clz(rand);
-      if constexpr (bits::is64())
+      if constexpr (Pal::address_bits > 32)
       {
         if (offset > 30)
           offset = 30;


### PR DESCRIPTION
FreeBSD RISC-V is the primary motivating example of a platform that really constrains the AS: it exposes a 38 bit AS for user programs (that is, it uses the sv39 page table format and cleaves the AS in half for kernel/user).  If we go with the traditionally hard-coded 48 bit AS estimate from `ds/bits`, we end up trying to allocate the whole user AS (48 bits in AS - 14 bits for a 16K chunk size + 4 bits for a `MetaEntry` = 38 bits of `Pagemap`).  As you might imagine, this doesn't go well for us (and it goes somehow even worse for us on CHERI when we ask for a 39-bit AS allocation...).  FreeBSD MIPS is similar and exposes a 39 bit AS and so also suffers (even if we only ask for half the AS for the Pagemap, it still doesn't really work out well for us), but I don't think that matters as much going forward.