### PR TITLE
Allow POSIX PALs to overwrite writev and fsync.

### DIFF
--- a/src/pal/pal_bsd.h
+++ b/src/pal/pal_bsd.h
@@ -10,8 +10,8 @@ namespace snmalloc
    * Generic *BSD PAL mixin.  This provides features that are common to the BSD
    * family.
    */
-  template<typename OS>
-  class PALBSD : public PALPOSIX<OS>
+  template<typename OS, auto... Args>
+  class PALBSD : public PALPOSIX<OS, Args...>
   {
   public:
     /**

--- a/src/pal/pal_bsd_aligned.h
+++ b/src/pal/pal_bsd_aligned.h
@@ -10,8 +10,8 @@ namespace snmalloc
    * This adds aligned allocation using `MAP_ALIGNED` to the generic BSD
    * implementation.  This flag is supported by NetBSD and FreeBSD.
    */
-  template<class OS>
-  class PALBSD_Aligned : public PALBSD<OS>
+  template<class OS, auto... Args>
+  class PALBSD_Aligned : public PALBSD<OS, Args...>
   {
   public:
     /**

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -18,7 +18,7 @@
  * won't work if malloc is broken.
  * @{
  */
-extern "C" ssize_t __sys_writev(int fd, const struct iovec *iov, int iovcnt);
+extern "C" ssize_t __sys_writev(int fd, const struct iovec* iov, int iovcnt);
 extern "C" int __sys_fsync(int fd);
 /// @}
 
@@ -30,7 +30,8 @@ namespace snmalloc
    * This adds FreeBSD-specific aligned allocation to the generic BSD
    * implementation.
    */
-  class PALFreeBSD : public PALBSD_Aligned<PALFreeBSD, __sys_writev, __sys_fsync>
+  class PALFreeBSD
+  : public PALBSD_Aligned<PALFreeBSD, __sys_writev, __sys_fsync>
   {
   public:
     /**

--- a/src/pal/pal_freebsd.h
+++ b/src/pal/pal_freebsd.h
@@ -13,6 +13,15 @@
 #    endif
 #  endif
 
+/**
+ * Direct system-call wrappers so that we can skip libthr interception, which
+ * won't work if malloc is broken.
+ * @{
+ */
+extern "C" ssize_t __sys_writev(int fd, const struct iovec *iov, int iovcnt);
+extern "C" int __sys_fsync(int fd);
+/// @}
+
 namespace snmalloc
 {
   /**
@@ -21,7 +30,7 @@ namespace snmalloc
    * This adds FreeBSD-specific aligned allocation to the generic BSD
    * implementation.
    */
-  class PALFreeBSD : public PALBSD_Aligned<PALFreeBSD>
+  class PALFreeBSD : public PALBSD_Aligned<PALFreeBSD, __sys_writev, __sys_fsync>
   {
   public:
     /**

--- a/src/pal/pal_posix.h
+++ b/src/pal/pal_posix.h
@@ -34,11 +34,13 @@ namespace snmalloc
    * efficient implementation.  Subclasses should provide more efficient
    * implementations using platform-specific functionality.
    *
-   * The template parameter for this is the subclass and is used for explicit
-   * up casts to allow this class to call non-virtual methods on the templated
-   * version.
+   * The first template parameter for this is the subclass and is used for
+   * explicit up casts to allow this class to call non-virtual methods on the
+   * templated version.  The next two allow subclasses to provide `writev` and
+   * `fsync` implementations that bypass any libc machinery that might not be
+   * working when an early-malloc error appears.
    */
-  template<class OS>
+  template<class OS, auto writev = ::writev, auto fsync = ::fsync>
   class PALPOSIX : public PalTimerDefaultImpl<PALPOSIX<OS>>
   {
     /**


### PR DESCRIPTION
On FreeBSD (possibly elsewhere) the normal versions of these go via an
indirection layer because they are pthread cancellation points.  This
indirection layer does not work correctly if pthreads can't allocate
memory and so we can't get debug output until malloc is working, at
least a little bit.

With this version, we can call the __sys_ variants, which skip any libc
/ libthr interposition.