### PR TITLE
Refill heuristic

### DIFF
--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -98,22 +98,35 @@ namespace snmalloc
 #endif
 
     // Set up source of memory
-    using P = PalRange<DefaultPal>;
+    using P = PalRange<PAL>;
     using Base = std::conditional_t<
       fixed_range,
       EmptyRange,
       PagemapRegisterRange<Pagemap, P, CONSOLIDATE_PAL_ALLOCS>>;
+
+    static constexpr size_t MinBaseSizeBits()
+    {
+      if constexpr (pal_supports<AlignedAllocation, PAL>)
+      {
+        return bits::next_pow2_bits_const(PAL::minimum_alloc_size);
+      }
+      else
+      {
+        return MIN_CHUNK_BITS;
+      }
+    }
+
     // Global range of memory
-    using StatsR =
-      StatsRange<LargeBuddyRange<Base, 24, bits::BITS - 1, Pagemap>>;
+    using StatsR = StatsRange<
+      LargeBuddyRange<Base, 24, bits::BITS - 1, Pagemap, MinBaseSizeBits()>>;
     using GlobalR = GlobalRange<StatsR>;
 
 #ifdef SNMALLOC_META_PROTECTED
     // Source for object allocations
     using ObjectRange =
-      LargeBuddyRange<CommitRange<GlobalR, DefaultPal>, 21, 21, Pagemap>;
+      LargeBuddyRange<CommitRange<GlobalR, PAL>, 21, 21, Pagemap>;
     // Set up protected range for metadata
-    using SubR = CommitRange<SubRange<GlobalR, DefaultPal, 6>, DefaultPal>;
+    using SubR = CommitRange<SubRange<GlobalR, PAL, 6>, PAL>;
     using MetaRange =
       SmallBuddyRange<LargeBuddyRange<SubR, 21 - 6, bits::BITS - 1, Pagemap>>;
     using GlobalMetaRange = GlobalRange<MetaRange>;
@@ -121,7 +134,7 @@ namespace snmalloc
     // Source for object allocations and metadata
     // No separation between the two
     using ObjectRange = SmallBuddyRange<
-      LargeBuddyRange<CommitRange<GlobalR, DefaultPal>, 21, 21, Pagemap>>;
+      LargeBuddyRange<CommitRange<GlobalR, PAL>, 21, 21, Pagemap>>;
     using GlobalMetaRange = GlobalRange<ObjectRange>;
 #endif
 

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -97,15 +97,6 @@ namespace snmalloc
     static constexpr bool CONSOLIDATE_PAL_ALLOCS = true;
 #endif
 
-#if defined(OPEN_ENCLAVE)
-    // Single global buddy allocator is used on open enclave due to
-    // the limited address space.
-    using StatsR = StatsRange<SmallBuddyRange<
-      LargeBuddyRange<EmptyRange, bits::BITS - 1, bits::BITS - 1, Pagemap>>>;
-    using GlobalR = GlobalRange<StatsR>;
-    using ObjectRange = GlobalR;
-    using GlobalMetaRange = ObjectRange;
-#else
     // Set up source of memory
     using P = PalRange<DefaultPal>;
     using Base = std::conditional_t<
@@ -117,7 +108,7 @@ namespace snmalloc
       StatsRange<LargeBuddyRange<Base, 24, bits::BITS - 1, Pagemap>>;
     using GlobalR = GlobalRange<StatsR>;
 
-#  ifdef SNMALLOC_META_PROTECTED
+#ifdef SNMALLOC_META_PROTECTED
     // Source for object allocations
     using ObjectRange =
       LargeBuddyRange<CommitRange<GlobalR, DefaultPal>, 21, 21, Pagemap>;
@@ -126,13 +117,12 @@ namespace snmalloc
     using MetaRange =
       SmallBuddyRange<LargeBuddyRange<SubR, 21 - 6, bits::BITS - 1, Pagemap>>;
     using GlobalMetaRange = GlobalRange<MetaRange>;
-#  else
+#else
     // Source for object allocations and metadata
     // No separation between the two
     using ObjectRange = SmallBuddyRange<
       LargeBuddyRange<CommitRange<GlobalR, DefaultPal>, 21, 21, Pagemap>>;
     using GlobalMetaRange = GlobalRange<ObjectRange>;
-#  endif
 #endif
 
     struct LocalState

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -178,8 +178,9 @@ namespace snmalloc
    *
    * Pagemap - How to access the pagemap, which is used to store the red black
    * tree nodes for the buddy allocators.
-   * 
-   * MIN_REFILL_SIZE_BITS - The minimum size that the ParentRange can be asked for
+   *
+   * MIN_REFILL_SIZE_BITS - The minimum size that the ParentRange can be asked
+   * for
    */
   template<
     typename ParentRange,
@@ -199,7 +200,8 @@ namespace snmalloc
     /**
      * Minimum size of a refill
      */
-    static constexpr size_t MIN_REFILL_SIZE = bits::one_at_bit(MIN_REFILL_SIZE_BITS);
+    static constexpr size_t MIN_REFILL_SIZE =
+      bits::one_at_bit(MIN_REFILL_SIZE_BITS);
 
     /**
      * The size of memory requested so far.

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -183,7 +183,8 @@ namespace snmalloc
     typename ParentRange,
     size_t REFILL_SIZE_BITS,
     size_t MAX_SIZE_BITS,
-    SNMALLOC_CONCEPT(ConceptBuddyRangeMeta) Pagemap>
+    SNMALLOC_CONCEPT(ConceptBuddyRangeMeta) Pagemap,
+    size_t MIN_REFILL_SIZE_BITS = 0>
   class LargeBuddyRange
   {
     ParentRange parent{};
@@ -192,6 +193,11 @@ namespace snmalloc
      * Maximum size of a refill
      */
     static constexpr size_t REFILL_SIZE = bits::one_at_bit(REFILL_SIZE_BITS);
+
+    /**
+     * Minimum size of a refill
+     */
+    static constexpr size_t MIN_REFILL_SIZE = bits::one_at_bit(MIN_REFILL_SIZE_BITS);
 
     /**
      * The size of memory requested so far.
@@ -265,6 +271,7 @@ namespace snmalloc
         // depends on the ParentRange behaviour.
         size_t refill_size =
           bits::min(REFILL_SIZE, bits::next_pow2(requested_total));
+        refill_size = bits::max(refill_size, MIN_REFILL_SIZE);
         refill_size = bits::max(refill_size, size);
 
         auto refill_range = parent.alloc_range(refill_size);

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -178,6 +178,8 @@ namespace snmalloc
    *
    * Pagemap - How to access the pagemap, which is used to store the red black
    * tree nodes for the buddy allocators.
+   * 
+   * MIN_REFILL_SIZE_BITS - The minimum size that the ParentRange can be asked for
    */
   template<
     typename ParentRange,
@@ -269,10 +271,10 @@ namespace snmalloc
         // REFILL_SIZE, REFILL_SIZE, ... Hence if this if they are coming from a
         // contiguous aligned range, then they could be consolidated.  This
         // depends on the ParentRange behaviour.
-        size_t refill_size =
-          bits::min(REFILL_SIZE, bits::next_pow2(requested_total));
+        size_t refill_size = bits::min(REFILL_SIZE, requested_total);
         refill_size = bits::max(refill_size, MIN_REFILL_SIZE);
         refill_size = bits::max(refill_size, size);
+        refill_size = bits::next_pow2(refill_size);
 
         auto refill_range = parent.alloc_range(refill_size);
         if (refill_range != nullptr)


### PR DESCRIPTION
Modify the large buddy allocator to gradually grow its refill size up to a set amount.  This is designed to work well on more limited address space platforms, but be able to grow to reduce contention on larger systems.

Primary use is for OE, where changes from CoffeeLake to IceLake mean the address space limits are very different.