### PR TITLE
unsafe_{to,from}_uintptr<T> and a quick audit of casts

### DIFF
--- a/src/backend/largebuddyrange.h
+++ b/src/backend/largebuddyrange.h
@@ -43,9 +43,9 @@ namespace snmalloc
       MetaEntry& entry =
         Pagemap::template get_metaentry_mut<false>(address_cast(k));
       if (direction)
-        return *reinterpret_cast<Holder*>(&entry.meta);
+        return entry.meta;
 
-      return *reinterpret_cast<Holder*>(&entry.remote_and_sizeclass);
+      return entry.remote_and_sizeclass;
     }
 
     static bool is_red(Contents k)

--- a/src/backend/pagemap.h
+++ b/src/backend/pagemap.h
@@ -130,7 +130,7 @@ namespace snmalloc
 
       // Put pagemap at start of range.
       // TODO CHERI capability bound here!
-      body = reinterpret_cast<T*>(b);
+      body = static_cast<T*>(b);
       body_opt = body;
       // Advance by size of pagemap.
       // Note that base needs to be aligned to GRANULARITY for the rest of the
@@ -176,8 +176,7 @@ namespace snmalloc
       // Begin pagemap at random offset within the additionally allocated space.
       static_assert(bits::is_pow2(sizeof(T)), "Next line assumes this.");
       size_t offset = get_entropy64<PAL>() & (additional_size - sizeof(T));
-      auto new_body =
-        reinterpret_cast<T*>(pointer_offset(new_body_untyped, offset));
+      auto new_body = pointer_offset<T>(new_body_untyped, offset);
 
       if constexpr (pal_supports<LazyCommit, PAL>)
       {
@@ -191,7 +190,7 @@ namespace snmalloc
           start_page, pointer_diff(start_page, end_page));
       }
 #else
-      auto new_body = reinterpret_cast<T*>(new_body_untyped);
+      auto new_body = static_cast<T*>(new_body_untyped);
 #endif
       // Ensure bottom page is committed
       // ASSUME: new memory is zeroed.

--- a/src/ds/address.h
+++ b/src/ds/address.h
@@ -28,8 +28,8 @@ namespace snmalloc
   inline U* pointer_offset(T* base, size_t diff)
   {
     SNMALLOC_ASSERT(base != nullptr); /* Avoid UB */
-    return reinterpret_cast<U*>(
-      reinterpret_cast<uintptr_t>(base) + static_cast<uintptr_t>(diff));
+    return unsafe_from_uintptr<U>(
+      unsafe_to_uintptr<T>(base) + static_cast<uintptr_t>(diff));
   }
 
   template<SNMALLOC_CONCEPT(capptr::ConceptBound) bounds, typename T>
@@ -129,8 +129,8 @@ namespace snmalloc
   template<size_t alignment, typename T = void>
   inline T* pointer_align_down(void* p)
   {
-    return reinterpret_cast<T*>(
-      pointer_align_down<alignment>(reinterpret_cast<uintptr_t>(p)));
+    return unsafe_from_uintptr<T>(
+      pointer_align_down<alignment>(unsafe_to_uintptr<void>(p)));
   }
 
   template<
@@ -164,8 +164,8 @@ namespace snmalloc
 #if __has_builtin(__builtin_align_up)
       return static_cast<T*>(__builtin_align_up(p, alignment));
 #else
-      return reinterpret_cast<T*>(
-        bits::align_up(reinterpret_cast<uintptr_t>(p), alignment));
+      return unsafe_from_uintptr<T>(
+        bits::align_up(unsafe_to_uintptr<void>(p), alignment));
 #endif
     }
   }
@@ -197,8 +197,8 @@ namespace snmalloc
 #if __has_builtin(__builtin_align_down)
     return static_cast<T*>(__builtin_align_down(p, alignment));
 #else
-    return reinterpret_cast<T*>(
-      bits::align_down(reinterpret_cast<uintptr_t>(p), alignment));
+    return unsafe_from_uintptr<T>(
+      bits::align_down(unsafe_to_uintptr<void>(p), alignment));
 #endif
   }
 
@@ -221,8 +221,8 @@ namespace snmalloc
 #if __has_builtin(__builtin_align_up)
     return static_cast<T*>(__builtin_align_up(p, alignment));
 #else
-    return reinterpret_cast<T*>(
-      bits::align_up(reinterpret_cast<uintptr_t>(p), alignment));
+    return unsafe_from_uintptr<T>(
+      bits::align_up(unsafe_to_uintptr<void>(p), alignment));
 #endif
   }
 

--- a/src/ds/ptrwrap.h
+++ b/src/ds/ptrwrap.h
@@ -7,6 +7,30 @@
 
 namespace snmalloc
 {
+  /*
+   * reinterpret_cast<> is a powerful primitive that, excitingly, does not
+   * require the programmer to annotate the expected *source* type.  We
+   * therefore wrap its use to interconvert between uintptr_t and pointer types.
+   */
+
+  /**
+   * Convert a pointer to a uintptr_t.  Template argument inference is
+   * prohibited.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH_INLINE uintptr_t
+  unsafe_to_uintptr(std::enable_if_t<true, T>* p)
+  {
+    return reinterpret_cast<uintptr_t>(p);
+  }
+
+  /** Convert a uintptr_t to a T*. */
+  template<typename T>
+  SNMALLOC_FAST_PATH_INLINE T* unsafe_from_uintptr(uintptr_t p)
+  {
+    return reinterpret_cast<T*>(p);
+  }
+
   /**
    * To assist in providing a uniform interface regardless of pointer wrapper,
    * we also export intrinsic pointer and atomic pointer aliases, as the postfix
@@ -321,7 +345,7 @@ namespace snmalloc
 
     [[nodiscard]] SNMALLOC_FAST_PATH uintptr_t unsafe_uintptr() const
     {
-      return reinterpret_cast<uintptr_t>(this->unsafe_capptr);
+      return unsafe_to_uintptr<T>(this->unsafe_capptr);
     }
   };
 

--- a/src/mem/freelist.h
+++ b/src/mem/freelist.h
@@ -239,8 +239,8 @@ namespace snmalloc
 
         if constexpr (CHECK_CLIENT && !aal_supports<StrictProvenance>)
         {
-          return reinterpret_cast<Object::T<BQueue>*>(
-            reinterpret_cast<uintptr_t>(next) ^ key.key_next);
+          return unsafe_from_uintptr<Object::T<BQueue>>(
+            unsafe_to_uintptr<Object::T<BQueue>>(next) ^ key.key_next);
         }
         else
         {

--- a/src/mem/metaslab.h
+++ b/src/mem/metaslab.h
@@ -272,7 +272,7 @@ namespace snmalloc
      */
     SNMALLOC_FAST_PATH
     MetaEntry(Metaslab* meta, uintptr_t remote_and_sizeclass)
-    : meta(reinterpret_cast<uintptr_t>(meta)),
+    : meta(unsafe_to_uintptr<Metaslab>(meta)),
       remote_and_sizeclass(remote_and_sizeclass)
     {}
 
@@ -281,11 +281,11 @@ namespace snmalloc
       Metaslab* meta,
       RemoteAllocator* remote,
       sizeclass_t sizeclass = sizeclass_t())
-    : meta(reinterpret_cast<uintptr_t>(meta))
+    : meta(unsafe_to_uintptr<Metaslab>(meta))
     {
       /* remote might be nullptr; cast to uintptr_t before offsetting */
-      remote_and_sizeclass =
-        pointer_offset(reinterpret_cast<uintptr_t>(remote), sizeclass.raw());
+      remote_and_sizeclass = pointer_offset(
+        unsafe_to_uintptr<RemoteAllocator>(remote), sizeclass.raw());
     }
 
     /**
@@ -296,7 +296,7 @@ namespace snmalloc
     [[nodiscard]] SNMALLOC_FAST_PATH Metaslab* get_metaslab() const
     {
       SNMALLOC_ASSERT(get_remote() != nullptr);
-      return reinterpret_cast<Metaslab*>(meta & ~BOUNDARY_BIT);
+      return unsafe_from_uintptr<Metaslab>(meta & ~BOUNDARY_BIT);
     }
 
     /**
@@ -312,7 +312,7 @@ namespace snmalloc
 
     [[nodiscard]] SNMALLOC_FAST_PATH RemoteAllocator* get_remote() const
     {
-      return reinterpret_cast<RemoteAllocator*>(
+      return unsafe_from_uintptr<RemoteAllocator>(
         pointer_align_down<REMOTE_WITH_BACKEND_MARKER_ALIGN>(
           remote_and_sizeclass));
     }

--- a/src/test/func/external_pagemap/external_pagemap.cc
+++ b/src/test/func/external_pagemap/external_pagemap.cc
@@ -20,7 +20,7 @@ int main()
   auto& global = GlobalChunkmap::pagemap();
   SNMALLOC_CHECK(&p == &global);
   // Get a valid heap address
-  uintptr_t addr = reinterpret_cast<uintptr_t>(malloc(42));
+  uintptr_t addr = unsafe_to_uintptr<void>(malloc(42));
   // Make this very strongly aligned
   addr &= ~0xfffffULL;
   void* page = p.page_for_address(addr);

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
   //
   // Note: We cannot use the check or assert macros here because they depend on
   // `MessageBuilder` working.  They are safe to use in any other test.
-  void* fakeptr = reinterpret_cast<void*>(static_cast<uintptr_t>(0x42));
+  void* fakeptr = unsafe_from_uintptr<void>(static_cast<uintptr_t>(0x42));
   MessageBuilder<1024> b{
     "testing pointer {} size_t {} message, {} world, null is {}, -123456 is "
     "{}, 1234567 is {}",

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -88,16 +88,12 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
       expected_size);
     failed = true;
   }
-  if (
-    (static_cast<size_t>(reinterpret_cast<uintptr_t>(p) % align) != 0) &&
-    (size != 0))
+  if (((address_cast(p) % align) != 0) && (size != 0))
   {
     INFO("Address is {}, but required to be aligned to {}.\n", p, align);
     failed = true;
   }
-  if (
-    static_cast<size_t>(
-      reinterpret_cast<uintptr_t>(p) % natural_alignment(size)) != 0)
+  if ((address_cast(p) % natural_alignment(size)) != 0)
   {
     INFO(
       "Address is {}, but should have natural alignment to {}.\n",

--- a/src/test/func/memcpy/func-memcpy.cc
+++ b/src/test/func/memcpy/func-memcpy.cc
@@ -69,8 +69,8 @@ extern "C" void abort()
 void check_size(size_t size)
 {
   START_TEST("checking {}-byte memcpy", size);
-  auto* s = reinterpret_cast<unsigned char*>(my_malloc(size + 1));
-  auto* d = reinterpret_cast<unsigned char*>(my_malloc(size + 1));
+  auto* s = static_cast<unsigned char*>(my_malloc(size + 1));
+  auto* d = static_cast<unsigned char*>(my_malloc(size + 1));
   d[size] = 0;
   s[size] = 255;
   for (size_t start = 0; start < size; start++)
@@ -115,8 +115,8 @@ void check_bounds(size_t size, size_t out_of_bounds)
 {
   START_TEST(
     "memcpy bounds, size {}, {} bytes out of bounds", size, out_of_bounds);
-  auto* s = reinterpret_cast<unsigned char*>(my_malloc(size));
-  auto* d = reinterpret_cast<unsigned char*>(my_malloc(size));
+  auto* s = static_cast<unsigned char*>(my_malloc(size));
+  auto* d = static_cast<unsigned char*>(my_malloc(size));
   for (size_t i = 0; i < size; ++i)
   {
     s[i] = static_cast<unsigned char>(i);

--- a/src/test/perf/memcpy/memcpy.cc
+++ b/src/test/perf/memcpy/memcpy.cc
@@ -30,7 +30,7 @@ void shape(size_t size)
     // size / alignment) * alignment;
     Shape s;
     s.object = ThreadAlloc::get().alloc(rsize);
-    s.dst = reinterpret_cast<unsigned char*>(s.object) + offset;
+    s.dst = static_cast<unsigned char*>(s.object) + offset;
     // Bring into cache the destination of the copy.
     memset(s.dst, 0xFF, size);
     allocs.push_back(s);
@@ -51,7 +51,7 @@ void test_memcpy(size_t size, void* src, Memcpy mc)
 {
   for (auto& s : allocs)
   {
-    auto* dst = reinterpret_cast<unsigned char*>(s.dst);
+    auto* dst = static_cast<unsigned char*>(s.dst);
     mc(dst, src, size);
   }
 }


### PR DESCRIPTION
After utter silence from the compiler as part of #477 spooked both @mjp41 and me (everything was fine, but it really should have been a warning), here's something that tries to induce the compiler to speak up a little more should similar things happen again.