### PR TITLE
Refactor error reporting for bounds checks.

### DIFF
--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -336,7 +336,7 @@ namespace snmalloc
       const char hexdigits[] = "0123456789abcdef";
       // Length of string including null terminator
       static_assert(sizeof(hexdigits) == 0x11);
-      for (ssize_t i = buf.size() - 1; i >= 0; i--)
+      for (long i = long(buf.size() - 1); i >= 0; i--)
       {
         buf[static_cast<size_t>(i)] = hexdigits[s & 0xf];
         s >>= 4;

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -338,7 +338,7 @@ namespace snmalloc
       static_assert(sizeof(hexdigits) == 0x11);
       for (ssize_t i = buf.size() - 1; i >= 0; i--)
       {
-        buf.at(static_cast<size_t>(i)) = hexdigits[s & 0xf];
+        buf[static_cast<size_t>(i)] = hexdigits[s & 0xf];
         s >>= 4;
       }
       bool skipZero = true;
@@ -364,7 +364,7 @@ namespace snmalloc
     template<typename... Args>
     SNMALLOC_FAST_PATH FatalErrorBuilder(const char* fmt, Args... args)
     {
-      buffer.at(SafeLength) = 0;
+      buffer[SafeLength] = 0;
       size_t arg = 0;
       auto args_tuple = std::forward_as_tuple(args...);
       for (const char* s = fmt; *s != 0; ++s)

--- a/src/mem/bounds_checks.h
+++ b/src/mem/bounds_checks.h
@@ -1,0 +1,108 @@
+#pragma once
+#include "../snmalloc.h"
+
+namespace snmalloc
+{
+  /**
+   * Should we check loads?  This defaults to on in debug builds, off in
+   * release (store-only checks) and can be overridden by defining the macro
+   * `SNMALLOC_CHECK_LOADS` to true or false.
+   */
+  static constexpr bool CheckReads =
+#ifdef SNMALLOC_CHECK_LOADS
+    SNMALLOC_CHECK_LOADS
+#else
+    DEBUG
+#endif
+    ;
+
+  /**
+   * Should we fail fast when we encounter an error?  With this set to true, we
+   * just issue a trap instruction and crash the process once we detect an
+   * error. With it set to false we print a helpful error message and then crash
+   * the process.  The process may be in an undefined state by the time the
+   * check fails, so there are potentially security implications to turning this
+   * off. It defaults to true for debug builds, false for release builds and
+   * can be overridden by defining the macro `SNMALLOC_FAIL_FAST` to true or
+   * false.
+   */
+  static constexpr bool FailFast =
+#ifdef SNMALLOC_FAIL_FAST
+    SNMALLOC_FAIL_FAST
+#else
+    !DEBUG
+#endif
+    ;
+
+  /**
+   * Report an error message for a failed bounds check and then abort the
+   * program.
+   * `p` is the input pointer and `len` is the offset from this pointer of the
+   * bounds.  `msg` is the message that will be reported along with the
+   * start and end of the real object's bounds.
+   */
+  SNMALLOC_SLOW_PATH SNMALLOC_UNUSED_FUNCTION inline void
+    report_fatal_bounds_error [[noreturn]] (
+      void* p, size_t len, const char* msg, decltype(ThreadAlloc::get())& alloc)
+  {
+    report_fatal_error(
+      "{}: {} is in allocation {}--{}, offset {} is past the end\n",
+      msg,
+      p,
+      alloc.template external_pointer<Start>(p),
+      alloc.template external_pointer<OnePastEnd>(p),
+      len);
+  }
+
+  /**
+   * The direction for a bounds check.
+   */
+  enum class CheckDirection
+  {
+    /**
+     * A read bounds check, performed only when read checks are enabled.
+     */
+    Read,
+
+    /**
+     * A write bounds check, performed unconditionally.
+     */
+    Write
+  };
+
+  /**
+   * Check whether a pointer + length is in the same object as the pointer.
+   * Fail with the error message from the third argument if not.
+   *
+   * The template parameter indicates whether this is a read.  If so, this
+   * function is a no-op when `CheckReads` is false.
+   */
+  template<CheckDirection Direction = CheckDirection::Write>
+  SNMALLOC_FAST_PATH_INLINE void
+  check_bounds(const void* ptr, size_t len, const char* msg = "")
+  {
+    if constexpr ((Direction == CheckDirection::Write) || CheckReads)
+    {
+      auto& alloc = ThreadAlloc::get();
+      void* p = const_cast<void*>(ptr);
+
+      if (SNMALLOC_UNLIKELY(!alloc.check_bounds(ptr, len)))
+      {
+        if constexpr (FailFast)
+        {
+          UNUSED(p, len, msg);
+          SNMALLOC_FAST_FAIL();
+        }
+        else
+        {
+          report_fatal_bounds_error(p, len, msg, alloc);
+        }
+      }
+    }
+    else
+    {
+      UNUSED(ptr, len, msg);
+    }
+  }
+
+}

--- a/src/mem/chunkallocator.h
+++ b/src/mem/chunkallocator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../backend/backend_concept.h"
 #include "../ds/mpmcstack.h"
 #include "../ds/spmcstack.h"
 #include "../mem/metaslab.h"

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -142,4 +142,30 @@ namespace snmalloc
 #  endif
     "Page size from system header does not match snmalloc config page size.");
 #endif
+
+  /**
+   * Report a fatal error via a PAL-specific error reporting mechanism.  This
+   * takes a format string and a set of arguments.  The format string indicates
+   * the remaining arguments with "{}".  This could be extended later to
+   * support indexing fairly easily, if we ever want to localise these error
+   * messages.
+   *
+   * The following are supported as arguments:
+   *
+   *  - Characters (`char`), printed verbatim.
+   *  - Strings (anything convertible to `std::string_view`), typically string
+   *    literals because nothing on this path should be performing heap
+   *    allocations.  Printed verbatim.
+   *  - Raw pointers (void*), printed as hex strings.
+   *  - Integers (convertible to `size_t`), printed as hex strings.
+   *
+   *  These types should be sufficient for allocator-related error messages.
+   */
+  template<size_t BufferSize = 1024, typename... Args>
+  [[noreturn]] inline void report_fatal_error(Args... args)
+  {
+    FatalErrorBuilder<BufferSize> msg{std::forward<Args>(args)...};
+    Pal::error(msg.get_message());
+  }
+
 } // namespace snmalloc

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -237,6 +237,19 @@ int main(int argc, char** argv)
 
   setup();
 
+  // Smoke test the fatal error builder.  Check that it can generate strings
+  // including all of the kinds of things that it expects to be able to format.
+  void* fakeptr = reinterpret_cast<void*>(static_cast<uintptr_t>(0x42));
+  FatalErrorBuilder<1024> b{
+    "testing pointer {} size_t {} message, {} world, null is {}", fakeptr, size_t(42), "hello", nullptr};
+  if (
+    strcmp(
+      "testing pointer 0x42 size_t 0x2a message, hello world, null is 0x0", b.get_message()) != 0)
+  {
+    printf("Incorrect rendering of fatal error message: %s\n", b.get_message());
+    abort();
+  }
+
   our_free(nullptr);
 
   /* A very large allocation size that we expect to fail. */

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -241,10 +241,15 @@ int main(int argc, char** argv)
   // including all of the kinds of things that it expects to be able to format.
   void* fakeptr = reinterpret_cast<void*>(static_cast<uintptr_t>(0x42));
   FatalErrorBuilder<1024> b{
-    "testing pointer {} size_t {} message, {} world, null is {}", fakeptr, size_t(42), "hello", nullptr};
+    "testing pointer {} size_t {} message, {} world, null is {}",
+    fakeptr,
+    size_t(42),
+    "hello",
+    nullptr};
   if (
     strcmp(
-      "testing pointer 0x42 size_t 0x2a message, hello world, null is 0x0", b.get_message()) != 0)
+      "testing pointer 0x42 size_t 0x2a message, hello world, null is 0x0",
+      b.get_message()) != 0)
   {
     printf("Incorrect rendering of fatal error message: %s\n", b.get_message());
     abort();


### PR DESCRIPTION
This introduces a very limited formatter that can embed strings and hex
representations of pointers / integers in an internal buffer. This is
used to format error strings for passing to `Pal::error`.  This is used,
in turn, by a wrapper for reporting bounds checks, which can be used by
external functions to implement bounds checks.

This removes the sprintf_l usage from the bounds checks.

This provides enough of a format implementation that the tests
introduced in #465 can be refactored to use this, instead of their
custom `printf` wrapper and that can be used by SNMALLOC_CHECK.  This
will be a follow-on PR.