### PR TITLE
Improve check_bounds init check.

### DIFF
--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -335,6 +335,12 @@ namespace snmalloc
         UNUSED(local_state);
         return concretePagemap.get_bounds();
       }
+
+      static bool is_initialised(LocalState* ls)
+      {
+        UNUSED(ls);
+        return concretePagemap.is_initialised();
+      }
     };
 
   private:

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -279,6 +279,14 @@ namespace snmalloc
     }
 
     /**
+     * Check if the pagemap has been initialised.
+     */
+    [[nodiscard]] bool is_initialised() const
+    {
+      return body_opt != nullptr;
+    }
+
+    /**
      * Return the starting address corresponding to a given entry within the
      * Pagemap. Also checks that the reference actually points to a valid entry.
      */

--- a/src/mem/localalloc.h
+++ b/src/mem/localalloc.h
@@ -772,6 +772,16 @@ namespace snmalloc
 #endif
     }
 
+    bool check_bounds(const void* p, size_t s)
+    {
+      auto ls = core_alloc->backend_state_ptr();
+      if (SNMALLOC_LIKELY(SharedStateHandle::Pagemap::is_initialised(ls)))
+      {
+        return remaining_bytes(p) >= s;
+      }
+      return true;
+    }
+
     /**
      * Returns the byte offset into an object.
      *

--- a/src/override/memcpy.cc
+++ b/src/override/memcpy.cc
@@ -137,7 +137,7 @@ namespace
       auto& alloc = ThreadAlloc::get();
       void* p = const_cast<void*>(ptr);
 
-      if (SNMALLOC_UNLIKELY(alloc.remaining_bytes(ptr) < len))
+      if (SNMALLOC_UNLIKELY(!alloc.check_bounds(ptr, len)))
       {
         if constexpr (FailFast)
         {

--- a/src/test/perf/memcpy/memcpy.cc
+++ b/src/test/perf/memcpy/memcpy.cc
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
   };
 
   std::vector<size_t> sizes;
-  for (size_t size = 1; size < 64; size++)
+  for (size_t size = 0; size < 64; size++)
   {
     sizes.push_back(size);
   }


### PR DESCRIPTION
There was a slightly awkward jump in the guarded memcpy implementation were if it was uninitialised, it then used the address of the default value.  This commit lifts some of the initialisation checking up a few levels, so that it can be detected, and we just succeed the bounds check if snmalloc has not been initialised.

The resulting ASM is:
```asm x86
<memcpy_guarded>:
    mov    rax,QWORD PTR [rip+0xbfa]        # Load Chunk map base
    test   rax,rax                          # Check if chunk map is initialised
    je     DONE                             #  |
    mov    rcx,rdi                          # Get chunk map entry
    shr    rcx,0xa                          #  |
    and    rcx,0xfffffffffffffff0           #  |
    mov    rax,QWORD PTR [rax+rcx*1+0x8]    # Load sizeclass
    and    eax,0x7f                         #  |
    shl    rax,0x5                          #  |
    lea    r8,[sizeclass_meta_data]         #  |
    mov    rcx,QWORD PTR [rax+r8*1]         # Load object size
    mov    r9,QWORD PTR [rax+r8*1+0x8]      # Load slab mask
    and    r9,rdi                           # Offset within slab
    mov    rax,QWORD PTR [rax+r8*1+0x10]    # Load modulus constant
    imul   rax,r9                           # Perform recripocal modulus
    shr    rax,0x36                         #  |
    imul   rax,rcx                          #  |
    sub    rcx,r9                           # Find distance to end of object.
    add    rcx,rax                          #  |
    cmp    rax,rdx                          # Compare to length of memcpy.
    jb     ERROR                            #  |
DONE:
    jmp    <memcpy>
ERROR:
    ud2                                     # Trap
```