### PR TITLE
Further disentangle front- and back-ends

### DIFF
--- a/docs/AddressSpace.md
+++ b/docs/AddressSpace.md
@@ -1,0 +1,157 @@
+# How snmalloc Manages Address Space
+
+Like any modern, high-performance allocator, `snmalloc` contains multiple layers of allocation.
+We give here some notes on the internal orchestration.
+
+## From platform to malloc
+
+Consider a first, "small" allocation (typically less than a platform page); such allocations showcase more of the machinery.
+For simplicity, we assume that
+
+- this is not an `OPEN_ENCLAVE` build,
+- the `BackendAllocator` has not been told to use a `fixed_range`,
+- this is not a `SNMALLOC_CHECK_CLIENT` build, and
+- (as a consequence of the above) `SNMALLOC_META_PROTECTED` is not `#define`-d.
+
+Since this is the first allocation, all the internal caches will be empty, and so we will hit all the slow paths.
+For simplicity, we gloss over much of the "lazy initialization" that would actually be implied by a first allocation.
+
+1. The `LocalAlloc::small_alloc` finds that it cannot satisfy the request because its `LocalCache` lacks a free list for this size class.
+   The request is delegated, unchanged, to `CoreAllocator::small_alloc`.
+
+2. The `CoreAllocator` has no active slab for this sizeclass, so `CoreAllocator::small_alloc_slow` delegates to `BackendAllocator::alloc_chunk`.
+   At this point, the allocation request is enlarged to one or a few chunks (a small counting number multiple of `MIN_CHUNK_SIZE`, which is typically 16KiB); see `sizeclass_to_slab_size`.
+
+3. `BackendAllocator::alloc_chunk` at this point splits the allocation request in two, allocating both the chunk's metadata structure (of size `PAGEMAP_METADATA_STRUCT_SIZE`) and the chunk itself (a multiple of `MIN_CHUNK_SIZE`).
+   Because the two exercise similar bits of machinery, we now track them in parallel in prose despite their sequential nature.
+
+4. The `BackendAllocator` has a chain of "range" types that it uses to manage address space.
+   By default (and in the case we are considering), that chain begins with a per-thread "small buddy allocator range".
+
+   1. For the metadata allocation, the size is (well) below `MIN_CHUNK_SIZE` and so this allocator, which by supposition is empty, attempts to `refill` itself from its parent.
+      This results in a request for a `MIN_CHUNK_SIZE` chunk from the parent allocator.
+
+   2. For the chunk allocation, the size is `MIN_CHUNK_SIZE` or larger, so this allocator immediately forwards the request to its parent.
+
+5. The next range allocator in the chain is a per-thread *large* buddy allocator that refills in 2 MiB granules.
+   (2 MiB chosen because it is a typical superpage size.)
+   At this point, both requests are for at least one and no more than a few times `MIN_CHUNK_SIZE` bytes.
+
+   1. The first request will `refill` this empty allocator by making a request for 2 MiB to its parent.
+
+   2. The second request will stop here, as the allocator will no longer be empty.
+
+6. The chain continues with a `CommitRange`, which simply forwards all allocation requests and (upon unwinding) ensures that the address space is mapped.
+
+7. The chain now transitions from thread-local to global; the `GlobalRange` simply serves to acquire a lock around the rest of the chain.
+
+8. The next entry in the chain is a `StatsRange` which serves to accumulate statistics.
+   We ignore this stage and continue onwards.
+
+9. The next entry in the chain is another *large* buddy allocator which refills at 16 MiB but can hold regions
+   of any size up to the entire address space.
+   The first request triggers a `refill`, continuing along the chain as a 16 MiB request.
+   (Recall that the second allocation will be handled at an earlier point on the chain.)
+
+10. The penultimate entry in the chain is a `PagemapRegisterRange`, which always forwards allocations along the chain.
+
+11. At long last, we have arrived at the last entry in the chain, a `PalRange`.
+    This delegates the actual allocation, of 16 MiB, to either the `reserve_aligned` or `reserve` method of the Platform Abstraction Layer (PAL).
+
+12. Having wound the chain onto our stack, we now unwind!
+    The `PagemapRegisterRange` ensures that the Pagemap entries for allocations passing through it are mapped and returns the allocation unaltered.
+
+13. The global large buddy allocator splits the 16 MiB refill into 8, 4, and 2 MiB regions it retains as well as returning the remaining 2 MiB back along the chain.
+
+14. The `StatsRange` makes its observations, the `GlobalRange` now unlocks the global component of the chain, and the `CommitRange` ensures that the allocation is mapped.
+    Aside from these side effects, these propagate the allocation along the chain unaltered.
+
+15. We now arrive back at the thread-local large buddy allocator, which takes its 2 MiB refill and breaks it down into powers of two down to the requested `MIN_CHUNK_SIZE`.
+    The second allocation (of the chunk), will either return or again break down one of these intermediate chunks.
+
+16. For the first (metadata) allocation, the thread-local *small* allocator breaks the `MIN_CHUNK_SIZE` allocation down into powers of two down to `PAGEMAP_METADATA_STRUCT_SIZE` and returns one of that size.
+    The second allocation will have been forwarded and so is not additionally handled here.
+
+Exciting, no?
+
+## What Can I Learn from the Pagemap?
+
+### Decoding a MetaEntry
+
+The centerpiece of `snmalloc`'s metadata is its `PageMap`, which associates each "chunk" of the address space (~16KiB; see `MIN_CHUNK_BITS`) with a `MetaEntry`.
+A `MetaEntry` is a pair of pointers, suggestively named `meta` and `remote_and_sizeclass`.
+In more detail, `MetaEntry`s are better represented by Sigma and Pi types, all packed into two pointer-sized words in ways that preserve pointer provenance on CHERI.
+
+To begin decoding, a bit (`REMOTE_BACKEND_MARKER`) in `remote_and_sizeclass` distinguishes chunks owned by frontend and backend allocators.
+
+For chunks owned by the *frontend* (`REMOTE_BACKEND_MARKER` not asserted),
+
+1. The `remote_and_sizeclass` field is a product of
+
+   1. A `RemoteAllocator*` indicating the `LocalAlloc` that owns the region of memory.
+
+   2. A "full sizeclass" value (itself a tagged sum type between large and small sizeclasses).
+
+2. The `meta` pointer is a bit-stuffed pair of
+
+   1. A pointer to a larger metadata structure with type dependent on the role of this chunk
+
+   2. A bit (`META_BOUNDARY_BIT`) that serves to limit chunk coalescing on platforms where that may not be possible, such as CHERI.
+
+See `src/backend/metatypes.h` and `src/mem/metaslab.h`.
+
+For chunks owned by a *backend* (`REMOTE_BACKEND_MARKER` asserted), there are again multiple possibilities.
+
+For chunks owned by a *small buddy allocator*, the remainder of the `MetaEntry` is zero.
+That is, it appears to have small sizeclass 0 and an implausible `RemoteAllocator*`.
+
+For chunks owned by a *large buddy allocator*, the `MetaEntry` is instead a node in a red-black tree of all such chunks.
+Its contents can be decoded as follows:
+
+1. The `meta` field's `META_BOUNDARY_BIT` is preserved, with the same meaning as in the frontend case, above.
+
+2. `meta` (resp. `remote_and_sizeclass`) includes a pointer to the left (resp. right) *chunk* of address space.
+   (The corresponding child *node* in this tree is found by taking the *address* of this chunk and looking up the `MetaEntry` in the Pagemap.
+   This trick of pointing at the child's chunk rather than at the child `MetaEntry` is particularly useful on CHERI:
+   it allows us to capture the authority to the chunk without needing another pointer and costs just a shift and add.)
+
+3. The `meta` field's `LargeBuddyRep::RED_BIT` is used to carry the red/black color of this node.
+
+See `src/backend/largebuddyrange.h`.
+
+### Encoding a MetaEntry
+
+We can also consider the process for generating a MetaEntry for a chunk of the address space given its state.
+The following cases apply:
+
+1. The address is not associated with `snmalloc`:
+   Here, the `MetaEntry`, if it is mapped, is all zeros and so it...
+   * has `REMOTE_BACKEND_MARKER` clear in `remote_and_sizeclass`.
+   * appears to be owned by a frontend RemoteAllocator at address 0 (probably, but not certainly, `nullptr`).
+   * has "small" sizeclass 0, which has size 0.
+   * has no associated metadata structure.
+
+2. The address is part of a free chunk in a backend's Large Buddy Allocator:
+   The `MetaEntry`...
+   * has `REMOTE_BACKEND_MARKER` asserted in `remote_and_sizeclass`.
+   * has "small" sizeclass 0, which has size 0.
+   * the remainder of its `MetaEntry` structure will be a Large Buddy Allocator rbtree node.
+   * has no associated metadata structure.
+
+3. The address is part of a free chunk inside a backend's Small Buddy Allocator:
+   Here, the `MetaEntry` is zero aside from the asserted `REMOTE_BACKEND_MARKER` bit, and so it...
+   * has "small" sizeclass 0, which has size 0.
+   * has no associated metadata structure.
+
+4. The address is part of a live large allocation (spanning one or more 16KiB chunks):
+   Here, the `MetaEntry`...
+   * has `REMOTE_BACKEND_MARKER` clear in `remote_and_sizeclass`.
+   * has a *large* sizeclass value.
+   * has an associated `RemoteAllocator*` and `Metaslab*` metadata structure
+     (holding just the original chunk pointer in its `MetaCommon` substructure;
+      it is configured to always trigger the deallocation slow-path to skip the logic when a chunk is in use as a slab).
+
+5. The address, whether or not it is presently within an allocated object, is part of an active slab.  Here, the `MetaEntry`....
+   * encodes the *small* sizeclass of all objects in the slab.
+   * has a `RemoteAllocator*` referencing the owning `LocalAlloc`'s message queue.
+   * points to the slab's `Metaslab` structure containing additional metadata (e.g., free list).

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "../mem/allocconfig.h"
-#include "../mem/metaslab.h"
 #include "../pal/pal.h"
 #include "chunkallocator.h"
 #include "commitrange.h"
@@ -8,6 +7,7 @@
 #include "empty_range.h"
 #include "globalrange.h"
 #include "largebuddyrange.h"
+#include "metatypes.h"
 #include "pagemap.h"
 #include "pagemapregisterrange.h"
 #include "palrange.h"
@@ -259,7 +259,7 @@ namespace snmalloc
       SNMALLOC_ASSERT(size >= MIN_CHUNK_SIZE);
 
       auto meta_cap =
-        local_state.get_meta_range()->alloc_range(sizeof(Metaslab));
+        local_state.get_meta_range()->alloc_range(PAGEMAP_METADATA_STRUCT_SIZE);
 
       auto meta = meta_cap.template as_reinterpret<Metaslab>().unsafe_ptr();
 
@@ -277,7 +277,8 @@ namespace snmalloc
 #endif
       if (p == nullptr)
       {
-        local_state.get_meta_range()->dealloc_range(meta_cap, sizeof(Metaslab));
+        local_state.get_meta_range()->dealloc_range(
+          meta_cap, PAGEMAP_METADATA_STRUCT_SIZE);
         errno = ENOMEM;
 #ifdef SNMALLOC_TRACING
         std::cout << "Out of memory" << std::endl;
@@ -300,7 +301,7 @@ namespace snmalloc
       auto chunk = chunk_record->meta_common.chunk;
 
       local_state.get_meta_range()->dealloc_range(
-        capptr::Chunk<void>(chunk_record), sizeof(Metaslab));
+        capptr::Chunk<void>(chunk_record), PAGEMAP_METADATA_STRUCT_SIZE);
 
       // TODO, should we set the sizeclass to something specific here?
 

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -305,10 +305,17 @@ namespace snmalloc
     {
       auto chunk = chunk_record->meta_common.chunk;
 
+      /*
+       * The backend takes possession of these chunks now, by disassociating
+       * any existing remote allocator and metadata structure.  If
+       * interrogated, the sizeclass reported by the MetaEntry is 0, which has
+       * size 0.
+       */
+      MetaEntry t(nullptr, MetaEntry::REMOTE_BACKEND_MARKER);
+      Pagemap::set_metaentry(address_cast(chunk), size, t);
+
       local_state.get_meta_range()->dealloc_range(
         capptr::Chunk<void>(chunk_record), PAGEMAP_METADATA_STRUCT_SIZE);
-
-      // TODO, should we set the sizeclass to something specific here?
 
       local_state.object_range->dealloc_range(chunk, size);
     }

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -217,7 +217,8 @@ namespace snmalloc
      *
      * The template argument is the type of the metadata being allocated.  This
      * allows the backend to allocate different types of metadata in different
-     * places or with different policies.
+     * places or with different policies.  The default implementation, here,
+     * does not avail itself of this degree of freedom.
      */
     template<typename T>
     static capptr::Chunk<void>

--- a/src/backend/backend_concept.h
+++ b/src/backend/backend_concept.h
@@ -24,10 +24,10 @@ namespace snmalloc
   {
     { Meta::set_metaentry(addr, sz, t) } -> ConceptSame<void>;
 
-    { Meta::template get_metaentry<true>(addr) }
+    { Meta::template get_metaentry<MetaEntry, true>(addr) }
       -> ConceptSame<const MetaEntry&>;
 
-    { Meta::template get_metaentry<false>(addr) }
+    { Meta::template get_metaentry<MetaEntry, false>(addr) }
       -> ConceptSame<const MetaEntry&>;
   };
 

--- a/src/backend/chunkallocator.h
+++ b/src/backend/chunkallocator.h
@@ -183,10 +183,9 @@ namespace snmalloc
     static std::pair<capptr::Chunk<void>, Metaslab*> alloc_chunk(
       typename SharedStateHandle::LocalState& local_state,
       ChunkAllocatorLocalState& chunk_alloc_local_state,
-      sizeclass_t sizeclass,
       chunksizeclass_t slab_sizeclass,
       size_t slab_size,
-      RemoteAllocator* remote)
+      uintptr_t ras)
     {
       using PAL = typename SharedStateHandle::Pal;
       ChunkAllocatorState& state =
@@ -234,7 +233,7 @@ namespace snmalloc
                   << " memory in stacks " << state.memory_in_stacks
                   << std::endl;
 #endif
-        MetaEntry entry{meta, remote, sizeclass};
+        MetaEntry entry{&meta->meta_common, ras};
         SharedStateHandle::Pagemap::set_metaentry(
           address_cast(slab), slab_size, entry);
         return {slab, meta};
@@ -242,8 +241,8 @@ namespace snmalloc
 
       // Allocate a fresh slab as there are no available ones.
       // First create meta-data
-      auto [slab, meta] = SharedStateHandle::alloc_chunk(
-        &local_state, slab_size, remote, sizeclass);
+      auto [slab, meta] =
+        SharedStateHandle::alloc_chunk(&local_state, slab_size, ras);
 #ifdef SNMALLOC_TRACING
       std::cout << "Create slab:" << slab.unsafe_ptr() << " slab_sizeclass "
                 << slab_sizeclass << " size " << slab_size << std::endl;

--- a/src/backend/largebuddyrange.h
+++ b/src/backend/largebuddyrange.h
@@ -29,7 +29,8 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT((r & (MIN_CHUNK_SIZE - 1)) == 0);
       // Preserve lower bits.
-      *ptr = r | address_cast(*ptr & (MIN_CHUNK_SIZE - 1)) | BACKEND_MARKER;
+      *ptr = r | address_cast(*ptr & (MIN_CHUNK_SIZE - 1)) |
+        MetaEntry::REMOTE_BACKEND_MARKER;
     }
 
     static Contents get(const Holder* ptr)

--- a/src/backend/largebuddyrange.h
+++ b/src/backend/largebuddyrange.h
@@ -3,7 +3,6 @@
 #include "../ds/address.h"
 #include "../ds/bits.h"
 #include "../mem/allocconfig.h"
-#include "../mem/metaslab.h"
 #include "../pal/pal.h"
 #include "buddy.h"
 #include "range_helpers.h"

--- a/src/backend/metatypes.h
+++ b/src/backend/metatypes.h
@@ -123,6 +123,17 @@ namespace snmalloc
     uintptr_t remote_and_sizeclass{0};
 
   public:
+    /**
+     * This bit is set in remote_and_sizeclass to discriminate between the case
+     * that it is in use by the frontend (0) or by the backend (1).  For the
+     * former case, see mem/metaslab.h; for the latter, see backend/backend.h
+     * and backend/largebuddyrange.h.
+     *
+     * This value is statically checked by the frontend to ensure that its
+     * bit packing does not conflict; see mem/remoteallocator.h
+     */
+    static constexpr address_t REMOTE_BACKEND_MARKER = 1 << 7;
+
     constexpr MetaEntry() = default;
 
     /**

--- a/src/backend/metatypes.h
+++ b/src/backend/metatypes.h
@@ -1,0 +1,196 @@
+#pragma once
+#include "../ds/concept.h"
+#include "../mem/allocconfig.h" /* TODO: CACHELINE_SIZE */
+#include "../pal/pal_concept.h"
+
+namespace snmalloc
+{
+  /**
+   * A guaranteed type-stable sub-structure of all metadata referenced by the
+   * Pagemap.  Use-specific structures (Metaslab, ChunkRecord) are expected to
+   * have this at offset zero so that, even in the face of concurrent mutation
+   * and reuse of the memory backing that metadata, the types of these fields
+   * remain fixed.
+   *
+   * This class's data is fully private but is friends with the relevant backend
+   * types and, thus, is "opaque" to the frontend.
+   */
+  class MetaCommon
+  {
+    friend class ChunkAllocator;
+
+    template<SNMALLOC_CONCEPT(ConceptPAL) PAL, bool, typename>
+    friend class BackendAllocator;
+
+    capptr::Chunk<void> chunk;
+
+  public:
+    /**
+     * Expose the address of, though not the authority to, our corresponding
+     * chunk.
+     */
+    [[nodiscard]] SNMALLOC_FAST_PATH address_t chunk_address()
+    {
+      return address_cast(this->chunk);
+    }
+
+    /**
+     * Zero (possibly by unmapping) the memory backing this chunk.  We must rely
+     * on the caller to tell us its size, which is a little unfortunate.
+     */
+    template<SNMALLOC_CONCEPT(ConceptPAL) PAL>
+    SNMALLOC_FAST_PATH void zero_chunk(size_t chunk_size)
+    {
+      PAL::zero(this->chunk.unsafe_ptr(), chunk_size);
+    }
+  };
+
+  static const size_t PAGEMAP_METADATA_STRUCT_SIZE =
+#ifdef __CHERI_PURE_CAPABILITY__
+    2 * CACHELINE_SIZE
+#else
+    CACHELINE_SIZE
+#endif
+    ;
+
+  // clang-format off
+  /* This triggers an ICE (C1001) in MSVC, so disable it there */
+#if defined(__cpp_concepts) && !defined(_MSC_VER)
+
+  template<typename Meta>
+  concept ConceptMetadataStruct =
+    // Metadata structures must be standard layout (for offsetof()),
+    std::is_standard_layout_v<Meta> &&
+    // must be of a sufficiently small size,
+    sizeof(Meta) <= PAGEMAP_METADATA_STRUCT_SIZE &&
+    // and must be pointer-interconvertable with MetaCommon.
+    (
+      ConceptSame<Meta, MetaCommon> ||
+      requires(Meta m) {
+        // Otherwise, meta must have MetaCommon field named meta_common ...
+        { &m.meta_common } -> ConceptSame<MetaCommon*>;
+        // at offset zero.
+        (offsetof(Meta, meta_common) == 0);
+      }
+    );
+
+  static_assert(ConceptMetadataStruct<MetaCommon>);
+#  define USE_METADATA_CONCEPT
+#endif
+  // clang-format on
+
+  struct RemoteAllocator;
+  class Metaslab;
+  class sizeclass_t;
+
+  /**
+   * Entry stored in the pagemap.
+   */
+  class MetaEntry
+  {
+    template<typename Pagemap>
+    friend class BuddyChunkRep;
+
+    /**
+     * The pointer to the metaslab, the bottom bit is used to indicate if this
+     * is the first chunk in a PAL allocation, that cannot be combined with
+     * the preceeding chunk.
+     */
+    uintptr_t meta{0};
+
+    /**
+     * Bit used to indicate this should not be considered part of the previous
+     * PAL allocation.
+     *
+     * Some platforms cannot treat different PalAllocs as a single allocation.
+     * This is true on CHERI as the combined permission might not be
+     * representable.  It is also true on Windows as you cannot Commit across
+     * multiple continuous VirtualAllocs.
+     */
+    static constexpr address_t BOUNDARY_BIT = 1;
+
+    /**
+     * A bit-packed pointer to the owning allocator (if any), and the sizeclass
+     * of this chunk.  The sizeclass here is itself a union between two cases:
+     *
+     *  * log_2(size), at least MIN_CHUNK_BITS, for large allocations.
+     *
+     *  * a value in [0, NUM_SMALL_SIZECLASSES] for small allocations.  These
+     *    may be directly passed to the sizeclass (not slab_sizeclass) functions
+     *    of sizeclasstable.h
+     *
+     */
+    uintptr_t remote_and_sizeclass{0};
+
+  public:
+    constexpr MetaEntry() = default;
+
+    /**
+     * Constructor, provides the remote and sizeclass embedded in a single
+     * pointer-sized word.  This format is not guaranteed to be stable and so
+     * the second argument of this must always be the return value from
+     * `get_remote_and_sizeclass`.
+     */
+    SNMALLOC_FAST_PATH
+    MetaEntry(Metaslab* meta, uintptr_t remote_and_sizeclass)
+    : meta(unsafe_to_uintptr<Metaslab>(meta)),
+      remote_and_sizeclass(remote_and_sizeclass)
+    {}
+
+    /* See mem/metaslab.h */
+    SNMALLOC_FAST_PATH
+    MetaEntry(Metaslab* meta, RemoteAllocator* remote, sizeclass_t sizeclass);
+
+    /**
+     * Return the Metaslab metadata associated with this chunk, guarded by an
+     * assert that this chunk is being used as a slab (i.e., has an associated
+     * owning allocator).
+     */
+    [[nodiscard]] SNMALLOC_FAST_PATH Metaslab* get_metaslab() const
+    {
+      SNMALLOC_ASSERT(get_remote() != nullptr);
+      return unsafe_from_uintptr<Metaslab>(meta & ~BOUNDARY_BIT);
+    }
+
+    /**
+     * Return the remote and sizeclass in an implementation-defined encoding.
+     * This is not guaranteed to be stable across snmalloc releases and so the
+     * only safe use for this is to pass it to the two-argument constructor of
+     * this class.
+     */
+    [[nodiscard]] SNMALLOC_FAST_PATH uintptr_t get_remote_and_sizeclass() const
+    {
+      return remote_and_sizeclass;
+    }
+
+    /* See mem/metaslab.h */
+    [[nodiscard]] SNMALLOC_FAST_PATH RemoteAllocator* get_remote() const;
+    [[nodiscard]] SNMALLOC_FAST_PATH sizeclass_t get_sizeclass() const;
+
+    MetaEntry(const MetaEntry&) = delete;
+
+    MetaEntry& operator=(const MetaEntry& other)
+    {
+      // Don't overwrite the boundary bit with the other's
+      meta = (other.meta & ~BOUNDARY_BIT) | address_cast(meta & BOUNDARY_BIT);
+      remote_and_sizeclass = other.remote_and_sizeclass;
+      return *this;
+    }
+
+    void set_boundary()
+    {
+      meta |= BOUNDARY_BIT;
+    }
+
+    [[nodiscard]] bool is_boundary() const
+    {
+      return meta & BOUNDARY_BIT;
+    }
+
+    bool clear_boundary_bit()
+    {
+      return meta &= ~BOUNDARY_BIT;
+    }
+  };
+
+} // namespace snmalloc

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -403,7 +403,8 @@ namespace snmalloc
      * by this thread, or handling the final deallocation onto a slab,
      * so it can be reused by other threads.
      */
-    SNMALLOC_SLOW_PATH void dealloc_local_object_slow(const MetaEntry& entry)
+    SNMALLOC_SLOW_PATH void
+    dealloc_local_object_slow(const MetaslabMetaEntry& entry)
     {
       // TODO: Handle message queue on this path?
 
@@ -486,19 +487,20 @@ namespace snmalloc
         [local_state](freelist::QueuePtr p) SNMALLOC_FAST_PATH_LAMBDA {
           return capptr_domesticate<SharedStateHandle>(local_state, p);
         };
-      auto cb = [this, &need_post](freelist::HeadPtr msg)
-                  SNMALLOC_FAST_PATH_LAMBDA {
+      auto cb = [this,
+                 &need_post](freelist::HeadPtr msg) SNMALLOC_FAST_PATH_LAMBDA {
 #ifdef SNMALLOC_TRACING
-                    std::cout << "Handling remote" << std::endl;
+        std::cout << "Handling remote" << std::endl;
 #endif
 
-                    auto& entry = SharedStateHandle::Pagemap::get_metaentry(
-                      snmalloc::address_cast(msg));
+        auto& entry =
+          SharedStateHandle::Pagemap::template get_metaentry<MetaslabMetaEntry>(
+            snmalloc::address_cast(msg));
 
-                    handle_dealloc_remote(entry, msg.as_void(), need_post);
+        handle_dealloc_remote(entry, msg.as_void(), need_post);
 
-                    return true;
-                  };
+        return true;
+      };
 
       if constexpr (SharedStateHandle::Options.QueueHeadsAreTame)
       {
@@ -532,7 +534,7 @@ namespace snmalloc
      * need_post will be set to true, if capacity is exceeded.
      */
     void handle_dealloc_remote(
-      const MetaEntry& entry,
+      const MetaslabMetaEntry& entry,
       CapPtr<void, capptr::bounds::Alloc> p,
       bool& need_post)
     {
@@ -672,8 +674,10 @@ namespace snmalloc
     SNMALLOC_FAST_PATH void
     dealloc_local_object(CapPtr<void, capptr::bounds::Alloc> p)
     {
-      const MetaEntry& entry =
-        SharedStateHandle::Pagemap::get_metaentry(snmalloc::address_cast(p));
+      // MetaEntry-s seen here are expected to have meaningful Remote pointers
+      auto& entry =
+        SharedStateHandle::Pagemap::template get_metaentry<MetaslabMetaEntry>(
+          snmalloc::address_cast(p));
       if (SNMALLOC_LIKELY(dealloc_local_object_fast(entry, p, entropy)))
         return;
 
@@ -681,7 +685,7 @@ namespace snmalloc
     }
 
     SNMALLOC_FAST_PATH static bool dealloc_local_object_fast(
-      const MetaEntry& entry,
+      const MetaslabMetaEntry& entry,
       CapPtr<void, capptr::bounds::Alloc> p,
       LocalEntropy& entropy)
     {
@@ -786,8 +790,8 @@ namespace snmalloc
       auto [slab, meta] = SharedStateHandle::alloc_chunk(
         get_backend_local_state(),
         slab_size,
-        public_state(),
-        sizeclass_t::from_small_class(sizeclass));
+        MetaslabMetaEntry::encode(
+          public_state(), sizeclass_t::from_small_class(sizeclass)));
 
       if (slab == nullptr)
       {
@@ -840,8 +844,9 @@ namespace snmalloc
         {
           bool need_post = true; // Always going to post, so ignore.
           auto n_tame = p_tame->atomic_read_next(key_global, domesticate);
-          auto& entry = SharedStateHandle::Pagemap::get_metaentry(
-            snmalloc::address_cast(p_tame));
+          const MetaslabMetaEntry& entry =
+            SharedStateHandle::Pagemap::template get_metaentry<
+              MetaslabMetaEntry>(snmalloc::address_cast(p_tame));
           handle_dealloc_remote(entry, p_tame.as_void(), need_post);
           p_tame = n_tame;
         }

--- a/src/mem/corealloc.h
+++ b/src/mem/corealloc.h
@@ -332,7 +332,7 @@ namespace snmalloc
 
       SNMALLOC_ASSERT(
         address_cast(start_of_slab) ==
-        address_cast(chunk_record->meta_common.chunk));
+        chunk_record->meta_common.chunk_address());
 
 #if defined(__CHERI_PURE_CAPABILITY__) && !defined(SNMALLOC_CHECK_CLIENT)
       // Zero the whole slab. For CHERI we at least need to clear the freelist
@@ -340,9 +340,9 @@ namespace snmalloc
       // the freelist order as for SNMALLOC_CHECK_CLIENT. Zeroing the whole slab
       // may be more friendly to hw because it does not involve pointer chasing
       // and is amenable to prefetching.
-      SharedStateHandle::Pal::zero(
-        chunk_record->meta_common.chunk.unsafe_ptr(),
-        snmalloc::sizeclass_to_slab_size(sizeclass));
+      chunk_record->meta_common
+        .template zero_chunk<typename SharedStateHandle::Pal>(
+          snmalloc::sizeclass_to_slab_size(sizeclass));
 #endif
 
 #ifdef SNMALLOC_TRACING

--- a/src/mem/remoteallocator.h
+++ b/src/mem/remoteallocator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../backend/metatypes.h"
 #include "../mem/allocconfig.h"
 #include "../mem/freelist.h"
 #include "../mem/sizeclasstable.h"
@@ -15,14 +16,12 @@ namespace snmalloc
   static constexpr size_t REMOTE_MIN_ALIGN =
     bits::max<size_t>(CACHELINE_SIZE, SIZECLASS_REP_SIZE) << 1;
 
-  // This bit is set on the RemoteAllocator* to indicate it is
-  // actually being used by the backend for some other use.
-  static constexpr size_t BACKEND_MARKER = REMOTE_MIN_ALIGN >> 1;
-
   // The bit above the sizeclass is always zero unless this is used
   // by the backend to represent another datastructure such as the buddy
   // allocator entries.
-  constexpr size_t REMOTE_WITH_BACKEND_MARKER_ALIGN = BACKEND_MARKER;
+  constexpr size_t REMOTE_WITH_BACKEND_MARKER_ALIGN =
+    MetaEntry::REMOTE_BACKEND_MARKER;
+  static_assert((REMOTE_MIN_ALIGN >> 1) == MetaEntry::REMOTE_BACKEND_MARKER);
 
   /**
    * Global key for all remote lists.

--- a/src/mem/remotecache.h
+++ b/src/mem/remotecache.h
@@ -52,7 +52,7 @@ namespace snmalloc
      *
      * This does not require initialisation to be safely called.
      */
-    SNMALLOC_FAST_PATH bool reserve_space(const MetaEntry& entry)
+    SNMALLOC_FAST_PATH bool reserve_space(const MetaslabMetaEntry& entry)
     {
       auto size =
         static_cast<int64_t>(sizeclass_full_to_size(entry.get_sizeclass()));
@@ -101,8 +101,9 @@ namespace snmalloc
           if (!list[i].empty())
           {
             auto [first, last] = list[i].extract_segment(key);
-            const MetaEntry& entry =
-              SharedStateHandle::Pagemap::get_metaentry(address_cast(first));
+            const MetaslabMetaEntry& entry =
+              SharedStateHandle::Pagemap::template get_metaentry<
+                MetaslabMetaEntry>(address_cast(first));
             auto remote = entry.get_remote();
             // If the allocator is not correctly aligned, then the bit that is
             // set implies this is used by the backend, and we should not be
@@ -141,8 +142,9 @@ namespace snmalloc
           // Use the next N bits to spread out remote deallocs in our own
           // slot.
           auto r = resend.take(key, domesticate);
-          const MetaEntry& entry =
-            SharedStateHandle::Pagemap::get_metaentry(address_cast(r));
+          const MetaslabMetaEntry& entry =
+            SharedStateHandle::Pagemap::template get_metaentry<
+              MetaslabMetaEntry>(address_cast(r));
           auto i = entry.get_remote()->trunc_id();
           size_t slot = get_slot<allocator_size>(i, post_round);
           list[slot].add(r, key);

--- a/src/mem/remotecache.h
+++ b/src/mem/remotecache.h
@@ -108,7 +108,7 @@ namespace snmalloc
             // set implies this is used by the backend, and we should not be
             // deallocating memory here.
             snmalloc_check_client(
-              (address_cast(remote) & BACKEND_MARKER) == 0,
+              (address_cast(remote) & MetaEntry::REMOTE_BACKEND_MARKER) == 0,
               "Delayed detection of attempt to free internal structure.");
             if constexpr (SharedStateHandle::Options.QueueHeadsAreTame)
             {

--- a/src/mem/sizeclasstable.h
+++ b/src/mem/sizeclasstable.h
@@ -357,6 +357,8 @@ namespace snmalloc
     }
     else
     {
+      if (size == 0)
+        return 0;
       return slab_start + (offset / size) * size;
     }
   }

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -344,6 +344,7 @@ void test_external_pointer_large()
 
 void test_external_pointer_dealloc_bug()
 {
+  std::cout << "Testing external pointer dealloc bug" << std::endl;
   auto& alloc = ThreadAlloc::get();
   constexpr size_t count = MIN_CHUNK_SIZE;
   void* allocs[count];
@@ -364,6 +365,29 @@ void test_external_pointer_dealloc_bug()
   }
 
   alloc.dealloc(allocs[0]);
+  std::cout << "Testing external pointer dealloc bug - done" << std::endl;
+}
+
+void test_external_pointer_stack()
+{
+  std::cout << "Testing external pointer stack" << std::endl;
+
+  std::array<int, 2000> stack;
+
+  auto& alloc = ThreadAlloc::get();
+
+  for (size_t i = 0; i < stack.size(); i++)
+  {
+    if (alloc.external_pointer(&stack[i]) > &stack[i])
+    {
+      std::cout << "Stack pointer: " << &stack[i]
+                << " external pointer: " << alloc.external_pointer(&stack[i])
+                << std::endl;
+      abort();
+    }
+  }
+
+  std::cout << "Testing external pointer stack - done" << std::endl;
 }
 
 void test_alloc_16M()
@@ -500,6 +524,7 @@ int main(int argc, char** argv)
   test_remaining_bytes();
   test_static_sized_allocs();
   test_calloc_large_bug();
+  test_external_pointer_stack();
   test_external_pointer_dealloc_bug();
   test_external_pointer_large();
   test_external_pointer();


### PR DESCRIPTION
This is starting to sprawl a bit, but it's all sort of thematically related towards the end goal of removing includes of src/mem from src/backend.

By and large NFCI, except for "clobber MetaEntry-s in dealloc_chunk", which more aggressively zeros out `MetaEntry::meta` pointers and came up while writing docs.