### PR TITLE
PAL netbsd (temporary until some time 2022) build fix.

### DIFF
--- a/src/pal/pal_linux.h
+++ b/src/pal/pal_linux.h
@@ -4,7 +4,6 @@
 #  include "../ds/bits.h"
 #  include "pal_posix.h"
 
-#  include <fcntl.h>
 #  include <string.h>
 #  include <sys/mman.h>
 #  include <syscall.h>
@@ -166,39 +165,7 @@ namespace snmalloc
       // reentrancy problem during initialisation routine.
       // 2. some implementations also require libstdc++ to be linked since
       // its APIs are not exception-free.
-      int flags = O_RDONLY;
-#  if defined(O_CLOEXEC)
-      flags |= O_CLOEXEC;
-#  endif
-      auto fd = open("/dev/urandom", flags, 0);
-      if (fd > 0)
-      {
-        auto current = std::begin(buffer);
-        auto target = std::end(buffer);
-        while (auto length = static_cast<size_t>(target - current))
-        {
-          ret = read(fd, current, length);
-          if (ret <= 0)
-          {
-            if (errno != EAGAIN && errno != EINTR)
-            {
-              break;
-            }
-          }
-          else
-          {
-            current += ret;
-          }
-        }
-        ret = close(fd);
-        SNMALLOC_ASSERT(0 == ret);
-        if (SNMALLOC_LIKELY(target == current))
-        {
-          return result;
-        }
-      }
-
-      error("Failed to get system randomness");
+      return dev_urandom();
     }
   };
 } // namespace snmalloc

--- a/src/pal/pal_netbsd.h
+++ b/src/pal/pal_netbsd.h
@@ -3,6 +3,8 @@
 #ifdef __NetBSD__
 #  include "pal_bsd_aligned.h"
 
+#  include <fcntl.h>
+
 namespace snmalloc
 {
   /**
@@ -26,7 +28,17 @@ namespace snmalloc
      * As NetBSD does not have the getentropy call, get_entropy64 will
      * currently fallback to C++ libraries std::random_device.
      */
-    static constexpr uint64_t pal_features = PALBSD_Aligned::pal_features;
+    static constexpr uint64_t pal_features =
+      PALBSD_Aligned::pal_features | Entropy;
+
+    /**
+     * Temporary solution while waiting getrandom support for the next release
+     * random_device seems unimplemented in clang for this platform
+     */
+    static uint64_t get_entropy64()
+    {
+      return PALPOSIX::dev_urandom();
+    }
   };
 } // namespace snmalloc
 #endif


### PR DESCRIPTION
std::random_device seems unimplemented on this platform
 thus falling back to the usual /dev/urandom device for
the time being.