### PR TITLE
Post large deallocations to original thread

### DIFF
--- a/src/mem/localcache.h
+++ b/src/mem/localcache.h
@@ -15,7 +15,8 @@ namespace snmalloc
   inline static SNMALLOC_FAST_PATH capptr::Alloc<void>
   finish_alloc_no_zero(freelist::HeadPtr p, smallsizeclass_t sizeclass)
   {
-    SNMALLOC_ASSERT(is_start_of_object(sizeclass, address_cast(p)));
+    SNMALLOC_ASSERT(is_start_of_object(
+      sizeclass_t::from_small_class(sizeclass), address_cast(p)));
     UNUSED(sizeclass);
 
     return p.as_void();
@@ -90,7 +91,8 @@ namespace snmalloc
         while (!small_fast_free_lists[i].empty())
         {
           auto p = small_fast_free_lists[i].take(key, domesticate);
-          SNMALLOC_ASSERT(is_start_of_object(i, address_cast(p)));
+          SNMALLOC_ASSERT(is_start_of_object(
+            sizeclass_t::from_small_class(i), address_cast(p)));
           dealloc(p.as_void());
         }
       }

--- a/src/mem/localcache.h
+++ b/src/mem/localcache.h
@@ -15,7 +15,7 @@ namespace snmalloc
   inline static SNMALLOC_FAST_PATH capptr::Alloc<void>
   finish_alloc_no_zero(freelist::HeadPtr p, smallsizeclass_t sizeclass)
   {
-    SNMALLOC_ASSERT(Metaslab::is_start_of_object(sizeclass, address_cast(p)));
+    SNMALLOC_ASSERT(is_start_of_object(sizeclass, address_cast(p)));
     UNUSED(sizeclass);
 
     return p.as_void();
@@ -90,7 +90,7 @@ namespace snmalloc
         while (!small_fast_free_lists[i].empty())
         {
           auto p = small_fast_free_lists[i].take(key, domesticate);
-          SNMALLOC_ASSERT(Metaslab::is_start_of_object(i, address_cast(p)));
+          SNMALLOC_ASSERT(is_start_of_object(i, address_cast(p)));
           dealloc(p.as_void());
         }
       }

--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -369,10 +369,11 @@ namespace snmalloc
     return sizeclass_metadata.fast(sc).size - index_in_object(sc, addr);
   }
 
-  inline static bool divisible_by_sizeclass(sizeclass_t sc, size_t offset)
+  inline static bool is_start_of_object(sizeclass_t sc, address_t addr)
   {
-    // Only works up to certain offsets, exhaustively tested by rounding.cc
+    size_t offset = addr & (sizeclass_full_to_slab_size(sc) - 1);
 
+    // Only works up to certain offsets, exhaustively tested by rounding.cc
     if constexpr (sizeof(offset) >= 8)
     {
       // Only works for 64 bit multiplication, as the following will overflow in
@@ -386,17 +387,6 @@ namespace snmalloc
       // Use 32-bit division as considerably faster than 64-bit, and
       // everything fits into 32bits here.
       return static_cast<uint32_t>(offset % sizeclass_full_to_size(sc)) == 0;
-  }
-
-  inline static bool is_start_of_object(sizeclass_t sc, address_t addr)
-  {
-    size_t offset = addr & (sizeclass_full_to_slab_size(sc) - 1);
-    return divisible_by_sizeclass(sc, offset);
-  }
-
-  inline static bool is_start_of_object(smallsizeclass_t sc, address_t addr)
-  {
-    return is_start_of_object(sizeclass_t::from_small_class(sc), addr);
   }
 
   inline static size_t large_size_to_chunk_size(size_t size)

--- a/src/test/func/release-rounding/rounding.cc
+++ b/src/test/func/release-rounding/rounding.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
         failed = true;
       }
 
-      bool opt_mod_0 = divisible_by_sizeclass(size_class, offset);
+      bool opt_mod_0 = is_start_of_object(sc, offset);
       if (opt_mod_0 != mod_0)
       {
         std::cout << "rsize " << rsize << "  offset  " << offset


### PR DESCRIPTION
This change sets all large allocations to be owned by the originating
thread. This means they will be messaged back to the original thread
before they can be reused.

The following reason for making this change:
* This will improve producer/consumer apps involving large allocations.
* It enables the implementation of a more complex chunk allocator that
reassembles chunks.
* It addresses an issue with compartmentalisation where the handling of
large allocations can result in meta-data ownership changing.