### PR TITLE
Add timeout to ci tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,19 +189,14 @@ jobs:
     strategy:
       matrix:
         # Build each combination of OS and release/debug variants
-        os: [ windows-2016, windows-2019 ]
+        os: [ windows-2019 ]
         build-type: [ Release, Debug ]
         arch: [ Win32, x64 ]
         toolchain: [ "", "-T ClangCL" ]
         extra-cmake-flags: [ "" ]
-        # The ClangCL toolchain was added in Visual Studio 2019, the Windows
-        # 2016 runners have only VS 2017, so skip them for this configuration
-        exclude:
-          - os: windows-2016
-            toolchain: "-T ClangCL"
         # Add an extra check for the Windows 8 compatible PAL
         include:
-          - os: windows-2016
+          - os: windows-2019
             build-type: Release
             arch: x64
             toolchain: ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test
       if: ${{ matrix.build-only != 'yes' }}
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -j 4 -C ${{ matrix.build-type }}
+      run: ctest --output-on-failure -j 4 -C ${{ matrix.build-type }} --timeout 400
     - name: Selfhost
       if: ${{ matrix.self-host }}
       working-directory: ${{github.workspace}}/build
@@ -182,7 +182,7 @@ jobs:
     # QEMU)
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -E '(perf-.*)|(.*-malloc$)'
+      run: ctest --output-on-failure -E '(perf-.*)|(.*-malloc$)' --timeout 400
       timeout-minutes: 30
 
   windows:
@@ -222,7 +222,7 @@ jobs:
       # Run the tests.
     - name: Test
       working-directory: ${{ github.workspace }}/build
-      run: ctest -j 2 --interactive-debug-mode 0 --output-on-failure -C ${{ matrix.build-type }}
+      run: ctest -j 2 --interactive-debug-mode 0 --output-on-failure -C ${{ matrix.build-type }} --timeout 400
       timeout-minutes: 20
 
 


### PR DESCRIPTION
Windows can hang due to assert failures in CI.  Add a timeout to get
some information of what is happening.