### PR TITLE
clean up unused usages

### DIFF
--- a/src/backend/address_space_core.h
+++ b/src/backend/address_space_core.h
@@ -65,8 +65,7 @@ namespace snmalloc
         bits::align_up(address_cast(base), bits::one_at_bit(align_bits)));
       // All blocks need to be bigger than a pointer.
       SNMALLOC_ASSERT(bits::one_at_bit(align_bits) >= sizeof(void*));
-      UNUSED(base);
-      UNUSED(align_bits);
+      UNUSED(base, align_bits);
     }
 
     /**

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -90,8 +90,6 @@
 #  define __has_builtin(x) 0
 #endif
 
-#define UNUSED(x) ((void)(x))
-
 namespace snmalloc
 {
   // Forwards reference so that the platform can define how to handle errors.
@@ -168,4 +166,6 @@ namespace snmalloc
 #else
   static constexpr bool CHECK_CLIENT = false;
 #endif
+  template <typename... Args>
+  void UNUSED(Args&& ... unused [[maybe_unused]]) {}
 } // namespace snmalloc

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -167,6 +167,6 @@ namespace snmalloc
   static constexpr bool CHECK_CLIENT = false;
 #endif
   template<typename... Args>
-  void UNUSED(Args&&...)
+  SNMALLOC_FAST_PATH_INLINE void UNUSED(Args&&...)
   {}
 } // namespace snmalloc

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -167,5 +167,5 @@ namespace snmalloc
   static constexpr bool CHECK_CLIENT = false;
 #endif
   template <typename... Args>
-  void UNUSED(Args&& ... unused [[maybe_unused]]) {}
+  void UNUSED(Args&& ...) {}
 } // namespace snmalloc

--- a/src/ds/defines.h
+++ b/src/ds/defines.h
@@ -166,6 +166,7 @@ namespace snmalloc
 #else
   static constexpr bool CHECK_CLIENT = false;
 #endif
-  template <typename... Args>
-  void UNUSED(Args&& ...) {}
+  template<typename... Args>
+  void UNUSED(Args&&...)
+  {}
 } // namespace snmalloc

--- a/src/mem/allocstats.h
+++ b/src/mem/allocstats.h
@@ -322,9 +322,7 @@ namespace snmalloc
     template<class Alloc>
     void print(std::ostream& o, uint64_t dumpid = 0, uint64_t allocatorid = 0)
     {
-      UNUSED(o);
-      UNUSED(dumpid);
-      UNUSED(allocatorid);
+      UNUSED(o, dumpid, allocatorid);
 
       CSVStream csv(&o);
 

--- a/src/mem/globalalloc.h
+++ b/src/mem/globalalloc.h
@@ -44,8 +44,7 @@ namespace snmalloc
   template<SNMALLOC_CONCEPT(ConceptBackendGlobals) SharedStateHandle>
   inline static void print_all_stats(void*& o, uint64_t dumpid = 0)
   {
-    UNUSED(o);
-    UNUSED(dumpid);
+    UNUSED(o, dumpid);
   }
 #endif
 

--- a/src/override/memcpy.cc
+++ b/src/override/memcpy.cc
@@ -140,9 +140,7 @@ namespace
       {
         if constexpr (FailFast)
         {
-          UNUSED(ptr);
-          UNUSED(len);
-          UNUSED(msg);
+          UNUSED(ptr, len, msg);
           SNMALLOC_FAST_FAIL();
         }
         else
@@ -153,9 +151,7 @@ namespace
     }
     else
     {
-      UNUSED(ptr);
-      UNUSED(len);
-      UNUSED(msg);
+      UNUSED(ptr, len, msg);
     }
   }
 

--- a/src/pal/pal_noalloc.h
+++ b/src/pal/pal_noalloc.h
@@ -77,8 +77,7 @@ namespace snmalloc
       }
       else
       {
-        UNUSED(p);
-        UNUSED(size);
+        UNUSED(p, size);
       }
     }
 

--- a/src/pal/pal_plain.h
+++ b/src/pal/pal_plain.h
@@ -24,8 +24,7 @@ namespace snmalloc
       }
       else
       {
-        UNUSED(p);
-        UNUSED(size);
+        UNUSED(p, size);
       }
     }
   };

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -194,8 +194,7 @@ namespace snmalloc
       }
       else
       {
-        UNUSED(p);
-        UNUSED(size);
+        UNUSED(p, size);
       }
     }
 
@@ -216,8 +215,7 @@ namespace snmalloc
         mprotect(p, size, PROT_READ | PROT_WRITE);
       else
       {
-        UNUSED(p);
-        UNUSED(size);
+        UNUSED(p, size);
       }
 
       if constexpr (zero_mem == YesZero)
@@ -238,8 +236,7 @@ namespace snmalloc
         mprotect(p, size, PROT_READ);
       else
       {
-        UNUSED(p);
-        UNUSED(size);
+        UNUSED(p, size);
       }
     }
 

--- a/src/test/func/bits/bits.cc
+++ b/src/test/func/bits/bits.cc
@@ -35,8 +35,7 @@ void test_clz()
 
 int main(int argc, char** argv)
 {
-  UNUSED(argc);
-  UNUSED(argv);
+  snmalloc::UNUSED(argc, argv);
 
   setup();
 

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -27,8 +27,7 @@ using namespace snmalloc;
 
 void test_limited(rlim64_t as_limit, size_t& count)
 {
-  UNUSED(as_limit);
-  UNUSED(count);
+  UNUSED(as_limit, count);
 #if false && defined(TEST_LIMITED)
   auto pid = fork();
   if (!pid)
@@ -490,8 +489,7 @@ int main(int argc, char** argv)
   size_t seed = opt.is<size_t>("--seed", 0);
   Virtual::systematic_bump_ptr() += seed << 17;
 #else
-  UNUSED(argc);
-  UNUSED(argv);
+  UNUSED(argc, argv);
 #endif
   test_alloc_dealloc_64k();
   test_random_allocation();

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -120,8 +120,7 @@ void test_pagemap(bool bounded)
 
 int main(int argc, char** argv)
 {
-  UNUSED(argc);
-  UNUSED(argv);
+  UNUSED(argc, argv);
 
   setup();
 

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -124,8 +124,7 @@ int main(int argc, char** argv)
   size_t seed = opt.is<size_t>("--seed", 0);
   Virtual::systematic_bump_ptr() += seed << 17;
 #else
-  UNUSED(argc);
-  UNUSED(argv);
+  UNUSED(argc, argv);
 #endif
 
   test_alloc();

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -7,14 +7,13 @@
 
 extern "C" void* oe_memset_s(void* p, size_t p_size, int c, size_t size)
 {
-  UNUSED(p_size);
+  snmalloc::UNUSED(p_size);
   return memset(p, c, size);
 }
 
 extern "C" int oe_random(void* p, size_t p_size)
 {
-  UNUSED(p_size);
-  UNUSED(p);
+  snmalloc::UNUSED(p_size, p);
   // Stub for random data.
   return 0;
 }

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -63,7 +63,7 @@ void print_stack_trace()
 
 void _cdecl error(int signal)
 {
-  UNUSED(signal);
+  snmalloc::UNUSED(signal);
   puts("*****ABORT******");
 
   print_stack_trace();
@@ -73,7 +73,7 @@ void _cdecl error(int signal)
 
 LONG WINAPI VectoredHandler(struct _EXCEPTION_POINTERS* ExceptionInfo)
 {
-  UNUSED(ExceptionInfo);
+  snmalloc::UNUSED(ExceptionInfo);
 
   puts("*****UNHANDLED EXCEPTION******");
 
@@ -100,7 +100,7 @@ void setup()
 #    include <signal.h>
 void error_handle(int signal)
 {
-  UNUSED(signal);
+  snmalloc::UNUSED(signal);
   snmalloc::error("Seg Fault");
   _exit(1);
 }


### PR DESCRIPTION
Signed-off-by: SchrodingerZhu <i@zhuyi.fan>

This PR makes `UNUSED` as a function marked by `[[maybe_unused]]`. This enables us to put `UNUSED` to namespace without pollute global macros.