### PR TITLE
Refactor use of sizeclasses

### DIFF
--- a/src/backend/address_space_core.h
+++ b/src/backend/address_space_core.h
@@ -97,7 +97,7 @@ namespace snmalloc
         //
         // dealloc() can reject attempts to free such MetaEntry-s due to the
         // zero sizeclass.
-        MetaEntry t(reinterpret_cast<Metaslab*>(next.unsafe_ptr()), nullptr, 0);
+        MetaEntry t(reinterpret_cast<Metaslab*>(next.unsafe_ptr()), nullptr);
         Pagemap::set_metaentry(local_state, address_cast(base), 1, t);
         return;
       }

--- a/src/mem/allocconfig.h
+++ b/src/mem/allocconfig.h
@@ -68,9 +68,9 @@ namespace snmalloc
 #endif
 
   // Maximum size of an object that uses sizeclasses.
-  static constexpr size_t MAX_SIZECLASS_BITS = 16;
-  static constexpr size_t MAX_SIZECLASS_SIZE =
-    bits::one_at_bit(MAX_SIZECLASS_BITS);
+  static constexpr size_t MAX_SMALL_SIZECLASS_BITS = 16;
+  static constexpr size_t MAX_SMALL_SIZECLASS_SIZE =
+    bits::one_at_bit(MAX_SMALL_SIZECLASS_BITS);
 
   // Number of slots for remote deallocation.
   static constexpr size_t REMOTE_SLOT_BITS = 8;

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -179,7 +179,7 @@ namespace snmalloc
 #endif
     }
 
-    void sizeclass_alloc(sizeclass_t sc)
+    void sizeclass_alloc(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -189,7 +189,7 @@ namespace snmalloc
 #endif
     }
 
-    void sizeclass_dealloc(sizeclass_t sc)
+    void sizeclass_dealloc(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -209,7 +209,7 @@ namespace snmalloc
 #endif
     }
 
-    void sizeclass_alloc_slab(sizeclass_t sc)
+    void sizeclass_alloc_slab(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -219,7 +219,7 @@ namespace snmalloc
 #endif
     }
 
-    void sizeclass_dealloc_slab(sizeclass_t sc)
+    void sizeclass_dealloc_slab(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -266,7 +266,7 @@ namespace snmalloc
 #endif
     }
 
-    void remote_free(sizeclass_t sc)
+    void remote_free(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -282,7 +282,7 @@ namespace snmalloc
 #endif
     }
 
-    void remote_receive(sizeclass_t sc)
+    void remote_receive(smallsizeclass_t sc)
     {
       UNUSED(sc);
 
@@ -374,7 +374,7 @@ namespace snmalloc
             << "Count" << csv.endl;
       }
 
-      for (sizeclass_t i = 0; i < N; i++)
+      for (smallsizeclass_t i = 0; i < N; i++)
       {
         if (sizeclass[i].count.is_unused())
           continue;
@@ -387,15 +387,15 @@ namespace snmalloc
         sizeclass[i].print(csv, sizeclass_to_size(i));
       }
 
-      for (uint8_t i = 0; i < LARGE_N; i++)
-      {
-        if ((large_push_count[i] == 0) && (large_pop_count[i] == 0))
-          continue;
+      // for (uint8_t i = 0; i < LARGE_N; i++)
+      // {
+      //   if ((large_push_count[i] == 0) && (large_pop_count[i] == 0))
+      //     continue;
 
-        csv << "LargeBucketedStats" << dumpid << allocatorid << (i + N)
-            << large_sizeclass_to_size(i) << large_push_count[i]
-            << large_pop_count[i] << csv.endl;
-      }
+      //   csv << "LargeBucketedStats" << dumpid << allocatorid << (i + N)
+      //       << large_sizeclass_to_size(i) << large_push_count[i]
+      //       << large_pop_count[i] << csv.endl;
+      // }
 
       size_t low = 0;
       size_t high = 0;

--- a/src/mem/chunkallocator.h
+++ b/src/mem/chunkallocator.h
@@ -182,7 +182,7 @@ namespace snmalloc
       typename SharedStateHandle::LocalState& local_state,
       ChunkAllocatorLocalState& chunk_alloc_local_state,
       sizeclass_t sizeclass,
-      sizeclass_t slab_sizeclass, // TODO sizeclass_t
+      chunksizeclass_t slab_sizeclass,
       size_t slab_size,
       RemoteAllocator* remote)
     {

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -56,7 +56,7 @@ namespace snmalloc
     /**
      * Per size class list of active slabs for this allocator.
      */
-    MetaslabCache alloc_classes[NUM_SIZECLASSES];
+    MetaslabCache alloc_classes[NUM_SMALL_SIZECLASSES];
 
     /**
      * Local cache for the Chunk allocator.
@@ -196,7 +196,9 @@ namespace snmalloc
         };
       // Use attached cache, and fill it if it is empty.
       return attached_cache->template alloc<NoZero, SharedStateHandle>(
-        domesticate, size, [&](sizeclass_t sizeclass, freelist::Iter<>* fl) {
+        domesticate,
+        size,
+        [&](smallsizeclass_t sizeclass, freelist::Iter<>* fl) {
           return small_alloc<NoZero>(sizeclass, *fl);
         });
     }
@@ -285,7 +287,7 @@ namespace snmalloc
       bumpptr = slab_end;
     }
 
-    ChunkRecord* clear_slab(Metaslab* meta, sizeclass_t sizeclass)
+    ChunkRecord* clear_slab(Metaslab* meta, smallsizeclass_t sizeclass)
     {
       auto& key = entropy.get_free_list_key();
       freelist::Iter<> fl;
@@ -347,7 +349,7 @@ namespace snmalloc
     }
 
     template<bool check_slabs = false>
-    SNMALLOC_SLOW_PATH void dealloc_local_slabs(sizeclass_t sizeclass)
+    SNMALLOC_SLOW_PATH void dealloc_local_slabs(smallsizeclass_t sizeclass)
     {
       // Return unused slabs of sizeclass_t back to global allocator
       alloc_classes[sizeclass].available.filter([this,
@@ -400,7 +402,7 @@ namespace snmalloc
       // TODO: Handle message queue on this path?
 
       Metaslab* meta = entry.get_metaslab();
-      sizeclass_t sizeclass = entry.get_sizeclass();
+      smallsizeclass_t sizeclass = entry.get_sizeclass().as_small();
 
       UNUSED(entropy);
       if (meta->is_sleeping())
@@ -557,11 +559,11 @@ namespace snmalloc
         get_backend_local_state(), chunk_local_state);
 
 #ifndef NDEBUG
-      for (sizeclass_t i = 0; i < NUM_SIZECLASSES; i++)
+      for (smallsizeclass_t i = 0; i < NUM_SMALL_SIZECLASSES; i++)
       {
         size_t size = sizeclass_to_size(i);
-        sizeclass_t sc1 = size_to_sizeclass(size);
-        sizeclass_t sc2 = size_to_sizeclass_const(size);
+        smallsizeclass_t sc1 = size_to_sizeclass(size);
+        smallsizeclass_t sc2 = size_to_sizeclass_const(size);
         size_t size1 = sizeclass_to_size(sc1);
         size_t size2 = sizeclass_to_size(sc2);
 
@@ -662,7 +664,8 @@ namespace snmalloc
       SNMALLOC_ASSERT(!meta->is_unused());
 
       check_client(
-        Metaslab::is_start_of_object(entry.get_sizeclass(), address_cast(p)),
+        Metaslab::is_start_of_object(
+          entry.get_sizeclass().as_small(), address_cast(p)),
         "Not deallocating start of an object");
 
       auto cp = p.as_static<freelist::Object::T<>>();
@@ -677,7 +680,7 @@ namespace snmalloc
 
     template<ZeroMem zero_mem>
     SNMALLOC_SLOW_PATH capptr::Alloc<void>
-    small_alloc(sizeclass_t sizeclass, freelist::Iter<>& fast_free_list)
+    small_alloc(smallsizeclass_t sizeclass, freelist::Iter<>& fast_free_list)
     {
       // Look to see if we can grab a free list.
       auto& sl = alloc_classes[sizeclass].available;
@@ -737,8 +740,8 @@ namespace snmalloc
     }
 
     template<ZeroMem zero_mem>
-    SNMALLOC_SLOW_PATH capptr::Alloc<void>
-    small_alloc_slow(sizeclass_t sizeclass, freelist::Iter<>& fast_free_list)
+    SNMALLOC_SLOW_PATH capptr::Alloc<void> small_alloc_slow(
+      smallsizeclass_t sizeclass, freelist::Iter<>& fast_free_list)
     {
       size_t rsize = sizeclass_to_size(sizeclass);
 
@@ -755,7 +758,7 @@ namespace snmalloc
         snmalloc::ChunkAllocator::alloc_chunk<SharedStateHandle>(
           get_backend_local_state(),
           chunk_local_state,
-          sizeclass,
+          sizeclass_t::from_small(sizeclass),
           slab_sizeclass,
           slab_size,
           public_state());
@@ -831,7 +834,8 @@ namespace snmalloc
           [&](capptr::Alloc<void> p) { dealloc_local_object(p); });
 
       // We may now have unused slabs, return to the global allocator.
-      for (sizeclass_t sizeclass = 0; sizeclass < NUM_SIZECLASSES; sizeclass++)
+      for (smallsizeclass_t sizeclass = 0; sizeclass < NUM_SMALL_SIZECLASSES;
+           sizeclass++)
       {
         dealloc_local_slabs<true>(sizeclass);
       }

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -758,7 +758,7 @@ namespace snmalloc
         snmalloc::ChunkAllocator::alloc_chunk<SharedStateHandle>(
           get_backend_local_state(),
           chunk_local_state,
-          sizeclass_t::from_small(sizeclass),
+          sizeclass_t::from_small_class(sizeclass),
           slab_sizeclass,
           slab_size,
           public_state());

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -622,6 +622,10 @@ namespace snmalloc
     template<Boundary location = Start>
     void* external_pointer(void* p)
     {
+      // Note that each case uses `pointer_offset`, so that on
+      // CHERI it is monotone with respect to the capability.
+      // Note that the returned pointer could be outside the CHERI
+      // bounds of `p`, and thus not something that can be followed.
       if constexpr (location == Start)
       {
         size_t index = index_in_object(p);

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -12,17 +12,8 @@ namespace snmalloc
 {
   // Remotes need to be aligned enough that the bottom bits have enough room for
   // all the size classes, both large and small.
-  //
-  // Including large classes in this calculation might seem remarkably strange,
-  // since large allocations don't have associated Remotes, that is, their
-  // remote is taken to be 0.  However, if there are very few small size
-  // classes and many large classes, the attempt to align that 0 down by the
-  // alignment of a Remote might result in a nonzero value.
-  static constexpr size_t REMOTE_MIN_ALIGN = bits::max<size_t>(
-    CACHELINE_SIZE,
-    bits::max<size_t>(
-      bits::next_pow2_const(NUM_SIZECLASSES + 1),
-      bits::next_pow2_const(NUM_LARGE_CLASSES + 1)));
+  static constexpr size_t REMOTE_MIN_ALIGN =
+    bits::max<size_t>(CACHELINE_SIZE, SIZECLASS_REP_SIZE);
 
   /**
    * Global key for all remote lists.

--- a/src/mem/remotecache.h
+++ b/src/mem/remotecache.h
@@ -55,7 +55,7 @@ namespace snmalloc
     SNMALLOC_FAST_PATH bool reserve_space(const MetaEntry& entry)
     {
       auto size =
-        static_cast<int64_t>(sizeclass_to_size(entry.get_sizeclass()));
+        static_cast<int64_t>(sizeclass_full_to_size(entry.get_sizeclass()));
 
       bool result = capacity > size;
       if (result)

--- a/src/override/memcpy.cc
+++ b/src/override/memcpy.cc
@@ -136,8 +136,7 @@ namespace
       auto& alloc = ThreadAlloc::get();
       void* p = const_cast<void*>(ptr);
 
-      if (unlikely(
-            pointer_diff(ptr, alloc.external_pointer<OnePastEnd>(p)) < len))
+      if (unlikely(alloc.remaining_bytes(ptr) < len))
       {
         if constexpr (FailFast)
         {

--- a/src/override/rust.cc
+++ b/src/override/rust.cc
@@ -32,7 +32,8 @@ rust_realloc(void* ptr, size_t alignment, size_t old_size, size_t new_size)
   size_t aligned_old_size = aligned_size(alignment, old_size),
          aligned_new_size = aligned_size(alignment, new_size);
   if (
-    size_to_sizeclass(aligned_old_size) == size_to_sizeclass(aligned_new_size))
+    size_to_sizeclass_full(aligned_old_size).raw() ==
+    size_to_sizeclass_full(aligned_new_size).raw())
     return ptr;
   void* p = ThreadAlloc::get().alloc(aligned_new_size);
   if (p)

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -166,7 +166,7 @@ int main(int, char**)
   f(5);
   f(7);
   printf("\n");
-  for (size_t exp = 1; exp < snmalloc::MAX_SIZECLASS_BITS; exp++)
+  for (size_t exp = 1; exp < snmalloc::MAX_SMALL_SIZECLASS_BITS; exp++)
   {
     auto shifted = [exp](size_t v) { return v << exp; };
 

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
 
   our_free(nullptr);
 
-  for (sizeclass_t sc = 0; sc < (MAX_SIZECLASS_BITS + 4); sc++)
+  for (smallsizeclass_t sc = 0; sc < (MAX_SMALL_SIZECLASS_BITS + 4); sc++)
   {
     const size_t size = bits::one_at_bit(sc);
     printf("malloc: %zu\n", size);
@@ -161,12 +161,13 @@ int main(int argc, char** argv)
 
   our_free(nullptr);
 
-  for (sizeclass_t sc = 0; sc < NUM_SIZECLASSES; sc++)
+  for (smallsizeclass_t sc = 0; sc < NUM_SMALL_SIZECLASSES; sc++)
   {
     const size_t size = sizeclass_to_size(sc);
 
     bool overflow = false;
-    for (size_t n = 1; bits::umul(size, n, overflow) <= MAX_SIZECLASS_SIZE;
+    for (size_t n = 1;
+         bits::umul(size, n, overflow) <= MAX_SMALL_SIZECLASS_SIZE;
          n *= 5)
     {
       if (overflow)
@@ -178,13 +179,13 @@ int main(int argc, char** argv)
     test_calloc(0, size, SUCCESS, false);
   }
 
-  for (sizeclass_t sc = 0; sc < NUM_SIZECLASSES; sc++)
+  for (smallsizeclass_t sc = 0; sc < NUM_SMALL_SIZECLASSES; sc++)
   {
     const size_t size = sizeclass_to_size(sc);
     test_realloc(our_malloc(size), size, SUCCESS, false);
     test_realloc(nullptr, size, SUCCESS, false);
     test_realloc(our_malloc(size), ((size_t)-1) / 2, ENOMEM, true);
-    for (sizeclass_t sc2 = 0; sc2 < NUM_SIZECLASSES; sc2++)
+    for (smallsizeclass_t sc2 = 0; sc2 < NUM_SMALL_SIZECLASSES; sc2++)
     {
       const size_t size2 = sizeclass_to_size(sc2);
       test_realloc(our_malloc(size), size2, SUCCESS, false);
@@ -192,13 +193,13 @@ int main(int argc, char** argv)
     }
   }
 
-  for (sizeclass_t sc = 0; sc < (MAX_SIZECLASS_BITS + 4); sc++)
+  for (smallsizeclass_t sc = 0; sc < (MAX_SMALL_SIZECLASS_BITS + 4); sc++)
   {
     const size_t size = bits::one_at_bit(sc);
     test_realloc(our_malloc(size), size, SUCCESS, false);
     test_realloc(nullptr, size, SUCCESS, false);
     test_realloc(our_malloc(size), ((size_t)-1) / 2, ENOMEM, true);
-    for (sizeclass_t sc2 = 0; sc2 < (MAX_SIZECLASS_BITS + 4); sc2++)
+    for (smallsizeclass_t sc2 = 0; sc2 < (MAX_SMALL_SIZECLASS_BITS + 4); sc2++)
     {
       const size_t size2 = bits::one_at_bit(sc2);
       printf("size1: %zu, size2:%zu\n", size, size2);
@@ -213,10 +214,10 @@ int main(int argc, char** argv)
   test_posix_memalign(((size_t)-1) / 2, 0, EINVAL, true);
   test_posix_memalign(OS_PAGE_SIZE, sizeof(uintptr_t) / 2, EINVAL, true);
 
-  for (size_t align = sizeof(uintptr_t); align < MAX_SIZECLASS_SIZE * 8;
+  for (size_t align = sizeof(uintptr_t); align < MAX_SMALL_SIZECLASS_SIZE * 8;
        align <<= 1)
   {
-    for (sizeclass_t sc = 0; sc < NUM_SIZECLASSES - 6; sc++)
+    for (smallsizeclass_t sc = 0; sc < NUM_SMALL_SIZECLASSES - 6; sc++)
     {
       const size_t size = sizeclass_to_size(sc);
       test_posix_memalign(size, align, SUCCESS, false);

--- a/src/test/func/release-rounding/rounding.cc
+++ b/src/test/func/release-rounding/rounding.cc
@@ -17,35 +17,37 @@ int main(int argc, char** argv)
 
   bool failed = false;
 
-  for (size_t size_class = 0; size_class < NUM_SIZECLASSES; size_class++)
+  for (size_t size_class = 0; size_class < NUM_SMALL_SIZECLASSES; size_class++)
   {
     size_t rsize = sizeclass_to_size((uint8_t)size_class);
     size_t max_offset = sizeclass_to_slab_size(size_class);
+    sizeclass_t sc = sizeclass_t::from_small(size_class);
     for (size_t offset = 0; offset < max_offset; offset++)
     {
-      size_t rounded = (offset / rsize) * rsize;
+      size_t mod = offset % rsize;
       bool mod_0 = (offset % rsize) == 0;
 
-      size_t opt_rounded = round_by_sizeclass(size_class, offset);
-      if (rounded != opt_rounded)
+      size_t opt_mod = index_in_object(sc, offset);
+      if (mod != opt_mod)
       {
         std::cout << "rsize " << rsize << "  offset  " << offset << "  opt "
-                  << opt_rounded << " correct " << rounded << std::endl
+                  << opt_mod << " correct " << mod << std::endl
                   << std::flush;
         failed = true;
       }
 
-      bool opt_mod_0 = is_multiple_of_sizeclass(size_class, offset);
+      bool opt_mod_0 = divisible_by_sizeclass(size_class, offset);
       if (opt_mod_0 != mod_0)
       {
-        std::cout << "rsize " << rsize << "  offset  " << offset << "  opt_mod "
-                  << opt_mod_0 << " correct " << mod_0 << std::endl
+        std::cout << "rsize " << rsize << "  offset  " << offset
+                  << "  opt_mod0 " << opt_mod_0 << " correct " << mod_0
+                  << std::endl
                   << std::flush;
         failed = true;
       }
     }
+    if (failed)
+      abort();
   }
-  if (failed)
-    abort();
   return 0;
 }

--- a/src/test/func/release-rounding/rounding.cc
+++ b/src/test/func/release-rounding/rounding.cc
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
   {
     size_t rsize = sizeclass_to_size((uint8_t)size_class);
     size_t max_offset = sizeclass_to_slab_size(size_class);
-    sizeclass_t sc = sizeclass_t::from_small(size_class);
+    sizeclass_t sc = sizeclass_t::from_small_class(size_class);
     for (size_t offset = 0; offset < max_offset; offset++)
     {
       size_t mod = offset % rsize;

--- a/src/test/func/sizeclass/sizeclass.cc
+++ b/src/test/func/sizeclass/sizeclass.cc
@@ -3,7 +3,7 @@
 #include <test/setup.h>
 
 NOINLINE
-snmalloc::sizeclass_t size_to_sizeclass(size_t size)
+snmalloc::smallsizeclass_t size_to_sizeclass(size_t size)
 {
   return snmalloc::size_to_sizeclass(size);
 }
@@ -15,7 +15,7 @@ void test_align_size()
   SNMALLOC_CHECK(snmalloc::aligned_size(128, 160) == 256);
 
   for (size_t size = 1;
-       size < snmalloc::sizeclass_to_size(snmalloc::NUM_SIZECLASSES - 1);
+       size < snmalloc::sizeclass_to_size(snmalloc::NUM_SMALL_SIZECLASSES - 1);
        size++)
   {
     size_t rsize = snmalloc::round_size(size);
@@ -39,7 +39,7 @@ void test_align_size()
     }
 
     for (size_t alignment_bits = 0;
-         alignment_bits < snmalloc::MAX_SIZECLASS_BITS;
+         alignment_bits < snmalloc::MAX_SMALL_SIZECLASS_BITS;
          alignment_bits++)
     {
       auto alignment = (size_t)1 << alignment_bits;
@@ -78,10 +78,11 @@ int main(int, char**)
   std::cout << "sizeclass |-> [size_low, size_high] " << std::endl;
 
   size_t slab_size = 0;
-  for (snmalloc::sizeclass_t sz = 0; sz < snmalloc::NUM_SIZECLASSES; sz++)
+  for (snmalloc::smallsizeclass_t sz = 0; sz < snmalloc::NUM_SMALL_SIZECLASSES;
+       sz++)
   {
     if (
-      sz < snmalloc::NUM_SIZECLASSES &&
+      sz < snmalloc::NUM_SMALL_SIZECLASSES &&
       slab_size != snmalloc::sizeclass_to_slab_size(sz))
     {
       slab_size = snmalloc::sizeclass_to_slab_size(sz);

--- a/src/test/func/teardown/teardown.cc
+++ b/src/test/func/teardown/teardown.cc
@@ -188,7 +188,7 @@ int main(int, char**)
   f(5);
   f(7);
   printf("\n");
-  for (size_t exp = 1; exp < snmalloc::MAX_SIZECLASS_BITS; exp++)
+  for (size_t exp = 1; exp < snmalloc::MAX_SMALL_SIZECLASS_BITS; exp++)
   {
     auto shifted = [exp](size_t v) { return v << exp; };
 


### PR DESCRIPTION
The primary aim for this refactor is to use a representation for
sizeclasses that uniformly covers both large and small.  This allows
certain operations such as alloc_size and external_pointer to be
uniformly implemented.

The additional types make clear which kind of sizeclass is in use.

This also tidies up the code for sizeclass based divisible by and
modulus.

It fixes a bug in rust_realloc that didn't correctly determine a realloc
was required for large classes.