### PR TITLE
g++ 12 unit test build fix.

### DIFF
--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -134,8 +134,8 @@ void test_random_allocation()
       auto& cell = objects[index % count];
       if (cell != nullptr)
       {
-        alloc.dealloc(cell);
         allocated.erase(cell);
+        alloc.dealloc(cell);
         cell = nullptr;
         alloc_count--;
       }


### PR DESCRIPTION
test_random_allocation, g++ sees the removal from the list of the test case
as UAF.