### PR TITLE
Expose notify_using_readonly

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -34,6 +34,15 @@ If the template parameter is set to `YesZero` then this function is also
 responsible for ensuring that the newly requested memory is full of zeros.
 
 ```c++
+static void notify_using_readonly(void* p, size_t size) noexcept;
+```
+Notify the system that the range of memory from `p` to `p` + `size` is now in use
+for read-only access.  This is currently only requried on platforms that support
+`LazyCommit`.
+On systems that lazily provide physical memory to virtual mappings, this
+function may not be required to do anything.
+
+```c++
 template<bool page_aligned = false>
 static void zero(void* p, size_t size) noexcept;
 ```

--- a/src/pal/pal_bsd.h
+++ b/src/pal/pal_bsd.h
@@ -34,14 +34,16 @@ namespace snmalloc
     static void notify_not_using(void* p, size_t size) noexcept
     {
       SNMALLOC_ASSERT(is_aligned_block<OS::page_size>(p, size));
-      // Call this Pal to simulate the Windows decommit in CI.
-#if defined(SNMALLOC_CHECK_CLIENT) && !defined(NDEBUG)
+
+#if !defined(NDEBUG)
       memset(p, 0x5a, size);
 #endif
       madvise(p, size, MADV_FREE);
-#ifdef SNMALLOC_CHECK_CLIENT
-      mprotect(p, size, PROT_NONE);
-#endif
+
+      if constexpr (PalEnforceAccess)
+      {
+        mprotect(p, size, PROT_NONE);
+      }
     }
   };
 } // namespace snmalloc

--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -28,7 +28,7 @@ namespace snmalloc
     /**
      * Reserve memory at a specific alignment.
      */
-    template<bool committed>
+    template<bool state_using>
     static void* reserve_aligned(size_t size) noexcept
     {
       // Alignment must be a power of 2.
@@ -37,11 +37,8 @@ namespace snmalloc
 
       int log2align = static_cast<int>(bits::next_pow2_bits(size));
 
-#ifdef SNMALLOC_CHECK_CLIENT
-      auto prot = committed ? PROT_READ | PROT_WRITE : PROT_NONE;
-#else
-      auto prot = PROT_READ | PROT_WRITE;
-#endif
+      auto prot =
+        state_using || !PalEnforceAccess ? PROT_READ | PROT_WRITE : PROT_NONE;
 
       void* p = mmap(
         nullptr,

--- a/src/pal/pal_consts.h
+++ b/src/pal/pal_consts.h
@@ -7,6 +7,21 @@
 namespace snmalloc
 {
   /**
+   * Pal implementations should query this flag to see whether they
+   * are allowed to optimise memory access, or that they must provide
+   * exceptions/segfaults if accesses do not obey the
+   *  - using
+   *  - using_readonly
+   *  - not_using
+   * model.
+   */
+#ifdef SNMALLOC_CHECK_CLIENT
+  static constexpr bool PalEnforceAccess = true;
+#else
+  static constexpr bool PalEnforceAccess = false;
+#endif
+
+  /**
    * Flags in a bitfield of optional features that a PAL may support.  These
    * should be set in the PAL's `pal_features` static constexpr field.
    */

--- a/src/pal/pal_freebsd_kernel.h
+++ b/src/pal/pal_freebsd_kernel.h
@@ -59,7 +59,7 @@ namespace snmalloc
       ::bzero(p, size);
     }
 
-    template<bool committed>
+    template<bool state_using>
     static void* reserve_aligned(size_t size) noexcept
     {
       SNMALLOC_ASSERT(bits::is_pow2(size));
@@ -80,7 +80,7 @@ namespace snmalloc
       {
         return nullptr;
       }
-      if (committed)
+      if (state_using)
       {
         if (
           kmem_back(kernel_object, addr, size, M_ZERO | M_WAITOK) !=

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -158,7 +158,7 @@ namespace snmalloc
     }
 
 #  ifdef PLATFORM_HAS_VIRTUALALLOC2
-    template<bool committed>
+    template<bool state_using>
     static void* reserve_aligned(size_t size) noexcept
     {
       SNMALLOC_ASSERT(bits::is_pow2(size));
@@ -166,7 +166,7 @@ namespace snmalloc
 
       DWORD flags = MEM_RESERVE;
 
-      if (committed)
+      if (state_using)
         flags |= MEM_COMMIT;
 
       // If we're on Windows 10 or newer, we can use the VirtualAlloc2


### PR DESCRIPTION
This exposes a readonly notify using, so that the underlying platform
can map the range of pages readonly into the application.  This improves
performance of external pointer on platforms that support lazy commit
of pages as it can access anything in the range.