### PR TITLE
Out-of-memory can fail silently

### DIFF
--- a/src/test/perf/contention/contention.cc
+++ b/src/test/perf/contention/contention.cc
@@ -90,7 +90,7 @@ void test_tasks_f(size_t id)
     else
     {
       std::cout << "Failed to allocate " << size << " bytes" << std::endl;
-      abort();
+      // Continue as this is not an important failure.
     }
 
     size_t* out =


### PR DESCRIPTION
If this test fails to allocate memory, that should not cause the test to
fail.  The 'abort' was added previously to confirm a infrequent failure
was caused by out-of-memory causing the test to assign to nullptr.

This was confirmed in a CI run, and now the test can be made to ignore
allocation failure.