### PR TITLE
Modify heuristic for adding new slabs.

### DIFF
--- a/src/ds/seqset.h
+++ b/src/ds/seqset.h
@@ -159,5 +159,13 @@ namespace snmalloc
         v.end = &(item->next);
       }
     }
+
+    /**
+     * Peek at next element in the set.
+     */
+    SNMALLOC_FAST_PATH const T* peek()
+    {
+      return v.head;
+    }
   };
 } // namespace snmalloc

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -695,7 +695,7 @@ namespace snmalloc
           // new slab.
           auto min = alloc_classes[sizeclass]
                        .available.peek()
-                       ->free_queue.length_after_close();
+                       ->free_queue.min_list_length();
           if ((min * 2) < threshold_for_waking_slab(sizeclass))
             if (entropy.next_bit() == 0)
               return small_alloc_slow<zero_mem>(sizeclass, fast_free_list);

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -740,6 +740,25 @@ namespace snmalloc
         UNUSED(domesticate);
 #endif
       }
+
+      /**
+       * Returns length of free list if you call close.
+       *
+       * The Builder is not always emptied when you call close,
+       * this returns the length of the list if you had just called
+       * close.
+       */
+      [[nodiscard]] size_t length_after_close() const
+      {
+        if constexpr (RANDOM)
+        {
+          return length[0] < length[1] ? length[0] : length[1];
+        }
+        else
+        {
+          return 0;
+        }
+      }
     };
   } // namespace freelist
 } // namespace snmalloc

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -742,22 +742,17 @@ namespace snmalloc
       }
 
       /**
-       * Returns length of free list if you call close.
+       * Returns length of the shorter free list.
        *
-       * The Builder is not always emptied when you call close,
-       * this returns the length of the list if you had just called
-       * close.
+       * This method is only usable if the free list is adding randomisation
+       * as that is when it has two lists.
        */
-      [[nodiscard]] size_t length_after_close() const
+      template<bool RANDOM_ = RANDOM>
+      [[nodiscard]] std::enable_if_t<RANDOM_, size_t> min_list_length() const
       {
-        if constexpr (RANDOM)
-        {
-          return length[0] < length[1] ? length[0] : length[1];
-        }
-        else
-        {
-          return 0;
-        }
+        static_assert(RANDOM_ == RANDOM, "Don't set SFINAE parameter!");
+
+        return length[0] < length[1] ? length[0] : length[1];
       }
     };
   } // namespace freelist


### PR DESCRIPTION
If there is only one slab remaining, then we probabalisticly allocator a
new one. If a slab is barely in use, then this could cause us to
effectively double the number of slabs in use.

This commit checks if the remaining slab has enough remaining elements
to provide randomisation.