### PR TITLE
Modified Metadata range to have separate pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ function(add_warning_flags name)
     $<$<CXX_COMPILER_ID:Clang>:-Wsign-conversion -Wconversion>)
   target_link_options(${name} PRIVATE 
     $<$<BOOL:${SNMALLOC_LINKER_SUPPORT_NO_ALLOW_SHLIB_UNDEF}>:-Wl,--no-undefined>
-    $<$<CXX_COMPILER_ID:MSVC>:$<${ci_or_debug}:/DEBUG>>)
+    $<$<PLATFORM_ID:Windows>:$<${ci_or_debug}:/DEBUG>>)
 endfunction()
 
 


### PR DESCRIPTION
The Metadata range should not be shared with the object range.  This
change ensures that their are separate requests to the Pal for meta-data
and object data ranges.  The requests are never combined, and thus
memory cannot flow from being used in malloc to later be used in meta-
data.