### PR TITLE
Remove fake_large_remote

### DIFF
--- a/src/backend/address_space_core.h
+++ b/src/backend/address_space_core.h
@@ -89,10 +89,9 @@ namespace snmalloc
         // The pagemap stores `MetaEntry`s; abuse the metaslab field to be the
         // next block in the stack of blocks.
         //
-        // The pagemap entries here have nullptr (i.e., fake_large_remote) as
-        // their remote, and so other accesses to the pagemap (by
-        // external_pointer, for example) will not attempt to follow this
-        // "Metaslab" pointer.
+        // The pagemap entries here have nullptr as their remote, and so other
+        // accesses to the pagemap (by external_pointer, for example) will not
+        // attempt to follow this "Metaslab" pointer.
         //
         // dealloc() can reject attempts to free such MetaEntry-s due to the
         // zero sizeclass.

--- a/src/backend/commonconfig.h
+++ b/src/backend/commonconfig.h
@@ -104,24 +104,6 @@ namespace snmalloc
      */
     SNMALLOC_REQUIRE_CONSTINIT
     inline static RemoteAllocator unused_remote;
-
-    /**
-     * Special remote that is used in meta-data for large allocations.
-     *
-     * nullptr is considered a large allocations for this purpose to move
-     * of the critical path.
-     *
-     * Bottom bits of the remote pointer are used for a sizeclass, we need
-     * size bits to represent the non-large sizeclasses, we can then get
-     * the large sizeclass by having the fake large_remote considerably
-     * more aligned.
-     */
-    SNMALLOC_REQUIRE_CONSTINIT
-    inline static constexpr RemoteAllocator* fake_large_remote{nullptr};
-
-    static_assert(
-      &unused_remote != fake_large_remote,
-      "Compilation should ensure these are different");
   };
 
   /**

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -640,8 +640,7 @@ namespace snmalloc
         return;
       }
 
-      if (SNMALLOC_LIKELY(
-            entry.get_remote() != SharedStateHandle::fake_large_remote))
+      if (SNMALLOC_LIKELY(entry.get_remote() != nullptr))
       {
 #  if defined(__CHERI_PURE_CAPABILITY__) && defined(SNMALLOC_CHECK_CLIENT)
         dealloc_cheri_checks(p_tame.unsafe_ptr());


### PR DESCRIPTION
Since #441 was merged, pagemap entries are no longer ever set to
fake_large_remote.