### PR TITLE
Added constness to argv in Opt

### DIFF
--- a/src/test/opt.h
+++ b/src/test/opt.h
@@ -11,10 +11,10 @@ namespace opt
   {
   private:
     int argc;
-    char** argv;
+    const char* const* argv;
 
   public:
-    Opt(int argc, char** argv) : argc(argc), argv(argv) {}
+    Opt(int argc, const char* const* argv) : argc(argc), argv(argv) {}
 
     bool has(const char* opt)
     {


### PR DESCRIPTION
Enables more options for writing tests and Opt should not be modifying argv content anyway.