### PR TITLE
RFC Backend *Range plumbing

### DIFF
--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../mem/allocconfig.h"
 #include "../pal/pal.h"
+#include "backend_concept.h"
 #include "chunkallocator.h"
 #include "commitrange.h"
 #include "commonconfig.h"

--- a/src/backend/backend_concept.h
+++ b/src/backend/backend_concept.h
@@ -82,19 +82,20 @@ namespace snmalloc
    */
   template<typename Range>
   concept ConceptBackendRange_Alloc =
-    requires(Range r, size_t sz)
+    requires(Range r, typename Range::KArg k, size_t sz)
     {
-       { r.alloc_range(sz) } -> ConceptSame<CapPtr<void, typename Range::B>>;
+       { r.alloc_range(k, sz) } -> ConceptSame<CapPtr<void, typename Range::B>>;
     };
 
   template<typename Range>
   concept ConceptBackendRange_Dealloc =
     requires(
       Range r,
+      typename Range::KArg k,
       CapPtr<void, typename Range::B> p,
       size_t sz)
     {
-       { r.dealloc_range(p, sz) } -> ConceptSame<void>;
+       { r.dealloc_range(k, p, sz) } -> ConceptSame<void>;
     };
 
   template<typename Range>

--- a/src/backend/backend_concept.h
+++ b/src/backend/backend_concept.h
@@ -76,6 +76,29 @@ namespace snmalloc
         -> ConceptSame<capptr::Alloc<char>>;
     };
 
+  /**
+   * Backend allocators are formed of Range sources, which must know how to
+   * allocate and may know how to deallocate ranges.
+   */
+  template<typename Range>
+  concept ConceptBackendRange_Alloc =
+    requires(Range r, size_t sz)
+    {
+       { r.alloc_range(sz) } -> ConceptSame<capptr::Chunk<void>>;
+    };
+
+  template<typename Range>
+  concept ConceptBackendRange_Dealloc =
+    requires(Range r, capptr::Chunk<void> p, size_t sz)
+    {
+       { r.dealloc_range(p, sz) } -> ConceptSame<void>;
+    };
+
+  template<typename Range>
+  concept ConceptBackendRange =
+    ConceptBackendRange_Alloc<Range> &&
+    ConceptBackendRange_Dealloc<Range>;
+
   class CommonConfig;
   struct Flags;
 

--- a/src/backend/backend_concept.h
+++ b/src/backend/backend_concept.h
@@ -84,12 +84,15 @@ namespace snmalloc
   concept ConceptBackendRange_Alloc =
     requires(Range r, size_t sz)
     {
-       { r.alloc_range(sz) } -> ConceptSame<capptr::Chunk<void>>;
+       { r.alloc_range(sz) } -> ConceptSame<CapPtr<void, typename Range::B>>;
     };
 
   template<typename Range>
   concept ConceptBackendRange_Dealloc =
-    requires(Range r, capptr::Chunk<void> p, size_t sz)
+    requires(
+      Range r,
+      CapPtr<void, typename Range::B> p,
+      size_t sz)
     {
        { r.dealloc_range(p, sz) } -> ConceptSame<void>;
     };

--- a/src/backend/commitrange.h
+++ b/src/backend/commitrange.h
@@ -25,11 +25,13 @@ namespace snmalloc
       }
     };
 
+    using B = typename ParentRange::B;
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr CommitRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(size_t size)
     {
       auto range = parent->alloc_range(size);
       if (range != nullptr)
@@ -38,7 +40,7 @@ namespace snmalloc
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(capptr::Chunk<void> base, size_t size)
+    void dealloc_range(CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,

--- a/src/backend/commitrange.h
+++ b/src/backend/commitrange.h
@@ -4,7 +4,9 @@
 
 namespace snmalloc
 {
-  template<typename ParentRange, typename PAL>
+  template<
+    SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange,
+    SNMALLOC_CONCEPT(ConceptPAL) PAL>
   class CommitRange
   {
     typename ParentRange::State parent{};
@@ -35,8 +37,12 @@ namespace snmalloc
       return range;
     }
 
+    template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
     void dealloc_range(capptr::Chunk<void> base, size_t size)
     {
+      static_assert(
+        std::is_same<_pr, ParentRange>::value,
+        "Don't set SFINAE template parameter!");
       PAL::notify_not_using(base.unsafe_ptr(), size);
       parent->dealloc_range(base, size);
     }

--- a/src/backend/commitrange.h
+++ b/src/backend/commitrange.h
@@ -26,27 +26,28 @@ namespace snmalloc
     };
 
     using B = typename ParentRange::B;
+    using KArg = typename ParentRange::KArg;
 
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr CommitRange() = default;
 
-    CapPtr<void, B> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(KArg ka, size_t size)
     {
-      auto range = parent->alloc_range(size);
+      auto range = parent->alloc_range(ka, size);
       if (range != nullptr)
         PAL::template notify_using<NoZero>(range.unsafe_ptr(), size);
       return range;
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(CapPtr<void, B> base, size_t size)
+    void dealloc_range(KArg ka, CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,
         "Don't set SFINAE template parameter!");
       PAL::notify_not_using(base.unsafe_ptr(), size);
-      parent->dealloc_range(base, size);
+      parent->dealloc_range(ka, base, size);
     }
   };
 } // namespace snmalloc

--- a/src/backend/empty_range.h
+++ b/src/backend/empty_range.h
@@ -17,11 +17,13 @@ namespace snmalloc
       constexpr State() = default;
     };
 
+    using B = capptr::bounds::Chunk;
+
     static constexpr bool Aligned = true;
 
     constexpr EmptyRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t)
+    CapPtr<void, B> alloc_range(size_t)
     {
       return nullptr;
     }

--- a/src/backend/empty_range.h
+++ b/src/backend/empty_range.h
@@ -18,12 +18,13 @@ namespace snmalloc
     };
 
     using B = capptr::bounds::Chunk;
+    using KArg = std::nullptr_t;
 
     static constexpr bool Aligned = true;
 
     constexpr EmptyRange() = default;
 
-    CapPtr<void, B> alloc_range(size_t)
+    CapPtr<void, B> alloc_range(KArg, size_t)
     {
       return nullptr;
     }

--- a/src/backend/globalrange.h
+++ b/src/backend/globalrange.h
@@ -35,18 +35,20 @@ namespace snmalloc
       constexpr State() = default;
     };
 
+    using B = typename ParentRange::B;
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr GlobalRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(size_t size)
     {
       FlagLock lock(spin_lock);
       return parent->alloc_range(size);
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(capptr::Chunk<void> base, size_t size)
+    void dealloc_range(CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,

--- a/src/backend/globalrange.h
+++ b/src/backend/globalrange.h
@@ -36,25 +36,26 @@ namespace snmalloc
     };
 
     using B = typename ParentRange::B;
+    using KArg = typename ParentRange::KArg;
 
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr GlobalRange() = default;
 
-    CapPtr<void, B> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(KArg ka, size_t size)
     {
       FlagLock lock(spin_lock);
-      return parent->alloc_range(size);
+      return parent->alloc_range(ka, size);
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(CapPtr<void, B> base, size_t size)
+    void dealloc_range(KArg ka, CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,
         "Don't set SFINAE template parameter!");
       FlagLock lock(spin_lock);
-      parent->dealloc_range(base, size);
+      parent->dealloc_range(ka, base, size);
     }
   };
 } // namespace snmalloc

--- a/src/backend/globalrange.h
+++ b/src/backend/globalrange.h
@@ -10,7 +10,7 @@ namespace snmalloc
    * Makes the supplied ParentRange into a global variable,
    * and protects access with a lock.
    */
-  template<typename ParentRange>
+  template<SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange>
   class GlobalRange
   {
     typename ParentRange::State parent{};
@@ -45,8 +45,12 @@ namespace snmalloc
       return parent->alloc_range(size);
     }
 
+    template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
     void dealloc_range(capptr::Chunk<void> base, size_t size)
     {
+      static_assert(
+        std::is_same<_pr, ParentRange>::value,
+        "Don't set SFINAE template parameter!");
       FlagLock lock(spin_lock);
       parent->dealloc_range(base, size);
     }

--- a/src/backend/indirectrange.h
+++ b/src/backend/indirectrange.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "../ds/ptrwrap.h"
+
+namespace snmalloc
+{
+  template<typename T>
+  static T& IndirectRange_default_kparent(T* x)
+  {
+    return *x;
+  }
+
+  template<
+    typename ParentRange,
+    typename KArg_ = typename ParentRange::State*,
+    typename ParentRange::State& (*KParent)(KArg_) =
+      IndirectRange_default_kparent,
+    typename ParentRange::KArg (*KPArg)(KArg_) = [](KArg_) { return nullptr; }>
+  class IndirectRange
+  {
+  public:
+    class State
+    {
+      IndirectRange this_range{};
+
+    public:
+      IndirectRange* operator->()
+      {
+        return &this_range;
+      }
+
+      constexpr State() = default;
+    };
+
+    using KArg = KArg_;
+
+    static constexpr bool Aligned = ParentRange::Aligned;
+
+    constexpr IndirectRange() = default;
+
+    using B = capptr::bounds::Chunk;
+
+    CapPtr<void, B> alloc_range(KArg ka, size_t size)
+    {
+      return KParent(ka)->alloc_range(KPArg(ka), size);
+    }
+
+    // template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
+    void dealloc_range(KArg ka, CapPtr<void, B> base, size_t size)
+    {
+      /*
+            static_assert(
+              std::is_same<_pr, ParentRange>::value,
+              "Don't set SFINAE template parameter!");
+      */
+      KParent(ka)->dealloc_range(KPArg(ka), base, size);
+    }
+  };
+
+  template<typename ParentRange, typename KArg_>
+  class DropArgRange
+  {
+    static_assert(std::is_same_v<std::nullptr_t, typename ParentRange::KArg>);
+
+    typename ParentRange::State parent{};
+
+  public:
+    class State
+    {
+      DropArgRange noarg_range{};
+
+    public:
+      constexpr DropArgRange* operator->()
+      {
+        return &noarg_range;
+      }
+
+      constexpr State() = default;
+    };
+
+    using KArg = KArg_;
+
+    static constexpr bool Aligned = ParentRange::Aligned;
+
+    constexpr DropArgRange() = default;
+
+    using B = capptr::bounds::Chunk;
+
+    CapPtr<void, B> alloc_range(KArg, size_t size)
+    {
+      return parent->alloc_range(nullptr, size);
+    }
+
+    // template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
+    void dealloc_range(KArg, CapPtr<void, B> base, size_t size)
+    {
+      /*
+            static_assert(
+              std::is_same<_pr, ParentRange>::value,
+              "Don't set SFINAE template parameter!");
+      */
+      parent->dealloc_range(nullptr, base, size);
+    }
+  };
+} // namespace snmalloc

--- a/src/backend/largebuddyrange.h
+++ b/src/backend/largebuddyrange.h
@@ -14,7 +14,7 @@ namespace snmalloc
   /**
    * Class for using the pagemap entries for the buddy allocator.
    */
-  template<typename Pagemap>
+  template<SNMALLOC_CONCEPT(ConceptBackendMeta) Pagemap>
   class BuddyChunkRep
   {
   public:
@@ -132,7 +132,7 @@ namespace snmalloc
   };
 
   template<
-    typename ParentRange,
+    SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange,
     size_t REFILL_SIZE_BITS,
     size_t MAX_SIZE_BITS,
     SNMALLOC_CONCEPT(ConceptBackendMeta) Pagemap,
@@ -165,6 +165,11 @@ namespace snmalloc
     {
       if constexpr (MAX_SIZE_BITS != (bits::BITS - 1))
       {
+#ifdef __cpp_concepts
+        static_assert(
+          ConceptBackendRange_Dealloc<ParentRange>,
+          "MAX_SIZE_BITS < address space size requires overflow to parent");
+#endif
         if (overflow != nullptr)
         {
           parent->dealloc_range(overflow, bits::one_at_bit(MAX_SIZE_BITS));

--- a/src/backend/metatypes.h
+++ b/src/backend/metatypes.h
@@ -85,7 +85,7 @@ namespace snmalloc
    */
   class MetaEntry
   {
-    template<typename Pagemap>
+    template<SNMALLOC_CONCEPT(ConceptBackendMeta)>
     friend class BuddyChunkRep;
 
     /**

--- a/src/backend/pagemapregisterrange.h
+++ b/src/backend/pagemapregisterrange.h
@@ -7,7 +7,7 @@ namespace snmalloc
 {
   template<
     SNMALLOC_CONCEPT(ConceptBackendMetaRange) Pagemap,
-    typename ParentRange>
+    SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange>
   class PagemapRegisterRange
   {
     typename ParentRange::State state{};

--- a/src/backend/pagemapregisterrange.h
+++ b/src/backend/pagemapregisterrange.h
@@ -31,11 +31,13 @@ namespace snmalloc
     using B = typename ParentRange::B;
     static_assert(B::spatial >= capptr::dimension::Spatial::Chunk);
 
+    using KArg = typename ParentRange::KArg;
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
-    CapPtr<void, B> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(KArg ka, size_t size)
     {
-      auto base = state->alloc_range(size);
+      auto base = state->alloc_range(ka, size);
 
       if (base != nullptr)
         Pagemap::register_range(address_cast(base), size);

--- a/src/backend/pagemapregisterrange.h
+++ b/src/backend/pagemapregisterrange.h
@@ -28,9 +28,12 @@ namespace snmalloc
 
     constexpr PagemapRegisterRange() = default;
 
+    using B = typename ParentRange::B;
+    static_assert(B::spatial >= capptr::dimension::Spatial::Chunk);
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(size_t size)
     {
       auto base = state->alloc_range(size);
 

--- a/src/backend/palrange.h
+++ b/src/backend/palrange.h
@@ -23,12 +23,13 @@ namespace snmalloc
     };
 
     using B = capptr::bounds::Chunk;
+    using KArg = std::nullptr_t;
 
     static constexpr bool Aligned = pal_supports<AlignedAllocation, PAL>;
 
     constexpr PalRange() = default;
 
-    CapPtr<void, B> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(KArg, size_t size)
     {
       if (bits::next_pow2_bits(size) >= bits::BITS - 1)
       {

--- a/src/backend/palrange.h
+++ b/src/backend/palrange.h
@@ -22,11 +22,13 @@ namespace snmalloc
       constexpr State() = default;
     };
 
+    using B = capptr::bounds::Chunk;
+
     static constexpr bool Aligned = pal_supports<AlignedAllocation, PAL>;
 
     constexpr PalRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(size_t size)
     {
       if (bits::next_pow2_bits(size) >= bits::BITS - 1)
       {
@@ -37,7 +39,7 @@ namespace snmalloc
       {
         SNMALLOC_ASSERT(size >= PAL::minimum_alloc_size);
         auto result =
-          capptr::Chunk<void>(PAL::template reserve_aligned<false>(size));
+          CapPtr<void, B>(PAL::template reserve_aligned<false>(size));
 
 #ifdef SNMALLOC_TRACING
         message<1024>("Pal range alloc: {} ({})", result.unsafe_ptr(), size);
@@ -46,7 +48,7 @@ namespace snmalloc
       }
       else
       {
-        auto result = capptr::Chunk<void>(PAL::reserve(size));
+        auto result = CapPtr<void, B>(PAL::reserve(size));
 
 #ifdef SNMALLOC_TRACING
         message<1024>("Pal range alloc: {} ({})", result.unsafe_ptr(), size);

--- a/src/backend/smallbuddyrange.h
+++ b/src/backend/smallbuddyrange.h
@@ -122,7 +122,7 @@ namespace snmalloc
     }
   };
 
-  template<typename ParentRange>
+  template<SNMALLOC_CONCEPT(ConceptBackendRange) ParentRange>
   class SmallBuddyRange
   {
     typename ParentRange::State parent{};

--- a/src/backend/statsrange.h
+++ b/src/backend/statsrange.h
@@ -29,11 +29,13 @@ namespace snmalloc
       constexpr State() = default;
     };
 
+    using B = typename ParentRange::B;
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr StatsRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(size_t size)
     {
       auto result = parent->alloc_range(size);
       if (result != nullptr)
@@ -50,7 +52,7 @@ namespace snmalloc
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(capptr::Chunk<void> base, size_t size)
+    void dealloc_range(CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,

--- a/src/backend/statsrange.h
+++ b/src/backend/statsrange.h
@@ -30,14 +30,15 @@ namespace snmalloc
     };
 
     using B = typename ParentRange::B;
+    using KArg = typename ParentRange::KArg;
 
     static constexpr bool Aligned = ParentRange::Aligned;
 
     constexpr StatsRange() = default;
 
-    CapPtr<void, B> alloc_range(size_t size)
+    CapPtr<void, B> alloc_range(KArg ka, size_t size)
     {
-      auto result = parent->alloc_range(size);
+      auto result = parent->alloc_range(ka, size);
       if (result != nullptr)
       {
         auto prev = current_usage.fetch_add(size);
@@ -52,13 +53,13 @@ namespace snmalloc
     }
 
     template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
-    void dealloc_range(CapPtr<void, B> base, size_t size)
+    void dealloc_range(KArg ka, CapPtr<void, B> base, size_t size)
     {
       static_assert(
         std::is_same<_pr, ParentRange>::value,
         "Don't set SFINAE template parameter!");
       current_usage -= size;
-      parent->dealloc_range(base, size);
+      parent->dealloc_range(ka, base, size);
     }
 
     size_t get_current_usage()

--- a/src/backend/statsrange.h
+++ b/src/backend/statsrange.h
@@ -7,7 +7,7 @@ namespace snmalloc
   /**
    * Used to measure memory usage.
    */
-  template<typename ParentRange>
+  template<SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange>
   class StatsRange
   {
     typename ParentRange::State parent{};
@@ -49,8 +49,12 @@ namespace snmalloc
       return result;
     }
 
+    template<SNMALLOC_CONCEPT(ConceptBackendRange_Dealloc) _pr = ParentRange>
     void dealloc_range(capptr::Chunk<void> base, size_t size)
     {
+      static_assert(
+        std::is_same<_pr, ParentRange>::value,
+        "Don't set SFINAE template parameter!");
       current_usage -= size;
       parent->dealloc_range(base, size);
     }

--- a/src/backend/subrange.h
+++ b/src/backend/subrange.h
@@ -32,9 +32,11 @@ namespace snmalloc
 
     constexpr SubRange() = default;
 
+    using B = typename ParentRange::B;
+
     static constexpr bool Aligned = ParentRange::Aligned;
 
-    capptr::Chunk<void> alloc_range(size_t sub_size)
+    CapPtr<void, B> alloc_range(size_t sub_size)
     {
       SNMALLOC_ASSERT(bits::is_pow2(sub_size));
 

--- a/src/backend/subrange.h
+++ b/src/backend/subrange.h
@@ -8,7 +8,10 @@ namespace snmalloc
    * 2^RATIO_BITS.  Will not return a the block at the start or
    * the end of the large allocation.
    */
-  template<typename ParentRange, typename PAL, size_t RATIO_BITS>
+  template<
+    SNMALLOC_CONCEPT(ConceptBackendRange_Alloc) ParentRange,
+    SNMALLOC_CONCEPT(ConceptPAL) PAL,
+    size_t RATIO_BITS>
   class SubRange
   {
     typename ParentRange::State parent{};

--- a/src/backend/subrange.h
+++ b/src/backend/subrange.h
@@ -33,15 +33,16 @@ namespace snmalloc
     constexpr SubRange() = default;
 
     using B = typename ParentRange::B;
+    using KArg = typename ParentRange::KArg;
 
     static constexpr bool Aligned = ParentRange::Aligned;
 
-    CapPtr<void, B> alloc_range(size_t sub_size)
+    CapPtr<void, B> alloc_range(KArg ka, size_t sub_size)
     {
       SNMALLOC_ASSERT(bits::is_pow2(sub_size));
 
       auto full_size = sub_size << RATIO_BITS;
-      auto overblock = parent->alloc_range(full_size);
+      auto overblock = parent->alloc_range(ka, full_size);
       if (overblock == nullptr)
         return nullptr;
 


### PR DESCRIPTION
This sets the stage for bounding metadata allocations more tightly than the whole underlying arena (on CHERI) though it does not actually do so yet.  Specifically, this series serves to get the `SmallBuddyRange` out of the chain taken by ordinary objects and only on the chain (at the head, in fact) for metadata objects; we can therefore have these two chains have different return values.

While it seems attractive to introduce a `Range` type that manages single chunks and caches the arena-bounded pointer in the `PageMap` on `alloc` and substitutes the cached version back on `dealloc`, I think that this is insufficient for `SmallBuddyRange`'s needs once it begins enforcing bounds on allocations, and so I fear that `SmallBuddyRange` will come to directly know about the `PageMap`... but I haven't gotten there yet, so am not sure.