### PR TITLE
Add Morello CI

### DIFF
--- a/.github/workflows/morello.yml
+++ b/.github/workflows/morello.yml
@@ -1,0 +1,93 @@
+name: snmalloc CI for Morello
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # UNIX-like, but with some needed TLC for the moment, so not folded in to the main unixlike CI.
+  # Morello can't easily self-host since it mixes purecap and hybrid build tools.
+  # We point cmake at the LLVM Clang frontend explicitly lest it pick up the more magic wrappers.
+  morello:
+    strategy:
+      matrix:
+        # Build each combination of OS and release/debug variants
+        os: [ "morello" ]
+        build-type: [ Release, Debug ]
+        caps: [ Hybrid, Purecap ]
+        include:
+          - os: "morello"
+            caps: Hybrid
+            dependencies: |
+              pkg64 install -y llvm-localbase cmake ninja
+            cmake-flags: >
+              -DCMAKE_CXX_COMPILER=/usr/local64/bin/clang++
+              -DCMAKE_C_COMPILER=/usr/local64/bin/clang
+              -DCMAKE_CXX_FLAGS='-march=morello -Xclang -morello-vararg=new'
+              -DCMAKE_C_FLAGS='-march=morello -Xclang -morello-vararg=new'
+          - os: "morello"
+            caps: Purecap
+            dependencies: |
+              pkg64 install -y llvm-localbase cmake ninja
+            cmake-flags: >
+              -DCMAKE_CXX_COMPILER=/usr/local64/bin/clang++
+              -DCMAKE_C_COMPILER=/usr/local64/bin/clang
+              -DCMAKE_CXX_FLAGS='-march=morello -mabi=purecap -Xclang -morello-vararg=new'
+              -DCMAKE_C_FLAGS='-march=morello -mabi=purecap -Xclang -morello-vararg=new'
+              -DSNMALLOC_LINK_ICF=OFF
+            # SNMALLOC_LINK_ICF=OFF until the fix for
+            # https://git.morello-project.org/morello/llvm-project/-/issues/51 , namely
+            # https://git.morello-project.org/morello/llvm-project/-/commit/f41cb9104e0793de87d98b38acb274b2e3266091
+            # lands in a package or a release.  That's probably the Fall 2022 release.
+      # Don't abort runners if a single one fails
+      fail-fast: false
+    # Morello needs special handling to get picked up by our self-hosted runners
+    # When/if we do integrate this back into the unixlike matrix above, we could
+    # say something like::
+    #   runs-on: >-
+    #     ${{ (matrix.os == 'morello' && fromJSON('["self-hosted", "msr-morello", "2022.05-benchmark"]'))
+    #         || matrix.os }}
+    # to dispatch dynamically.
+    runs-on: ["self-hosted", "msr-morello", "2022.05-benchmark"]
+    name: ${{ matrix.os }} ${{ matrix.build-type }} ${{ matrix.caps }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install build dependencies
+      run: ${{ matrix.dependencies }}
+    - name: Configure CMake
+      run: >
+        cmake
+        -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+        -G Ninja ${{ matrix.cmake-flags }}
+        ${{ matrix.extra-cmake-flags }}
+      # Build with a nice ninja status line
+    - name: Build
+      # https://github.com/ChristopherHX/github-act-runner seemingly ignores working-directory,
+      # but everyone agrees that we start in ${{github.workspace}} by default, so just cd into
+      # the build directory ourselves.  See
+      #   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+      #   https://github.com/ChristopherHX/github-act-runner/issues/61
+      # working-directory: ${{github.workspace}}/build
+      run: |
+        cd build
+        NINJA_STATUS="%p [%f:%s/%t] %o/s, %es" ninja
+    - name: Test file size of binaries is sane
+      # working-directory: ${{github.workspace}}/build
+      run: |
+        cd build
+        ls -l func-first_operation-fast ; [ $(ls -l func-first_operation-fast | awk '{ print $5}') -lt 10000000 ]
+      # If the tests are enabled for this job, run them
+    - name: Test
+      if: ${{ matrix.build-only != 'yes' }}
+      # working-directory: ${{github.workspace}}/build
+      run: |
+        cd build
+        ctest --output-on-failure -j 4 -C ${{ matrix.build-type }} --timeout 400


### PR DESCRIPTION
For review and commentary.  If you want to test this and need access to the cluster, please let me know.  We should not merge this until R&CT 4968 is fully approved and the automation is actually set up in the right place on Azure.  (If that happens before CHERI support in `snmalloc`, we can just disable the Purecap builds herein.)

See https://github.com/nwf-msr/snmalloc/actions/runs/2385794002 for an example run.  The Purecap Release variant does not, at present, build, due to https://github.com/CTSRD-CHERI/llvm-project/issues/618, and the Purecap Debug variant does not build either, presumably just because we're missing a CHERI AAL and PAL.  (I haven't looked in detail.)