### PR TITLE
Enable memcpy checks for check shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,7 @@ option(SNMALLOC_NO_REALLOCARR "Build without reallocarr exported" ON)
 # Options that apply only if we're not building the header-only library
 cmake_dependent_option(SNMALLOC_RUST_SUPPORT "Build static library for rust" OFF "NOT SNMALLOC_HEADER_ONLY_LIBRARY" OFF)
 cmake_dependent_option(SNMALLOC_STATIC_LIBRARY "Build static libraries" ON "NOT SNMALLOC_HEADER_ONLY_LIBRARY" OFF)
-cmake_dependent_option(SNMALLOC_MEMCPY_BOUNDS "Perform bounds checks on memcpy with heap objects" OFF "NOT SNMALLOC_HEADER_ONLY_LIBRARY" OFF)
-cmake_dependent_option(SNMALLOC_CHECK_LOADS "Perform bounds checks on the source argument to memcpy with heap objects" OFF "SNMALLOC_MEMCPY_BOUNDS" OFF)
+cmake_dependent_option(SNMALLOC_CHECK_LOADS "Perform bounds checks on the source argument to memcpy with heap objects" OFF "NOT SNMALLOC_HEADER_ONLY_LIBRARY" OFF)
 cmake_dependent_option(SNMALLOC_OPTIMISE_FOR_CURRENT_MACHINE "Compile for current machine architecture" Off "NOT SNMALLOC_HEADER_ONLY_LIBRARY" OFF)
 if (NOT SNMALLOC_HEADER_ONLY_LIBRARY)
   # Pick a sensible default for the thread cleanup mechanism
@@ -329,9 +328,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
   endfunction()
 
   set(SHIM_FILES src/snmalloc/override/new.cc)
-  if (SNMALLOC_MEMCPY_BOUNDS)
-    list(APPEND SHIM_FILES src/snmalloc/override/memcpy.cc)
-  endif ()
+  set(SHIM_FILES_MEMCPY src/snmalloc/override/memcpy.cc)
 
   if (SNMALLOC_STATIC_LIBRARY)
     add_shim(snmallocshim-static STATIC ${SHIM_FILES})
@@ -341,7 +338,8 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
 
   if(NOT WIN32)
     add_shim(snmallocshim SHARED ${SHIM_FILES})
-    add_shim(snmallocshim-checks SHARED ${SHIM_FILES})
+    add_shim(snmallocshim-checks-memcpy-only SHARED ${SHIM_FILES} ${SHIM_FILES_MEMCPY})
+    add_shim(snmallocshim-checks SHARED ${SHIM_FILES} ${SHIM_FILES_MEMCPY})
     target_compile_definitions(snmallocshim-checks PRIVATE SNMALLOC_CHECK_CLIENT)
   endif()
 


### PR DESCRIPTION
Build three levels of checking
  - None
  - Checks memcpy only
  - Checks (full)

Currently you can build checks without enabling the memcpy protection.
This PR fixes that.