### PR TITLE
Add Pal::message.

### DIFF
--- a/src/pal/pal_freebsd_kernel.h
+++ b/src/pal/pal_freebsd_kernel.h
@@ -28,6 +28,15 @@ namespace snmalloc
      * PAL supports.
      */
     static constexpr uint64_t pal_features = AlignedAllocation;
+
+    /**
+     * Report a message to console, followed by a newline.
+     */
+    static void message(const char* const str) noexcept
+    {
+      printf("%s\n", str);
+    }
+
     [[noreturn]] void error(const char* const str)
     {
       panic("snmalloc error: %s", str);

--- a/src/pal/pal_noalloc.h
+++ b/src/pal/pal_noalloc.h
@@ -49,6 +49,14 @@ namespace snmalloc
     }
 
     /**
+     * Report a message to the user.
+     */
+    static void message(const char* const str) noexcept
+    {
+      BasePAL::message(str);
+    }
+
+    /**
      * Report a fatal error an exit.
      */
     [[noreturn]] static void error(const char* const str) noexcept

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -164,7 +164,7 @@ namespace snmalloc
      */
     static void message(const char* const str) noexcept
     {
-		void *nl = const_cast<char*>("\n");
+      void* nl = const_cast<char*>("\n");
       struct iovec iov[] = {{const_cast<char*>(str), strlen(str)}, {nl, 1}};
       UNUSED(writev(STDERR_FILENO, iov, sizeof(iov) / sizeof(struct iovec)));
       UNUSED(fsync(STDERR_FILENO));
@@ -179,8 +179,9 @@ namespace snmalloc
       /// subsequent allocation will work.
       /// @attention: since the program is failing, we do not guarantee that
       /// previous bytes in stdout will be flushed
-		void *nl = const_cast<char*>("\n");
-      struct iovec iov[] = {{nl,  1}, {const_cast<char*>(str), strlen(str)}, {nl, 1}};
+      void* nl = const_cast<char*>("\n");
+      struct iovec iov[] = {
+        {nl, 1}, {const_cast<char*>(str), strlen(str)}, {nl, 1}};
       UNUSED(writev(STDERR_FILENO, iov, sizeof(iov) / sizeof(struct iovec)));
       UNUSED(fsync(STDERR_FILENO));
       print_stack_trace();

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -118,8 +118,14 @@ namespace snmalloc
 
     [[noreturn]] static void error(const char* const str)
     {
-      puts(str);
-      fflush(stdout);
+      fputs(str, stderr);
+      fputc('\n', stderr);
+      fflush(stderr);
+    }
+
+    [[noreturn]] static void error(const char* const str)
+    {
+      message(str);
       abort();
     }
 

--- a/src/pal/pal_windows.h
+++ b/src/pal/pal_windows.h
@@ -116,7 +116,7 @@ namespace snmalloc
       low_memory_callbacks.register_notification(callback);
     }
 
-    [[noreturn]] static void error(const char* const str)
+    static void message(const char* const str)
     {
       fputs(str, stderr);
       fputc('\n', stderr);

--- a/src/test/helpers.h
+++ b/src/test/helpers.h
@@ -19,7 +19,7 @@ namespace snmalloc
   { \
     current_test = __PRETTY_FUNCTION__; \
     MessageBuilder<1024> mb{"Starting test: " msg "\n", ##__VA_ARGS__}; \
-    fputs(mb.get_message(), stderr); \
+    Pal::message(mb.get_message()); \
   } while (0)
 
   /**
@@ -33,7 +33,7 @@ namespace snmalloc
   do \
   { \
     MessageBuilder<1024> mb{msg "\n", ##__VA_ARGS__}; \
-    fputs(mb.get_message(), stderr); \
+    Pal::message(mb.get_message()); \
   } while (0)
 
 }

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -65,7 +65,7 @@ void print_stack_trace()
 void _cdecl error(int signal)
 {
   snmalloc::UNUSED(signal);
-  Pal::message("*****ABORT******");
+  snmalloc::Pal::message("*****ABORT******");
 
   print_stack_trace();
 
@@ -76,7 +76,7 @@ LONG WINAPI VectoredHandler(struct _EXCEPTION_POINTERS* ExceptionInfo)
 {
   snmalloc::UNUSED(ExceptionInfo);
 
-  Pal::message("*****UNHANDLED EXCEPTION******");
+  snmalloc::Pal::message("*****UNHANDLED EXCEPTION******");
 
   print_stack_trace();
 

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -1,4 +1,5 @@
 #if defined(SNMALLOC_CI_BUILD)
+#  include <pal/pal.h>
 #  if defined(WIN32)
 #    include <ds/bits.h>
 #    include <iostream>
@@ -96,7 +97,6 @@ void setup()
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 }
 #  else
-#    include <pal/pal.h>
 #    include <signal.h>
 void error_handle(int signal)
 {

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -64,7 +64,7 @@ void print_stack_trace()
 void _cdecl error(int signal)
 {
   snmalloc::UNUSED(signal);
-  puts("*****ABORT******");
+  Pal::message("*****ABORT******");
 
   print_stack_trace();
 
@@ -75,7 +75,7 @@ LONG WINAPI VectoredHandler(struct _EXCEPTION_POINTERS* ExceptionInfo)
 {
   snmalloc::UNUSED(ExceptionInfo);
 
-  puts("*****UNHANDLED EXCEPTION******");
+  Pal::message("*****UNHANDLED EXCEPTION******");
 
   print_stack_trace();
 


### PR DESCRIPTION
This provides a single place for reporting messages to the user.

While here, be consistent about using stderr for things that should go
to stderr.  We were previously using a mix of stderr and stdout.