### PR TITLE
Refactor capptr_domesticate SFINAE to make more statically safe.

### DIFF
--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -24,7 +24,26 @@ namespace snmalloc
       return alloc_pool;
     }
 
-    static constexpr Flags Options{};
+    /*
+     * The obvious
+     * `static constexpr Flags Options{.HasDomesticate = true};` fails on
+     * Ubuntu 18.04 with an error "sorry, unimplemented: non-trivial
+     * designated initializers not supported".
+     * The following was copied from domestication.cc test with the following
+     * comment:
+     * C++, even as late as C++20, has some really quite strict limitations on
+     * designated initializers.  However, as of C++17, we can have constexpr
+     * lambdas and so can use more of the power of the statement fragment of
+     * C++, and not just its initializer fragment, to initialize a non-prefix
+     * subset of the flags (in any order, at that).
+     */
+    static constexpr Flags Options = []() constexpr
+    {
+      Flags opts = {};
+      opts.HasDomesticate = true;
+      return opts;
+    }
+    ();
 
     // This needs to be a forward reference as the
     // thread local state will need to know about this.

--- a/src/snmalloc/backend_helpers/commonconfig.h
+++ b/src/snmalloc/backend_helpers/commonconfig.h
@@ -86,6 +86,13 @@ namespace snmalloc
      * the queue nodes themselves (which are always considered Wild)?
      */
     bool QueueHeadsAreTame = true;
+
+    /**
+     * Does the backend provide a capptr_domesticate function to sanity check
+     * pointers? If so it will be called when untrusted pointers are consumed
+     * (on dealloc and in freelists) otherwise a no-op version is provided.
+     */
+    bool HasDomesticate = false;
   };
 
   /**

--- a/src/test/func/domestication/domestication.cc
+++ b/src/test/func/domestication/domestication.cc
@@ -40,6 +40,7 @@ namespace snmalloc
     {
       Flags opts = {};
       opts.QueueHeadsAreTame = false;
+      opts.HasDomesticate = true;
       return opts;
     }
     ();


### PR DESCRIPTION
This refactoring was provided by David.  Previously if a backend
provided a capptr_domesticate function with the wrong type it would be
silently ignored.  This change requires backends to explicitly opt in
to domestication via a new Backend::Option and ensures the compiler
will loudly complain if there is a mismatch.