### PR TITLE
CHERI bounds bug

### DIFF
--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -45,6 +45,15 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
 #else
   const auto exact_size = align == 1;
 #endif
+#ifdef __CHERI_PURE_CAPABILITY__
+  const auto cheri_size = __builtin_cheri_length_get(p);
+  if (cheri_size != alloc_size && (size != 0))
+  {
+    printf(
+      "Cheri size is %zu, but required to be %zu.\n", cheri_size, alloc_size);
+    failed = true;
+  }
+#endif
   if (exact_size && (alloc_size != expected_size) && (size != 0))
   {
     printf(


### PR DESCRIPTION
Add check in malloc test that CHERI capability length matches `alloc_size` and fix a bug in `address_space_core.h` were not being set correctly.