### PR TITLE
Alter PAGE_SIZE usage

### DIFF
--- a/src/snmalloc/backend/standard_range.h
+++ b/src/snmalloc/backend/standard_range.h
@@ -41,11 +41,18 @@ namespace snmalloc
     using Stats = Pipe<GlobalR, CommitRange<PAL>, StatsRange<>>;
 
   private:
+    static constexpr size_t page_size_bits =
+      bits::next_pow2_bits_const(PAL::page_size);
+
     // Source for object allocations and metadata
     // Use buddy allocators to cache locally.
     using ObjectRange = Pipe<
       Stats,
-      LargeBuddyRange<LocalCacheSizeBits, LocalCacheSizeBits, Pagemap>,
+      LargeBuddyRange<
+        LocalCacheSizeBits,
+        LocalCacheSizeBits,
+        Pagemap,
+        page_size_bits>,
       SmallBuddyRange<>>;
 
   public:

--- a/src/snmalloc/backend_helpers/commitrange.h
+++ b/src/snmalloc/backend_helpers/commitrange.h
@@ -25,6 +25,11 @@ namespace snmalloc
 
     capptr::Chunk<void> alloc_range(size_t size)
     {
+      SNMALLOC_ASSERT_MSG(
+        (size % PAL::page_size) == 0,
+        "size ({}) must be a multiple of page size ({})",
+        size,
+        PAL::page_size);
       auto range = parent.alloc_range(size);
       if (range != nullptr)
         PAL::template notify_using<NoZero>(range.unsafe_ptr(), size);
@@ -33,6 +38,11 @@ namespace snmalloc
 
     void dealloc_range(capptr::Chunk<void> base, size_t size)
     {
+      SNMALLOC_ASSERT_MSG(
+        (size % PAL::page_size) == 0,
+        "size ({}) must be a multiple of page size ({})",
+        size,
+        PAL::page_size);
       PAL::notify_not_using(base.unsafe_ptr(), size);
       parent.dealloc_range(base, size);
     }

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -193,6 +193,12 @@ namespace snmalloc
   {
     using ContainsParent<ParentRange>::parent;
 
+    static_assert(
+      REFILL_SIZE_BITS <= MAX_SIZE_BITS, "REFILL_SIZE_BITS > MAX_SIZE_BITS");
+    static_assert(
+      MIN_REFILL_SIZE_BITS <= REFILL_SIZE_BITS,
+      "MIN_REFILL_SIZE_BITS > REFILL_SIZE_BITS");
+
     /**
      * Maximum size of a refill
      */

--- a/src/snmalloc/ds/allocconfig.h
+++ b/src/snmalloc/ds/allocconfig.h
@@ -26,8 +26,7 @@ namespace snmalloc
   static constexpr size_t MIN_ALLOC_BITS = bits::ctz_const(MIN_ALLOC_SIZE);
 
   // Minimum slab size.
-  static constexpr size_t MIN_CHUNK_BITS = bits::max(
-    static_cast<size_t>(14), bits::next_pow2_bits_const(OS_PAGE_SIZE));
+  static constexpr size_t MIN_CHUNK_BITS = static_cast<size_t>(14);
   static constexpr size_t MIN_CHUNK_SIZE = bits::one_at_bit(MIN_CHUNK_BITS);
 
   // Minimum number of objects on a slab
@@ -41,6 +40,10 @@ namespace snmalloc
   static constexpr size_t MAX_SMALL_SIZECLASS_BITS = 16;
   static constexpr size_t MAX_SMALL_SIZECLASS_SIZE =
     bits::one_at_bit(MAX_SMALL_SIZECLASS_BITS);
+
+  static_assert(
+    MAX_SMALL_SIZECLASS_SIZE >= MIN_CHUNK_SIZE,
+    "Large sizes need to be representable by as a multiple of MIN_CHUNK_SIZE");
 
   // Number of slots for remote deallocation.
   static constexpr size_t REMOTE_SLOT_BITS = 8;


### PR DESCRIPTION
Using PAGE_SIZE as the minimum size of the CHUNK means that if this is
configured to 2MiB, then there is a gap between
MAX_SMALL_SIZECLASS_SIZE, and MIN_CHUNK_SIZE, and thus
we can't represent certain sizes.

This removes that connection, and adds a static assert to check for the issue.