### PR TITLE
Add test helper macros.

### DIFF
--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -256,7 +256,7 @@ namespace snmalloc
    * build an on-stack buffer containing the formatted string.
    */
   template<size_t BufferSize>
-  class FatalErrorBuilder
+  class MessageBuilder
   {
     /**
      * The buffer that is used to store the formatted output.
@@ -428,7 +428,7 @@ namespace snmalloc
      * Constructor.  Takes a format string and the arguments to output.
      */
     template<typename... Args>
-    SNMALLOC_FAST_PATH FatalErrorBuilder(const char* fmt, Args... args)
+    SNMALLOC_FAST_PATH MessageBuilder(const char* fmt, Args... args)
     {
       buffer[SafeLength] = 0;
       size_t arg = 0;
@@ -450,10 +450,10 @@ namespace snmalloc
 
     /**
      * Constructor for trivial format strings (no arguments).  This exists to
-     * allow `FatalErrorBuilder` to be used with macros without special casing
+     * allow `MessageBuilder` to be used with macros without special casing
      * the single-argument version.
      */
-    SNMALLOC_FAST_PATH FatalErrorBuilder(const char* fmt)
+    SNMALLOC_FAST_PATH MessageBuilder(const char* fmt)
     {
       buffer[SafeLength] = 0;
       for (const char* s = fmt; *s != 0; ++s)

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -322,13 +322,14 @@ namespace snmalloc
      */
     void append(void* ptr)
     {
-      append(static_cast<size_t>(reinterpret_cast<uintptr_t>(ptr)));
+      append(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(ptr)));
+      // TODO: CHERI bits.
     }
 
     /**
      * Append a signed integer to the buffer, as a decimal string.
      */
-    void append(int64_t s)
+    void append(long long s)
     {
       if (s < 0)
       {
@@ -359,17 +360,9 @@ namespace snmalloc
     }
 
     /**
-     * Overload to force `int` to be promoted to `int64_t`, not `uint64_t`.
-     */
-    void append(int x)
-    {
-      append(int64_t(x));
-    }
-
-    /**
      * Append a size to the buffer, as a hex string.
      */
-    void append(uint64_t s)
+    void append(unsigned long long s)
     {
       append_char('0');
       append_char('x');
@@ -396,6 +389,38 @@ namespace snmalloc
       {
         append_char('0');
       }
+    }
+
+    /**
+     * Overload to force `long` to be promoted to `long long`.
+     */
+    void append(long x)
+    {
+      append(static_cast<long long>(x));
+    }
+
+    /**
+     * Overload to force `unsigned long` to be promoted to `unsigned long long`.
+     */
+    void append(unsigned long x)
+    {
+      append(static_cast<unsigned long long>(x));
+    }
+
+    /**
+     * Overload to force `int` to be promoted to `long long`.
+     */
+    void append(int x)
+    {
+      append(static_cast<long long>(x));
+    }
+
+    /**
+     * Overload to force `unsigned int` to be promoted to `unsigned long long`.
+     */
+    void append(unsigned int x)
+    {
+      append(static_cast<unsigned long long>(x));
     }
 
   public:

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -164,7 +164,7 @@ namespace snmalloc
   template<size_t BufferSize, typename... Args>
   [[noreturn]] inline void report_fatal_error(Args... args)
   {
-    FatalErrorBuilder<BufferSize> msg{std::forward<Args>(args)...};
+    MessageBuilder<BufferSize> msg{std::forward<Args>(args)...};
     Pal::error(msg.get_message());
   }
 

--- a/src/pal/pal.h
+++ b/src/pal/pal.h
@@ -161,7 +161,7 @@ namespace snmalloc
    *
    *  These types should be sufficient for allocator-related error messages.
    */
-  template<size_t BufferSize = 1024, typename... Args>
+  template<size_t BufferSize, typename... Args>
   [[noreturn]] inline void report_fatal_error(Args... args)
   {
     FatalErrorBuilder<BufferSize> msg{std::forward<Args>(args)...};

--- a/src/test/func/jemalloc/jemalloc.cc
+++ b/src/test/func/jemalloc/jemalloc.cc
@@ -60,10 +60,6 @@
 #  define ALLOCM_ERR_NOT_MOVED OUR_ALLOCM_ERR_NOT_MOVED
 #endif
 
-#ifdef _MSC_VER
-#  define __PRETTY_FUNCTION__ __FUNCSIG__
-#endif
-
 using namespace snmalloc;
 using namespace snmalloc::bits;
 

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -214,9 +214,9 @@ int main(int argc, char** argv)
   // including all of the kinds of things that it expects to be able to format.
   //
   // Note: We cannot use the check or assert macros here because they depend on
-  // `FatalErrorBuilder` working.  They are safe to use in any other test.
+  // `MessageBuilder` working.  They are safe to use in any other test.
   void* fakeptr = reinterpret_cast<void*>(static_cast<uintptr_t>(0x42));
-  FatalErrorBuilder<1024> b{
+  MessageBuilder<1024> b{
     "testing pointer {} size_t {} message, {} world, null is {}, -123456 is "
     "{}, 1234567 is {}",
     fakeptr,

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <test/helpers.h>
 #include <test/setup.h>
 
 #define SNMALLOC_NAME_MANGLE(a) our_##a
@@ -14,26 +15,20 @@ constexpr int SUCCESS = 0;
 void check_result(size_t size, size_t align, void* p, int err, bool null)
 {
   bool failed = false;
-  if (errno != err && err != SUCCESS)
-  {
-    // Note: successful calls are allowed to spuriously set errno
-    printf("Expected error: %d but got %d\n", err, errno);
-    abort();
-  }
-
+  EXPECT(
+    (errno == err) || (err == SUCCESS),
+    "Expected error: {} but got {}",
+    err,
+    errno);
   if (null)
   {
-    if (p != nullptr)
-    {
-      printf("Expected null, and got non-null return!\n");
-      abort();
-    }
+    EXPECT(p == nullptr, "Expected null but got {}", p);
     return;
   }
 
   if ((p == nullptr) && (size != 0))
   {
-    printf("Unexpected null returned.\n");
+    INFO("Unexpected null returned.\n");
     failed = true;
   }
   const auto alloc_size = our_malloc_usable_size(p);
@@ -57,8 +52,7 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
   const auto cheri_size = __builtin_cheri_length_get(p);
   if (cheri_size != alloc_size && (size != 0))
   {
-    printf(
-      "Cheri size is %zu, but required to be %zu.\n", cheri_size, alloc_size);
+    INFO("Cheri size is {}, but required to be {}.", cheri_size, alloc_size);
     failed = true;
   }
   if (p != nullptr)
@@ -82,16 +76,14 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
 #endif
   if (exact_size && (alloc_size != expected_size) && (size != 0))
   {
-    printf(
-      "Usable size is %zu, but required to be %zu.\n",
-      alloc_size,
-      expected_size);
+    INFO(
+      "Usable size is {}, but required to be {}.", alloc_size, expected_size);
     failed = true;
   }
   if ((!exact_size) && (alloc_size < expected_size))
   {
-    printf(
-      "Usable size is %zu, but required to be at least %zu.\n",
+    INFO(
+      "Usable size is {}, but required to be at least {}.",
       alloc_size,
       expected_size);
     failed = true;
@@ -100,34 +92,27 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
     (static_cast<size_t>(reinterpret_cast<uintptr_t>(p) % align) != 0) &&
     (size != 0))
   {
-    printf(
-      "Address is 0x%zx, but required to be aligned to 0x%zx.\n",
-      reinterpret_cast<size_t>(p),
-      align);
+    INFO("Address is {}, but required to be aligned to {}.\n", p, align);
     failed = true;
   }
   if (
     static_cast<size_t>(
       reinterpret_cast<uintptr_t>(p) % natural_alignment(size)) != 0)
   {
-    printf(
-      "Address is 0x%zx, but should have natural alignment to 0x%zx.\n",
-      reinterpret_cast<size_t>(p),
+    INFO(
+      "Address is {}, but should have natural alignment to {}.\n",
+      p,
       natural_alignment(size));
     failed = true;
   }
 
-  if (failed)
-  {
-    printf("check_result failed! %p", p);
-    abort();
-  }
+  EXPECT(!failed, "check_result failed! {}", p);
   our_free(p);
 }
 
 void test_calloc(size_t nmemb, size_t size, int err, bool null)
 {
-  printf("calloc(%zu, %zu)  combined size %zu\n", nmemb, size, nmemb * size);
+  START_TEST("calloc({}, {})  combined size {}\n", nmemb, size, nmemb * size);
   errno = SUCCESS;
   void* p = our_calloc(nmemb, size);
 
@@ -135,11 +120,7 @@ void test_calloc(size_t nmemb, size_t size, int err, bool null)
   {
     for (size_t i = 0; i < (size * nmemb); i++)
     {
-      if (((uint8_t*)p)[i] != 0)
-      {
-        printf("non-zero at @%zu\n", i);
-        abort();
-      }
+      EXPECT(((uint8_t*)p)[i] == 0, "non-zero at {}", i);
     }
   }
   check_result(nmemb * size, 1, p, err, null);
@@ -151,7 +132,7 @@ void test_realloc(void* p, size_t size, int err, bool null)
   if (p != nullptr)
     old_size = our_malloc_usable_size(p);
 
-  printf("realloc(%p(%zu), %zu)\n", p, old_size, size);
+  START_TEST("realloc({}({}), {})", p, old_size, size);
   errno = SUCCESS;
   auto new_p = our_realloc(p, size);
   // Realloc failure case, deallocate original block
@@ -162,7 +143,7 @@ void test_realloc(void* p, size_t size, int err, bool null)
 
 void test_posix_memalign(size_t size, size_t align, int err, bool null)
 {
-  printf("posix_memalign(&p, %zu, %zu)\n", align, size);
+  START_TEST("posix_memalign(&p, {}, {})", align, size);
   void* p = nullptr;
   errno = our_posix_memalign(&p, align, size);
   check_result(size, align, p, err, null);
@@ -170,7 +151,7 @@ void test_posix_memalign(size_t size, size_t align, int err, bool null)
 
 void test_memalign(size_t size, size_t align, int err, bool null)
 {
-  printf("memalign(%zu, %zu)\n", align, size);
+  START_TEST("memalign({}, {})", align, size);
   errno = SUCCESS;
   void* p = our_memalign(align, size);
   check_result(size, align, p, err, null);
@@ -183,7 +164,7 @@ void test_reallocarray(void* p, size_t nmemb, size_t size, int err, bool null)
   if (p != nullptr)
     old_size = our_malloc_usable_size(p);
 
-  printf("reallocarray(%p(%zu), %zu)\n", p, old_size, tsize);
+  START_TEST("reallocarray({}({}), {})", p, old_size, tsize);
   errno = SUCCESS;
   auto new_p = our_reallocarray(p, nmemb, size);
   if (new_p == nullptr && tsize != 0)
@@ -198,15 +179,11 @@ void test_reallocarr(
 
   if (size_old != (size_t)~0)
     p = our_malloc(size_old);
+  START_TEST("reallocarr({}({}), {})", p, nmemb, size);
   errno = SUCCESS;
   int r = our_reallocarr(&p, nmemb, size);
-  if (r != err)
-  {
-    printf("reallocarr failed! expected %d got %d\n", err, r);
-    abort();
-  }
+  EXPECT(r == err, "reallocarr failed! expected {} got {}\n", err, r);
 
-  printf("reallocarr(%p(%zu), %zu)\n", p, nmemb, size);
   check_result(nmemb * size, 1, p, err, null);
   p = our_malloc(size);
   if (!p)
@@ -221,11 +198,7 @@ void test_reallocarr(
 
   for (size_t i = 1; i < size; i++)
   {
-    if (static_cast<char*>(p)[i] != 1)
-    {
-      printf("data consistency failed! at %zu", i);
-      abort();
-    }
+    EXPECT(static_cast<char*>(p)[i] == 1, "data consistency failed! at {}", i);
   }
   our_free(p);
 }
@@ -239,16 +212,23 @@ int main(int argc, char** argv)
 
   // Smoke test the fatal error builder.  Check that it can generate strings
   // including all of the kinds of things that it expects to be able to format.
+  //
+  // Note: We cannot use the check or assert macros here because they depend on
+  // `FatalErrorBuilder` working.  They are safe to use in any other test.
   void* fakeptr = reinterpret_cast<void*>(static_cast<uintptr_t>(0x42));
   FatalErrorBuilder<1024> b{
-    "testing pointer {} size_t {} message, {} world, null is {}",
+    "testing pointer {} size_t {} message, {} world, null is {}, -123456 is "
+    "{}, 1234567 is {}",
     fakeptr,
     size_t(42),
     "hello",
-    nullptr};
+    nullptr,
+    -123456,
+    1234567};
   if (
     strcmp(
-      "testing pointer 0x42 size_t 0x2a message, hello world, null is 0x0",
+      "testing pointer 0x42 size_t 0x2a message, hello world, null is 0x0, "
+      "-123456 is -123456, 1234567 is 1234567",
       b.get_message()) != 0)
   {
     printf("Incorrect rendering of fatal error message: %s\n", b.get_message());
@@ -265,7 +245,7 @@ int main(int argc, char** argv)
   for (smallsizeclass_t sc = 0; sc < (MAX_SMALL_SIZECLASS_BITS + 4); sc++)
   {
     const size_t size = bits::one_at_bit(sc);
-    printf("malloc: %zu\n", size);
+    START_TEST("malloc: {}", size);
     errno = SUCCESS;
     check_result(size, 1, our_malloc(size), SUCCESS, false);
     errno = SUCCESS;
@@ -320,7 +300,7 @@ int main(int argc, char** argv)
     for (smallsizeclass_t sc2 = 0; sc2 < (MAX_SMALL_SIZECLASS_BITS + 4); sc2++)
     {
       const size_t size2 = bits::one_at_bit(sc2);
-      printf("size1: %zu, size2:%zu\n", size, size2);
+      INFO("size1: {}, size2:{}\n", size, size2);
       test_realloc(our_malloc(size), size2, SUCCESS, false);
       test_realloc(our_malloc(size + 1), size2, SUCCESS, false);
     }
@@ -373,32 +353,22 @@ int main(int argc, char** argv)
     test_reallocarr(size, 1, 0, SUCCESS, false);
     test_reallocarr(size, 2, size, SUCCESS, false);
     void* p = our_malloc(size);
-    if (p == nullptr)
-    {
-      printf("realloc alloc failed with %zu\n", size);
-      abort();
-    }
+    EXPECT(p != nullptr, "realloc alloc failed with {}", size);
     int r = our_reallocarr(&p, 1, too_big_size);
-    if (r != ENOMEM)
-    {
-      printf("expected failure on allocation\n");
-      abort();
-    }
+    EXPECT(r == ENOMEM, "expected failure on allocation\n");
     our_free(p);
 
     for (smallsizeclass_t sc2 = 0; sc2 < (MAX_SMALL_SIZECLASS_BITS + 4); sc2++)
     {
       const size_t size2 = bits::one_at_bit(sc2);
-      printf("size1: %zu, size2:%zu\n", size, size2);
+      START_TEST("size1: {}, size2:{}", size, size2);
       test_reallocarr(size, 1, size2, SUCCESS, false);
     }
   }
 
-  if (our_malloc_usable_size(nullptr) != 0)
-  {
-    printf("malloc_usable_size(nullptr) should be zero");
-    abort();
-  }
+  EXPECT(
+    our_malloc_usable_size(nullptr) == 0,
+    "malloc_usable_size(nullptr) should be zero");
 
   snmalloc::debug_check_empty<snmalloc::Globals>();
   return 0;

--- a/src/test/helpers.h
+++ b/src/test/helpers.h
@@ -1,4 +1,8 @@
 #pragma once
+#ifdef _MSC_VER
+#  define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
+
 namespace snmalloc
 {
   /**

--- a/src/test/helpers.h
+++ b/src/test/helpers.h
@@ -1,0 +1,35 @@
+#pragma once
+namespace snmalloc
+{
+  /**
+   * The name of the function under test.  This is set in the START_TEST macro
+   * and used for error reporting in EXPECT.
+   */
+  const char* current_test = "";
+
+  /**
+   * Log that the test started.
+   */
+#define START_TEST(msg, ...) \
+  do \
+  { \
+    current_test = __PRETTY_FUNCTION__; \
+    FatalErrorBuilder<1024> feb{"Starting test: " msg "\n", ##__VA_ARGS__}; \
+    fputs(feb.get_message(), stderr); \
+  } while (0)
+
+  /**
+   * An assertion that fires even in debug builds.  Uses the value set by
+   * START_TEST.
+   */
+#define EXPECT(x, msg, ...) \
+  SNMALLOC_CHECK_MSG(x, " in test {} " msg "\n", current_test, ##__VA_ARGS__)
+
+#define INFO(msg, ...) \
+  do \
+  { \
+    FatalErrorBuilder<1024> feb{msg "\n", ##__VA_ARGS__}; \
+    fputs(feb.get_message(), stderr); \
+  } while (0)
+
+}

--- a/src/test/helpers.h
+++ b/src/test/helpers.h
@@ -18,8 +18,8 @@ namespace snmalloc
   do \
   { \
     current_test = __PRETTY_FUNCTION__; \
-    FatalErrorBuilder<1024> feb{"Starting test: " msg "\n", ##__VA_ARGS__}; \
-    fputs(feb.get_message(), stderr); \
+    MessageBuilder<1024> mb{"Starting test: " msg "\n", ##__VA_ARGS__}; \
+    fputs(mb.get_message(), stderr); \
   } while (0)
 
   /**
@@ -32,8 +32,8 @@ namespace snmalloc
 #define INFO(msg, ...) \
   do \
   { \
-    FatalErrorBuilder<1024> feb{msg "\n", ##__VA_ARGS__}; \
-    fputs(feb.get_message(), stderr); \
+    MessageBuilder<1024> mb{msg "\n", ##__VA_ARGS__}; \
+    fputs(mb.get_message(), stderr); \
   } while (0)
 
 }


### PR DESCRIPTION
 - Refactor the existing SNMALLOC_ASSERT and SNMALLOC_CHECK.  These now
   use the FatalErrorBuilder to format the output if a format string is
   provided.
 - Extend the FatalErrorBuilder to print decimal integers for signed
   values.
 - Rewrite the macros used in the jemalloc tests to use
   FatalErrorBuilder and move them into a header.
 - Refactor some of the tests to use the new macros.