### PR TITLE
Use the custom memcpy for realloc.

### DIFF
--- a/src/mem/bounds_checks.h
+++ b/src/mem/bounds_checks.h
@@ -107,4 +107,4 @@ namespace snmalloc
     }
   }
 
-}
+} // namespace snmalloc

--- a/src/mem/memcpy.h
+++ b/src/mem/memcpy.h
@@ -328,4 +328,4 @@ namespace snmalloc
     Arch::copy(dst, src, len);
     return orig_dst;
   }
-} // namespace
+} // namespace snmalloc

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -34,7 +34,7 @@ namespace
        (MIN_ALLOC_SIZE - 1)) == 0);
     snmalloc::memcpy<DEBUG, false>(dst, src, size);
   }
-}
+} // namespace
 
 extern "C"
 {

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -118,7 +118,7 @@ extern "C"
       // Guard memcpy as GCC is assuming not nullptr for ptr after the memcpy
       // otherwise.
       if (sz != 0)
-        memcpy_for_realloc(p, ptr, bits::max(MIN_ALLOC_SIZE, sz));
+        memcpy_for_realloc(p, ptr, bits::align_up(sz, MIN_ALLOC_SIZE));
       a.dealloc(ptr);
     }
     else if (SNMALLOC_LIKELY(size == 0))
@@ -178,7 +178,7 @@ extern "C"
     // Guard memcpy as GCC is assuming not nullptr for ptr after the memcpy
     // otherwise.
     if (sz != 0)
-      memcpy_for_realloc(p, *ptr, bits::max(MIN_ALLOC_SIZE, sz));
+      memcpy_for_realloc(p, *ptr, bits::align_up(sz, MIN_ALLOC_SIZE));
     errno = err;
     a.dealloc(*ptr);
     *ptr = p;

--- a/src/override/malloc.cc
+++ b/src/override/malloc.cc
@@ -17,7 +17,7 @@ namespace
    * Specialised memcpy that knows that it is copying at least the minimum
    * object size and that the start and end are strongly aligned.
    */
-  SNMALLOC_FAST_PATH
+  SNMALLOC_FAST_PATH_INLINE
   void memcpy_for_realloc(void* dst, const void* src, size_t size)
   {
     // Tell the compiler some things that it can use to optimise the memcpy:
@@ -118,7 +118,7 @@ extern "C"
       // Guard memcpy as GCC is assuming not nullptr for ptr after the memcpy
       // otherwise.
       if (sz != 0)
-        memcpy_for_realloc(p, ptr, sz);
+        memcpy_for_realloc(p, ptr, bits::max(MIN_ALLOC_SIZE, sz));
       a.dealloc(ptr);
     }
     else if (SNMALLOC_LIKELY(size == 0))
@@ -178,7 +178,7 @@ extern "C"
     // Guard memcpy as GCC is assuming not nullptr for ptr after the memcpy
     // otherwise.
     if (sz != 0)
-      memcpy_for_realloc(p, *ptr, sz);
+      memcpy_for_realloc(p, *ptr, bits::max(MIN_ALLOC_SIZE, sz));
     errno = err;
     a.dealloc(*ptr);
     *ptr = p;

--- a/src/snmalloc.h
+++ b/src/snmalloc.h
@@ -15,7 +15,7 @@
 namespace snmalloc
 {
   using Alloc = snmalloc::LocalAllocator<snmalloc::Globals>;
-}
+} // namespace snmalloc
 
 // User facing API surface, needs to know what `Alloc` is.
 #  include "snmalloc_front.h"


### PR DESCRIPTION
This wraps our memcpy with some assumptions that let the optimiser know
that we're copying chunks that are strongly aligned.  With clang 13 on
x86, this generates three variants:

 - A special case for 16 bytes that's a single vector load + store.
 - A vector-copy loop for sizes <512 bytes.
 - rep movsb for larger sizes.

This is almost certainly faster than the platform memcpy (if for no
other reason than that it doesn't have to care about handling unaligned
copies).

I don't know if it will show up in benchmarks, but if it does then it
Fixes #154