### PR TITLE
`madvise` arguments are not flags.

### DIFF
--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -67,7 +67,8 @@ namespace snmalloc
       if constexpr (DEBUG)
         memset(p, 0x5a, size);
 
-      madvise(p, size, MADV_FREE | MADV_NOCORE);
+      madvise(p, size, MADV_NOCORE);
+      madvise(p, size, MADV_FREE);
 
       if constexpr (PalEnforceAccess)
       {


### PR DESCRIPTION
You can't or together multiple `madvise` flags in a single call.