### PR TITLE
Add a TID to the PAL

### DIFF
--- a/src/snmalloc/ds/flaglock.h
+++ b/src/snmalloc/ds/flaglock.h
@@ -15,6 +15,8 @@ namespace snmalloc
    */
   struct DebugFlagWord
   {
+    using ThreadIdentity = DefaultPal::ThreadIdentity;
+
     /**
      * @brief flag
      * The underlying atomic field.
@@ -33,7 +35,7 @@ namespace snmalloc
      */
     void set_owner()
     {
-      SNMALLOC_ASSERT(0 == owner);
+      SNMALLOC_ASSERT(ThreadIdentity() == owner);
       owner = get_thread_identity();
     }
 
@@ -44,7 +46,7 @@ namespace snmalloc
     void clear_owner()
     {
       SNMALLOC_ASSERT(get_thread_identity() == owner);
-      owner = 0;
+      owner = ThreadIdentity();
     }
 
     /**
@@ -57,18 +59,17 @@ namespace snmalloc
     }
 
   private:
-    using ThreadIdentity = size_t;
     /**
      * @brief owner
      * We use the Pal to provide the ThreadIdentity.
      */
-    std::atomic<ThreadIdentity> owner = 0;
+    std::atomic<ThreadIdentity> owner = ThreadIdentity();
 
     /**
      * @brief get_thread_identity
      * @return The identity of current thread.
      */
-    static size_t get_thread_identity()
+    static ThreadIdentity get_thread_identity()
     {
       return DefaultPal::get_tid();
     }

--- a/src/snmalloc/ds/flaglock.h
+++ b/src/snmalloc/ds/flaglock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../aal/aal.h"
+#include "../pal/pal.h"
 
 #include <atomic>
 #include <functional>
@@ -32,7 +33,7 @@ namespace snmalloc
      */
     void set_owner()
     {
-      SNMALLOC_ASSERT(nullptr == owner);
+      SNMALLOC_ASSERT(0 == owner);
       owner = get_thread_identity();
     }
 
@@ -43,7 +44,7 @@ namespace snmalloc
     void clear_owner()
     {
       SNMALLOC_ASSERT(get_thread_identity() == owner);
-      owner = nullptr;
+      owner = 0;
     }
 
     /**
@@ -56,24 +57,20 @@ namespace snmalloc
     }
 
   private:
-    using ThreadIdentity = int const*;
-
+    using ThreadIdentity = size_t;
     /**
      * @brief owner
-     * We use a pointer to TLS field as the thread identity.
-     * std::thread::id can be another solution but it does not
-     * support `constexpr` initialisation on some platforms.
+     * We use the Pal to provide the ThreadIdentity.
      */
-    std::atomic<ThreadIdentity> owner = nullptr;
+    std::atomic<ThreadIdentity> owner = 0;
 
     /**
      * @brief get_thread_identity
      * @return The identity of current thread.
      */
-    inline ThreadIdentity get_thread_identity()
+    static size_t get_thread_identity()
     {
-      static thread_local int SNMALLOC_THREAD_IDENTITY = 0;
-      return &SNMALLOC_THREAD_IDENTITY;
+      return DefaultPal::get_tid();
     }
   };
 

--- a/src/snmalloc/pal/pal.h
+++ b/src/snmalloc/pal/pal.h
@@ -177,7 +177,8 @@ namespace snmalloc
   inline void message(Args... args)
   {
     MessageBuilder<BufferSize> msg{std::forward<Args>(args)...};
-    MessageBuilder<BufferSize> msg_tid{"{}: {}", DefaultPal::get_tid(), msg.get_message()};
+    MessageBuilder<BufferSize> msg_tid{
+      "{}: {}", DefaultPal::get_tid(), msg.get_message()};
     DefaultPal::message(msg_tid.get_message());
   }
 } // namespace snmalloc

--- a/src/snmalloc/pal/pal.h
+++ b/src/snmalloc/pal/pal.h
@@ -173,23 +173,11 @@ namespace snmalloc
     DefaultPal::error(msg.get_message());
   }
 
-  static inline size_t get_tid()
-  {
-    static thread_local size_t tid{0};
-    static std::atomic<size_t> tid_source{1};
-
-    if (tid == 0)
-    {
-      tid = tid_source++;
-    }
-    return tid;
-  }
-
   template<size_t BufferSize, typename... Args>
   inline void message(Args... args)
   {
     MessageBuilder<BufferSize> msg{std::forward<Args>(args)...};
-    MessageBuilder<BufferSize> msg_tid{"{}: {}", get_tid(), msg.get_message()};
+    MessageBuilder<BufferSize> msg_tid{"{}: {}", DefaultPal::get_tid(), msg.get_message()};
     DefaultPal::message(msg_tid.get_message());
   }
 } // namespace snmalloc

--- a/src/snmalloc/pal/pal_concept.h
+++ b/src/snmalloc/pal/pal_concept.h
@@ -77,6 +77,19 @@ namespace snmalloc
   };
 
   /**
+   * The Pal must provide a thread id for debugging.  It should not return
+   * 0, as that is used as not an tid in some places.
+   */
+  template<typename PAL>
+  concept ConceptPAL_tid = requires()
+  {
+    {
+      PAL::get_tid()
+    }
+    noexcept->ConceptSame<size_t>;
+  };
+
+  /**
    * Absent any feature flags, the PAL must support a crude primitive allocator
    */
   template<typename PAL>
@@ -138,7 +151,7 @@ namespace snmalloc
   template<typename PAL>
   concept ConceptPAL = ConceptPAL_static_features<PAL>&&
                          ConceptPAL_static_sizes<PAL>&& ConceptPAL_error<PAL>&&
-                           ConceptPAL_memops<PAL> &&
+                           ConceptPAL_memops<PAL> &&  ConceptPAL_tid<PAL> &&
     (!pal_supports<Entropy, PAL> ||
      ConceptPAL_get_entropy64<
        PAL>)&&(!pal_supports<LowMemoryNotification, PAL> ||

--- a/src/snmalloc/pal/pal_concept.h
+++ b/src/snmalloc/pal/pal_concept.h
@@ -78,7 +78,8 @@ namespace snmalloc
 
   /**
    * The Pal must provide a thread id for debugging.  It should not return
-   * 0, as that is used as not an tid in some places.
+   * the default value of ThreadIdentity, as that is used as not an tid in some
+   * places.
    */
   template<typename PAL>
   concept ConceptPAL_tid = requires()
@@ -86,7 +87,7 @@ namespace snmalloc
     {
       PAL::get_tid()
     }
-    noexcept->ConceptSame<size_t>;
+    noexcept->ConceptSame<typename PAL::ThreadIdentity>;
   };
 
   /**
@@ -151,7 +152,7 @@ namespace snmalloc
   template<typename PAL>
   concept ConceptPAL = ConceptPAL_static_features<PAL>&&
                          ConceptPAL_static_sizes<PAL>&& ConceptPAL_error<PAL>&&
-                           ConceptPAL_memops<PAL> &&  ConceptPAL_tid<PAL> &&
+                           ConceptPAL_memops<PAL>&& ConceptPAL_tid<PAL> &&
     (!pal_supports<Entropy, PAL> ||
      ConceptPAL_get_entropy64<
        PAL>)&&(!pal_supports<LowMemoryNotification, PAL> ||

--- a/src/snmalloc/pal/pal_open_enclave.h
+++ b/src/snmalloc/pal/pal_open_enclave.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pal_noalloc.h"
+#include "pal_tid_default.h"
 
 #ifdef OPEN_ENCLAVE
 extern "C" void* oe_memset_s(void* p, size_t p_size, int c, size_t size);
@@ -25,7 +26,7 @@ namespace snmalloc
 
   using OpenEnclaveBasePAL = PALNoAlloc<OpenEnclaveErrorHandler>;
 
-  class PALOpenEnclave : public OpenEnclaveBasePAL
+  class PALOpenEnclave : public OpenEnclaveBasePAL, public PalTidDefault
   {
   public:
     /**

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../aal/aal.h"
+#include "pal_tid_default.h"
 #include "pal_timer_default.h"
 #if defined(SNMALLOC_BACKTRACE_HEADER)
 #  include SNMALLOC_BACKTRACE_HEADER
@@ -38,7 +39,8 @@ namespace snmalloc
    * working when an early-malloc error appears.
    */
   template<class OS, auto writev = ::writev, auto fsync = ::fsync>
-  class PALPOSIX : public PalTimerDefaultImpl<PALPOSIX<OS>>
+  class PALPOSIX : public PalTimerDefaultImpl<PALPOSIX<OS>>,
+                   public PalTidDefault
   {
     /**
      * Helper class to access the `default_mmap_flags` field of `OS` if one

--- a/src/snmalloc/pal/pal_tid_default.h
+++ b/src/snmalloc/pal/pal_tid_default.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <atomic>
+
+namespace snmalloc
+{
+  class PalTidDefault
+  {
+  public:
+    /**
+     * @brief Get the an id for the current thread.
+     * 
+     * @return the thread id, this should never be zero.
+     * Callers can assume it is non-zero.
+     */
+    static inline size_t get_tid() noexcept
+    {
+      static thread_local size_t tid{0};
+      static std::atomic<size_t> tid_source{0};
+
+      if (tid == 0)
+      {
+        tid = ++tid_source;
+      }
+      return tid;
+    }
+  };
+} // namespace snmalloc

--- a/src/snmalloc/pal/pal_tid_default.h
+++ b/src/snmalloc/pal/pal_tid_default.h
@@ -7,13 +7,15 @@ namespace snmalloc
   class PalTidDefault
   {
   public:
+    using ThreadIdentity = size_t;
+
     /**
      * @brief Get the an id for the current thread.
-     * 
-     * @return the thread id, this should never be zero.
-     * Callers can assume it is non-zero.
+     *
+     * @return the thread id, this should never be the default of
+     * ThreadIdentity. Callers can assume it is a non-default value.
      */
-    static inline size_t get_tid() noexcept
+    static inline ThreadIdentity get_tid() noexcept
     {
       static thread_local size_t tid{0};
       static std::atomic<size_t> tid_source{0};

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../aal/aal.h"
+#include "pal_tid_default.h"
 #include "pal_timer_default.h"
 
 #ifdef _WIN32
@@ -26,7 +27,8 @@
 
 namespace snmalloc
 {
-  class PALWindows : public PalTimerDefaultImpl<PALWindows>
+  class PALWindows : public PalTimerDefaultImpl<PALWindows>,
+                     public PalTidDefault
   {
     /**
      * A flag indicating that we have tried to register for low-memory


### PR DESCRIPTION
Making this part of the PAL allows other platforms to replace with
something more suitable.