### PR TITLE
Check things in release builds with check-client.

### DIFF
--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -315,7 +315,7 @@ namespace snmalloc
         count++;
       }
       // Check the list contains all the elements
-      SNMALLOC_ASSERT(
+      SNMALLOC_CHECK(
         (count + more) == snmalloc::sizeclass_to_slab_object_count(sizeclass));
 
       if (more > 0)
@@ -330,7 +330,7 @@ namespace snmalloc
           count++;
         }
       }
-      SNMALLOC_ASSERT(
+      SNMALLOC_CHECK(
         count == snmalloc::sizeclass_to_slab_object_count(sizeclass));
 #endif
       // TODO: This is a capability amplification as we are saying we

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -730,7 +730,7 @@ namespace snmalloc
         {
           if (&head[i] == end[i])
           {
-            SNMALLOC_ASSERT(length[i] == 0);
+            SNMALLOC_CHECK(length[i] == 0);
             continue;
           }
 
@@ -747,7 +747,7 @@ namespace snmalloc
             prev = signed_prev(address_cast(curr), address_cast(next), key);
             curr = next;
           }
-          SNMALLOC_ASSERT(count == length[i]);
+          SNMALLOC_CHECK(count == length[i]);
         }
 #else
         UNUSED(key);


### PR DESCRIPTION
Clang 15 doesn't build the release builds with CHECK_CLIENT enabled
because they are using `SNMALLOC_ASSERT` and so the values that we're
collecting to check are never actually checked.  This is probably a bug
- if we're turning on the checks, I imagine it's because we want them.