### PR TITLE
StrictProvenance backend support, take 2022.05

### DIFF
--- a/docs/StrictProvenance.md
+++ b/docs/StrictProvenance.md
@@ -1,6 +1,30 @@
 # StrictProvenance Architectures
 
-To aid code auditing and support of novel architectures, such as CHERI, which explicitly track pointer *provenance* and *bounds*, `snmalloc` makes heavy use of a `CapPtr<T, B>` wrapper type around `T*` values.
+## What is Strict Provenance?
+
+Some architectures, such as CHERI (including Arm's Morello), explicitly consider pointer *provenance* and *bounds* in addition to their target *addresses*.
+Adding these considerations to the architecture enables software to constrain uses of *particular pointers* in ways that are not available with traditional protection mechanisms.
+For example, while code may *have* a pointer that spans its entire C stack, it may construct a pointer that authorizes access only to a particular stack allocation (e.g., a buffer) and use this latter pointer while copying data.
+Even if an attacker is able to control the length of the copy, the bounds imposed upon pointers involved can ensure that an overflow is impossible.
+(On the other hand, if the attacker can influence both the *bounds* and the copy length, an overflow may still be possible; in practice, however, the two concerns are often sufficiently separated.)
+For `malloc()` in particular, it is enormously beneficial to be able to impose bounds on returned pointers: it becomes impossible for allocator clients to use a pointer from `malloc()` to access adjacent allocations!
+(*Temporal* concerns still apply, in that live allocations can overlap prior, now-dead allocations.
+Stochastic defenses are employed within `snmalloc` and deterministic defenses are ongoing research at MSR.)
+
+Borrowing terminology from CHERI, we speak of the **authority** (to a subset of the address space) held by a pointer and will justify actions in terms of this authority.[^mmu-perms]
+While many kinds of authority can be envisioned, herein we will mean either
+
+* *spatial* authority to read/write/execute within a single *interval* within the address space, or
+* *vmem* authority to request modification of the virtual page mappings for a given range of addresses.
+
+We may **bound** the authority of a pointer, deriving a new pointer with a subset of its progenitor's authority; this is assumed to be an ambient action requiring no additional authority.
+Dually, given two pointers, one with a subset of the other's authority, we may **amplify** the less-authorized, constructing a pointer with the same address but with increased authority (up to the held superset authority).[^amplifier-state]
+
+## snmalloc Support For Strict Provenance
+
+### Static Annotations With CapPtr
+
+To aid code auditing, `snmalloc` makes heavy use of a `CapPtr<T, B>` wrapper type around `T*` values.
 You can think of the annotation `B` on a `CapPtr<T, B>` as capturing something about the role of the pointer, e.g.:
 
 * A pointer to a whole chunk or slab, derived from an internal `void*`.
@@ -20,7 +44,7 @@ The remainder of this document...
 * provides a summary of the constraints imposed on clients,
 * describes the `StrictProvenance` `capptr_*` functions provided by `ds/ptrwrap.h`, the Architecture Abstraction Layer (AAL), and the Platform Abstraction Layer (PAL).
 
-## Limitations
+### Limitations
 
 The `CapPtr<T, B>` and `capptr_*` primitives and derived functions are intended to guide developers in useful directions; they are not security mechanisms in and of themselves.
 For non-CHERI architectures, the whole edifice crumbles in the face of an overzealous `reinterpret_cast<>` or `unsafe_*ptr` call.
@@ -37,8 +61,10 @@ This trend of aliasing continues into higher-level abstractions, such as the fre
 
 ### How do I safely get an ordinary pointer to reveal to the client?
 
-Neglecting platform-specific details of getting authority to address space and associating memory in the first place, almost all memory manipulated by `snmalloc` comes from the `AddressSpaceManager`.
-Its `reserve(size)` method returns a `capptr::Chunk<void>`; this pointer conveys full authority to the region of `size` at which it points.
+Almost all memory manipulated by `snmalloc` frontends comes via the backend's `alloc_chunk` method.
+The returned a `capptr::Chunk<void>`; this pointer is spatially bounded to the returned region (which is at least as big as requested).
+This pointer is, however, not restricted in its ability to manipulate the address space within its bounds; this permits the frontend to call `mmap` and `madvise` on pages therein.
+
 To derive a pointer that is suitable for client use, we must
 
 * further spatially refine the pointer: adjust its offset with `pointer_offset` and use `capptr_bound<T, capptr::bounds::AllocFull>` and
@@ -60,14 +86,14 @@ Nevertheless, if adding a new kind of deallocation, we suggest following the exi
 
 * Begin by calling `p_wild = capptr_from_client(p_raw)` to annotate it as `AllocWild` and avoid using the raw form thereafter.
 
-* Check the `Wild` pointer for domestication with `p_tame = capptr_domesticate<SharedState>(state_ptr, p_wild)`; `p_tame` will be a `capptr::Alloc` and will alias `p_wild` or will be `nullptr`.
+* Check the `Wild` pointer for domestication with `p_tame = capptr_domesticate<Config>(state_ptr, p_wild)`; `p_tame` will be a `capptr::Alloc` and will alias `p_wild` or will be `nullptr`.
   At this point, we have no more use for `p_wild`.
 
 * We may now probe the Pagemap; either `p_tame` is a pointer we have given out or `nullptr`, or this access may trap (especially on platforms where domestication is just a rubber stamp).
-  This will give us access to the associated `MetaEntry` and, if necessary, a `Chunk`-bounded pointer to the entire backing region.
+  This will give us access to the associated `MetaEntry` and, in general, a (path to a) `Chunk`-bounded pointer to the entire backing region.
 
 * If desired, we can now validate other attributes of the provided capability, including its length, base, and permissions.
-In fact, we can even go further and *reconstruct* the capability we would have given out for the indicated allocation, allowing for exact comparison.
+  In fact, we can even go further and *reconstruct* the capability we would have given out for the indicated allocation, allowing for exact comparison.
 
 Eventually we would like to reliably detect references to free objects as part of these flows, especially as frees can change the type of metadata found at the head of a chunk.
 When that is possible, we will add guidance that only reads of non-pointer scalar types are to be performed until after such tests have confirmed the object's liveness.
@@ -79,36 +105,18 @@ Because `CapPtr<T, B>` are not the kinds of pointers C++ expects to manipulate, 
 Instead, `CapPtr<T, B>` exposes `as_void()`, `template as_static<U>()`, and `template as_reinterpret<U>()` to perform `static_cast<void*>`, `static_cast<U*>`, and `reinterpret_cast<U*>` (respectively).
 Please use the first viable option from this list, reserving `reinterpret_cast` for more exciting circumstances.
 
-## StrictProvenance in More Detail
-
-Tracking pointer *provenance* and *bounds* enables software to constrain uses of *particular pointers* in ways that are not available with traditional protection mechanisms.
-For example, while code may *have* a pointer that spans its entire C stack, it may construct a pointer that authorizes access only to a particular stack allocation (e.g., a buffer) and use this latter pointer while copying data.
-Even if an attacker is able to control the length of the copy, the bounds imposed upon pointers involved can ensure that an overflow is impossible.
-(On the other hand, if the attacker can influence both the *bounds* and the copy length, an overflow may still be possible; in practice, however, the two concerns are often sufficiently separated.)
-For `malloc()` in particular, it is enormously beneficial to be able to impose bounds on returned pointers: it becomes impossible for allocator clients to use a pointer from `malloc()` to access adjacent allocations!
-(*Temporal* concerns still apply, in that live allocations can overlap prior, now-dead allocations.
-Stochastic defenses are employed within `snmalloc` and deterministic defenses are ongoing research at MSR.)
-
-Borrowing terminology from CHERI, we speak of the **authority** (to a subset of the address space) held by a pointer and will justify actions in terms of this authority.[^mmu-perms]
-While many kinds of authority can be envisioned, herein we will mean either
-
-* *spatial* authority to read/write/execute within a single *interval* within the address space, or
-* *vmmap* authority to request modification of the virtual page mappings for a given range of addresses.
-
-We may **bound** the authority of a pointer, deriving a new pointer with a subset of its progenitor's authority; this is assumed to be an ambient action requiring no additional authority.
-Dually, given two pointers, one with a subset of the other's authority, we may **amplify** the less-authorized, constructing a pointer with the same address but with increased authority (up to the held superset authority).[^amplifier-state]
-
 ## Constraints Imposed Upon Allocations
 
 `snmalloc` ensures that returned pointers are bounded to no more than the slab entry used to back each allocation.
+That is, **no two live allocations will have overlapping bounds**.
 It may be useful, mostly for debugging, to more precisely bound returned pointers to the actual allocation size,[^bounds-precision] but this is not required for security.
-The pointers returned from `alloc()` will also be stripped of their *vmmap* authority, if supported by the platform, ensuring that clients cannot manipulate the page mapping underlying `snmalloc`'s address space.
+The pointers returned from `alloc()` will also be stripped of their *vmem* authority, if supported by the platform, ensuring that clients cannot manipulate the page mapping underlying `snmalloc`'s address space.
 
 `realloc()`-ation has several policies that may be sensible.
-We choose a fairly simple one for the moment: resizing in ways that do not change the backing allocation's `snmalloc` size class are left in place, while any change to the size class triggers an allocate-copy-deallocate sequence.
-Even if `realloc()` leaves the object in place, the returned pointer should have its authority bounded as if this were a new allocation (and so may have less authority than `realloc()`'s pointer argument if sub-slab-entry bounds are being applied).
-(Notably, this policy is compatible with the existence of size-parameterized deallocation functions: the result of `realloc()` is always associated with the size class corresponding to the requested size.
-By contrast, shrinking in place in ways that changed the size class would require tracking the largest size ever associated with the allocation.)
+As a holdover from snmalloc v1, we have a fairly simple policy: resizing in ways that do not change the backing allocation's `snmalloc` size class are left in place, while any change to the size class triggers an allocate-copy-deallocate sequence.
+Even if `realloc()` leaves the object in place, the returned pointer should have its authority bounded as if this were a new allocation (and so the result may be a subset of the input to `realloc()`).
+
+Because snmalloc v2 no longer benefits from being provided the size of an allocated object (in, for example, dealloc), we may wish to adopt policies that allow objects to shrink in place beyond the lower bound of their sizeclass.
 
 ## Impact of Constraints On Deallocation
 
@@ -117,7 +125,16 @@ These operations relied on being able to take pointers out of bounds, and so pos
 The current edition of `snmalloc` instead follows pointers (starting from TLS or global roots), using address arithmetic only to derive indicies into these metadata pointers.
 
 When the allocator client returns memory (or otherwise refers to an allocation), we will be careful to use the *lower bound* address, not the indicated address per se, for looking up the allocation.
-The indicated address may be out of bounds, while `StrictProvenance` architectures should ensure that bounds are monotonically non-increasing, and so the lower bound will always be within the original allocation.
+The indicated address may be out of bounds, while `StrictProvenance` architectures should ensure that bounds are monotonically non-increasing, and so either
+
+* the lower bound will always be within the original allocation.
+* the pointer provided by the user will have zero length.
+
+If we must detach an address from the pointer, as in deallocation, we will generally reject zero-length pointers, as if they were nullptr.
+
+At the moment, **we permit a pointer to any part of an object to deallocate that object**.
+`snmalloc`'s design ensures that we will not create a new, free "object" at an interior pointer but will, instead, always be able to find the beginning and end of the object in question.
+In the future we are likely to be more strict, requiring authority to *the entire object* or at least *its lowest-address pointer-sized word* to free it.
 
 ## Object Lookup
 
@@ -125,24 +142,25 @@ The indicated address may be out of bounds, while `StrictProvenance` architectur
 To ensure that this function is not used as an amplification oracle, it must construct a return pointer with the same validity as its input even as it internally accesses metadata.
 We make `external_pointer` use `pointer_offset` on the user-provided pointer, ensuring that the result has no more authority than the client already held.
 
-XXX It may be worth requiring that the input pointer authorize the entire object?
-What are the desired security properties here?
-
 # Adapting the Implementation
 
 ## Design Overview
 
 For the majority of operations, no `StrictProvenance`-specific reasoning, beyond applying bounds, need be entertained.
-However, as regions of memory move into and out of an `AddressSpaceManagerCore` and `ChunkAllocator`, care must be taken to recover (and preserve) the internal, *vmmap*-authorizing pointers from the user's much more tightly bounded pointers.
+However, as regions of memory move out of (and back into) the allocator's client and fast free lists, care must be taken to recover (and preserve) the internal, *vmem*-authorizing pointers from the user's much more tightly bounded pointers.
 
 We store these internal pointers inside metadata, at different locations for each state:
 
-* For free chunks in `AddressSpaceManagerCore`s, the `next` pointers themselves will be internal pointers.
-  That is, the head of each list in the `AddressSpaceManagerCore` and the (coerced) next pointers in each `MetaEntry` will be suitable for internal use.
+* For free chunks in the "large `Range`" `Pipe`, we expect the `Range` objects themselves to work with these pointers.
+  In practice, these ranges place these pointers in global state or the `Pagemap` `MetaEntry`s directly.
 
-* Once outside the `AddressSpaceManager`, chunks have a `Metaslab` associated with them, and we can store internal pointers therein (in the `MetaCommon` `chunk` field).
+* Once outside the "large `Range`" `Pipe`, chunks holding heap objects will have a `SlabMetadata` structure associated with them, and we can store these high-authority pointers therein.
+  (Specifically, the `StrictProvenanceBackendSlabMetadata` class adds an `arena` member to the `SlabMetadata` in use.)
 
-Within each slab, there is one or more free list of objects.
+* Metadata chunks themselves, however, do not have `SlabMetadata` structures and are managed using a "small `Range`" `Pipe`.
+  These require special handling, considered below.
+
+Within each (data) slab, there is (at least) one free list of objects.
 We take the position that free list entries should be suitable for return, i.e., with authority bounded to their backing slab entry.
 (However, the *contents* of free memory may be dangerous to expose to the user and require clearing prior to handing out.)
 
@@ -150,7 +168,7 @@ We take the position that free list entries should be suitable for return, i.e.,
 
 We introduce a multi-dimensional space of bounds.  The facets are `enum class`-es in `snmalloc::capptr::dimension`.
 
-* `Spatial` captures the intended spatial extent / role of the pointer: either `Alloc`-ation or `Chunk`.
+* `Spatial` captures the intended spatial extent / role of the pointer: `Alloc`-ation, `Chunk`, or an entire `Arena`.
 
 * `AddressSpaceControl` captures whether the pointer conveys control of its address space.
 
@@ -161,11 +179,12 @@ This is enforced (loosely) using the `ConceptBound` C++20 concept.
 
 The namespace `snmalloc::capptr::bounds` contains particular points in the space of `capptr::bound<>` types:
 
-* bounded to a region of more than `MAX_SIZECLASS_SIZE` bytes with address space control, `Chunk`;
-* bounded to a region of more than `MAX_SIZECLASS_SIZE` bytes without address space control, `ChunkUser`;
+* bounded to a large region of the address space with address space control, `Arena`;
+* bounded to at least `MIN_CHUNK_SIZE` bytes with address space control, `Chunk`;
+* bounded to at least `MIN_CHUNK_SIZE` bytes without address space control, `ChunkUser`;
 * bounded to a smaller region but with address space control, `AllocFull`;
 * bounded to a smaller region and without address space control, `Alloc`;
-* bounded to a smaller region, without address space control, and unverified, `AllocWild`.
+* unverified but presumed to be to an `Alloc`-ation, `AllocWild`.
 
 ## Primitive Architectural Operations
 
@@ -173,17 +192,17 @@ Several new functions are introduced to AALs to capture primitives of the Archit
 
 * `CapPtr<T, Bout> capptr_bound(CapPtr<U, Bin> a, size_t sz)` spatially bounds the pointer `a` to have authority ranging only from its current target to its current target plus `sz` bytes (which must be within `a`'s authority).
   No imprecision in authority is permitted.
-  The bounds annotations must obey `capptr_is_spatial_refinement`.
+  The bounds annotations must obey `capptr_is_spatial_refinement`: the spatial dimension may change, but the others must be constant.
 
 Ultimately, all address space manipulated by `snmalloc` comes from its Platform's primitive allocator.
 An **arena** is a region returned by that provider.
-The `AddressSpaceManager` divides arenas into large allocations and manages their life cycles.
+The "large `Range`" `Pipe` serves to carve up `Arena`s; `Arena` pointers become `Chunk`s in the `backend`'s `alloc_chunk`.
 `snmalloc`'s (new, as of `snmalloc2`) heap layouts ensure that metadata associated with any object are reachable through globals, meaning no explicit amplification is required.
 
 ## Primitive Platform Operations
 
 * `CapPtr<void, Bout> capptr_to_user_address_control(CapPtr<T, Bin> f)` sheds authority over the address space from the `CapPtr`, on platforms where that is possible.
-On CheriBSD, specifically, this strips the `VMMAP` software permission, ensuring that clients cannot have the kernel manipulate heap pages.
+On CheriBSD, specifically, this strips the `VMAP` software permission, ensuring that clients cannot have the kernel manipulate heap pages.
 The annotation `Bout` is *computed* as a function of `Bin`.
 In future architectures, this is increasingly likely to be a no-op.
 
@@ -195,17 +214,37 @@ The annotation `Bout` is *computed* as a function of `Bin`.
 
 ## Constructed Operators
 
-* `capptr_chunk_is_alloc` converts a `capptr::ChunkUser<T>` to a `capptr::Alloc<T>` with no additional bounding; it is intended to ease auditing.
+* `capptr_from_client` wraps a `void *` as a `capptr::AllocWild<void>` to mark it as unverified.
+
+* `capptr_chunk_is_alloc` converts a `capptr::ChunkUser<T>` to a `capptr::Alloc<T>` without computational effect; it is intended to ease auditing.
 
 * `capptr_reveal` converts a `capptr::Alloc<void>` to a `void*`, annotating where we mean to return a pointer to the user.
 
 * `capptr_reveal_wild` converts a `capptr::AllocWild<void>` to a `void*`, annotating where we mean to return a *wild* pointer to the user (in `external_pointer`, e.g., where the result is just an offset of the user's pointer).
 
+## Metadata Bounds Handling
+
+We presently envision three policies for handling metadata:
+
+1. Metadata kept within `snmalloc` is always `Arena`-bounded; metadata handed to the user (the `Allocator`s themselves) are exactly bounded as `Alloc`.
+   Recycling internal metadata needs no amplification, and, as `Allocator`s are never deallocated, there is never a need to amplify an `Allocator*` back to a `Chunk`- or `Arena`-bounded pointer.
+
+2. All metadata is exactly bounded as `Alloc`.
+   Here, the "small `Range`" `Pipe` will require the ability to amplify back to `Chunk`- or `Arena`-bounded pointers when internal metadata is recycled.
+   We believe this is straightforwardly possible using a "provenance capturing `Range`" above the outermost `Range` in the small `Range` `Pipe`.
+
+3. No metadata is handed to the user; instead, opaque handles to `Allocator`s are given out.
+   (CHERI sealed capabilities are an excellent candidate for such handles, but are beyond the scope of this document.)
+   Here, it is no longer essential to bound any metadata pointers at all, though we may find it useful as a defence in depth.
+
+
+**At the time of this writing, policy 1 is in effect**; pointers to `Allocator`s are bounded only at the periphery of `snmalloc`.
+
 # Endnotes
 
 [^mmu-perms]: Pointer authority generally *intersects* with MMU-based authorization.
 For example, software using a pointer with both write and execute authority will still find that it cannot write to pages considered read-only by the MMU nor will it be able to execute non-executable pages.
-Generally speaking, `snmalloc` requires only read-write access to memory it manages and merely passes through other permissions, with the exception of *vmmap*, which it removes from any pointer it returns.
+Generally speaking, `snmalloc` requires only read-write access to memory it manages and merely passes through other permissions, with the exception of *vmem*, which it removes from any pointer it returns.
 
 [^amplifier-state]: As we are largely following the fat pointer model and its evolution into CHERI capabilities, we achieve amplification through a *stateful*, *software* mechanism, rather than an architectural mechanism.
 Specifically, the amplification mechanism will retain a superset of any authority it may be asked to reconstruct.

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -212,7 +212,8 @@ namespace snmalloc
         "capptr_bound must preserve non-spatial CapPtr dimensions");
 
       UNUSED(size);
-      return CapPtr<T, BOut>(a.template as_static<T>().unsafe_ptr());
+      return CapPtr<T, BOut>::unsafe_from(
+        a.template as_static<T>().unsafe_ptr());
     }
   };
 } // namespace snmalloc

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -246,6 +246,17 @@ namespace snmalloc
 
   template<AalFeatures F, SNMALLOC_CONCEPT(ConceptAAL) AAL = Aal>
   constexpr static bool aal_supports = (AAL::aal_features & F) == F;
+
+  /*
+   * The backend's leading-order response to StrictProvenance is entirely
+   * within its data structures and not actually anything to do with the
+   * architecture.  Rather than test aal_supports<StrictProvenance> or
+   * defined(__CHERI_PURE_CAPABILITY__) or such therein, using this
+   * backend_strict_provenance flag makes it easy to test a lot of machinery
+   * on non-StrictProvenance architectures.
+   */
+  static constexpr bool backend_strict_provenance =
+    aal_supports<StrictProvenance>;
 } // namespace snmalloc
 
 #ifdef __POINTER_WIDTH__

--- a/src/snmalloc/aal/aal_cheri.h
+++ b/src/snmalloc/aal/aal_cheri.h
@@ -86,7 +86,7 @@ namespace snmalloc
       }
 
       void* pb = __builtin_cheri_bounds_set_exact(a.unsafe_ptr(), size);
-      return CapPtr<T, BOut>(static_cast<T*>(pb));
+      return CapPtr<T, BOut>::unsafe_from(static_cast<T*>(pb));
     }
   };
 } // namespace snmalloc

--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -34,7 +34,8 @@ namespace snmalloc
   inline CapPtr<void, bounds>
   pointer_offset(CapPtr<T, bounds> base, size_t diff)
   {
-    return CapPtr<void, bounds>(pointer_offset(base.unsafe_ptr(), diff));
+    return CapPtr<void, bounds>::unsafe_from(
+      pointer_offset(base.unsafe_ptr(), diff));
   }
 
   /**
@@ -51,7 +52,8 @@ namespace snmalloc
   inline CapPtr<void, bounds>
   pointer_offset_signed(CapPtr<T, bounds> base, ptrdiff_t diff)
   {
-    return CapPtr<void, bounds>(pointer_offset_signed(base.unsafe_ptr(), diff));
+    return CapPtr<void, bounds>::unsafe_from(
+      pointer_offset_signed(base.unsafe_ptr(), diff));
   }
 
   /**
@@ -137,7 +139,8 @@ namespace snmalloc
     SNMALLOC_CONCEPT(capptr::ConceptBound) bounds>
   inline CapPtr<T, bounds> pointer_align_down(CapPtr<void, bounds> p)
   {
-    return CapPtr<T, bounds>(pointer_align_down<alignment, T>(p.unsafe_ptr()));
+    return CapPtr<T, bounds>::unsafe_from(
+      pointer_align_down<alignment, T>(p.unsafe_ptr()));
   }
 
   template<size_t alignment>
@@ -174,7 +177,8 @@ namespace snmalloc
     SNMALLOC_CONCEPT(capptr::ConceptBound) bounds>
   inline CapPtr<T, bounds> pointer_align_up(CapPtr<void, bounds> p)
   {
-    return CapPtr<T, bounds>(pointer_align_up<alignment, T>(p.unsafe_ptr()));
+    return CapPtr<T, bounds>::unsafe_from(
+      pointer_align_up<alignment, T>(p.unsafe_ptr()));
   }
 
   template<size_t alignment>
@@ -204,7 +208,8 @@ namespace snmalloc
   inline CapPtr<T, bounds>
   pointer_align_down(CapPtr<void, bounds> p, size_t alignment)
   {
-    return CapPtr<T, bounds>(pointer_align_down<T>(p.unsafe_ptr(), alignment));
+    return CapPtr<T, bounds>::unsafe_from(
+      pointer_align_down<T>(p.unsafe_ptr(), alignment));
   }
 
   /**
@@ -228,7 +233,8 @@ namespace snmalloc
   inline CapPtr<T, bounds>
   pointer_align_up(CapPtr<void, bounds> p, size_t alignment)
   {
-    return CapPtr<T, bounds>(pointer_align_up<T>(p.unsafe_ptr(), alignment));
+    return CapPtr<T, bounds>::unsafe_from(
+      pointer_align_up<T>(p.unsafe_ptr(), alignment));
   }
 
   /**

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -84,7 +84,7 @@ namespace snmalloc
         return {nullptr, nullptr};
       }
 
-      auto p = local_state.object_range.alloc_range(size);
+      auto p = local_state.get_object_range()->alloc_range(size);
 
 #ifdef SNMALLOC_TRACING
       message<1024>("Alloc chunk: {} ({})", p.unsafe_ptr(), size);
@@ -146,7 +146,7 @@ namespace snmalloc
       // the chunk.  On CHERI platforms this will need to be stored in the
       // SlabMetadata or similar.
       auto chunk = capptr::Chunk<void>::unsafe_from(alloc.unsafe_ptr());
-      local_state.object_range.dealloc_range(chunk, size);
+      local_state.get_object_range()->dealloc_range(chunk, size);
     }
 
     template<bool potentially_out_of_range = false>

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -140,12 +140,12 @@ namespace snmalloc
       Pagemap::set_metaentry(address_cast(alloc), size, t);
 
       local_state.get_meta_range().dealloc_range(
-        capptr::Chunk<void>(&slab_metadata), sizeof(SlabMetadata));
+        capptr::Chunk<void>::unsafe_from(&slab_metadata), sizeof(SlabMetadata));
 
       // On non-CHERI platforms, we don't need to re-derive to get a pointer to
       // the chunk.  On CHERI platforms this will need to be stored in the
       // SlabMetadata or similar.
-      capptr::Chunk<void> chunk{alloc.unsafe_ptr()};
+      auto chunk = capptr::Chunk<void>::unsafe_from(alloc.unsafe_ptr());
       local_state.object_range.dealloc_range(chunk, size);
     }
 

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -35,10 +35,10 @@ namespace snmalloc
      * does not avail itself of this degree of freedom.
      */
     template<typename T>
-    static capptr::Chunk<void>
+    static capptr::Arena<void>
     alloc_meta_data(LocalState* local_state, size_t size)
     {
-      capptr::Chunk<void> p;
+      capptr::Arena<void> p;
       if (local_state != nullptr)
       {
         p = local_state->get_meta_range().alloc_range_with_leftover(size);
@@ -84,7 +84,7 @@ namespace snmalloc
         return {nullptr, nullptr};
       }
 
-      auto p = local_state.get_object_range()->alloc_range(size);
+      capptr::Arena<void> p = local_state.get_object_range()->alloc_range(size);
 
 #ifdef SNMALLOC_TRACING
       message<1024>("Alloc chunk: {} ({})", p.unsafe_ptr(), size);
@@ -140,13 +140,13 @@ namespace snmalloc
       Pagemap::set_metaentry(address_cast(alloc), size, t);
 
       local_state.get_meta_range().dealloc_range(
-        capptr::Chunk<void>::unsafe_from(&slab_metadata), sizeof(SlabMetadata));
+        capptr::Arena<void>::unsafe_from(&slab_metadata), sizeof(SlabMetadata));
 
       // On non-CHERI platforms, we don't need to re-derive to get a pointer to
       // the chunk.  On CHERI platforms this will need to be stored in the
       // SlabMetadata or similar.
-      auto chunk = capptr::Chunk<void>::unsafe_from(alloc.unsafe_ptr());
-      local_state.get_object_range()->dealloc_range(chunk, size);
+      auto arena = capptr::Arena<void>::unsafe_from(alloc.unsafe_ptr());
+      local_state.get_object_range()->dealloc_range(arena, size);
     }
 
     template<bool potentially_out_of_range = false>

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -97,14 +97,13 @@ namespace snmalloc
 #ifdef SNMALLOC_TRACING
         message<1024>("Out of memory");
 #endif
-        return {p, nullptr};
+        return {nullptr, nullptr};
       }
 
       typename Pagemap::Entry t(meta, ras);
       Pagemap::set_metaentry(address_cast(p), size, t);
 
-      p = Aal::capptr_bound<void, capptr::bounds::Chunk>(p, size);
-      return {p, meta};
+      return {Aal::capptr_bound<void, capptr::bounds::Chunk>(p, size), meta};
     }
 
     /**

--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -78,7 +78,7 @@ namespace snmalloc
 
       // Push memory into the global range.
       range_to_pow_2_blocks<MIN_CHUNK_BITS>(
-        capptr::Chunk<void>(heap_base),
+        capptr::Chunk<void>::unsafe_from(heap_base),
         heap_length,
         [&](capptr::Chunk<void> p, size_t sz, bool) {
           typename LocalState::GlobalR g;
@@ -108,8 +108,8 @@ namespace snmalloc
 
       return CapPtr<
         T,
-        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>(
-        p.unsafe_ptr());
+        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>::
+        unsafe_from(p.unsafe_ptr());
     }
   };
 }

--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -78,9 +78,9 @@ namespace snmalloc
 
       // Push memory into the global range.
       range_to_pow_2_blocks<MIN_CHUNK_BITS>(
-        capptr::Chunk<void>::unsafe_from(heap_base),
+        capptr::Arena<void>::unsafe_from(heap_base),
         heap_length,
-        [&](capptr::Chunk<void> p, size_t sz, bool) {
+        [&](capptr::Arena<void> p, size_t sz, bool) {
           typename LocalState::GlobalR g;
           g.dealloc_range(p, sz);
         });

--- a/src/snmalloc/backend/meta_protected_range.h
+++ b/src/snmalloc/backend/meta_protected_range.h
@@ -103,12 +103,17 @@ namespace snmalloc
         Pagemap>,
       SmallBuddyRange>;
 
-  public:
-    using Stats = StatsCombiner<CentralObjectRange, CentralMetaRange>;
-
     ObjectRange object_range;
 
     MetaRange meta_range;
+
+  public:
+    using Stats = StatsCombiner<CentralObjectRange, CentralMetaRange>;
+
+    ObjectRange* get_object_range()
+    {
+      return &object_range;
+    }
 
     MetaRange& get_meta_range()
     {

--- a/src/snmalloc/backend/standard_range.h
+++ b/src/snmalloc/backend/standard_range.h
@@ -22,7 +22,7 @@ namespace snmalloc
   template<
     typename PAL,
     typename Pagemap,
-    typename Base = EmptyRange,
+    typename Base = EmptyRange<>,
     size_t MinSizeBits = MinBaseSizeBits<PAL>()>
   struct StandardLocalState : BaseLocalStateConstants
   {

--- a/src/snmalloc/backend_helpers/cheri_slabmetadata_mixin.h
+++ b/src/snmalloc/backend_helpers/cheri_slabmetadata_mixin.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "../pal/pal.h"
+
+namespace snmalloc
+{
+  /**
+   * In CHERI, we must retain, internal to the allocator, the authority to
+   * entire backing arenas, as there is no architectural mechanism to splice
+   * together two capabilities.  Additionally, these capabilities will retain
+   * the VMAP software permission, conveying our authority to manipulate the
+   * address space mappings for said arenas.
+   *
+   * We stash these pointers inside the SlabMetadata structures for parts of
+   * the address space for which SlabMetadata exists.  (In other parts of the
+   * system, we will stash them directly in the pagemap.)  This requires that
+   * we inherit from the FrontendSlabMetadata.
+   */
+  template<typename SlabMetadata>
+  class StrictProvenanceSlabMetadataMixin : public SlabMetadata
+  {
+    template<
+      SNMALLOC_CONCEPT(ConceptPAL) A1,
+      typename A2,
+      typename A3,
+      typename A4>
+    friend class BackendAllocator;
+
+    capptr::Arena<void> arena;
+
+    /* Set the arena pointer */
+    void arena_set(capptr::Arena<void> a)
+    {
+      arena = a;
+    }
+
+    /*
+     * Retrieve the stashed pointer for a chunk; the caller must ensure that
+     * this is the correct arena for the indicated chunk.  The latter is unused
+     * except in debug builds, as there is no architectural amplification.
+     */
+    capptr::Arena<void> arena_get(capptr::Alloc<void> c)
+    {
+      SNMALLOC_ASSERT(address_cast(arena) == address_cast(c));
+      UNUSED(c);
+      return arena;
+    }
+  };
+
+  /**
+   * A dummy implementation of StrictProvenanceBackendSlabMetadata that has no
+   * computational content, for use on non-StrictProvenance architectures.
+   */
+  template<typename SlabMetadata>
+  struct LaxProvenanceSlabMetadataMixin : public SlabMetadata
+  {
+    /* On non-StrictProvenance architectures, there's nothing to do */
+    void arena_set(capptr::Arena<void>) {}
+
+    /* Just a type sleight of hand, "amplifying" the non-existant bounds */
+    capptr::Arena<void> arena_get(capptr::Alloc<void> c)
+    {
+      return capptr::Arena<void>::unsafe_from(c.unsafe_ptr());
+    }
+  };
+
+#ifdef __cpp_concepts
+  /**
+   * Rather than having the backend test backend_strict_provenance in several
+   * places and doing sleights of hand with the type system, we encapsulate
+   * the amplification
+   */
+  template<typename T>
+  concept IsSlabMeta_Arena = requires(T* t, capptr::Arena<void> p)
+  {
+    {
+      t->arena_set(p)
+    }
+    ->ConceptSame<void>;
+  }
+  &&requires(T* t, capptr::Alloc<void> p)
+  {
+    {
+      t->arena_get(p)
+    }
+    ->ConceptSame<capptr::Arena<void>>;
+  };
+#endif
+
+} // namespace snmalloc

--- a/src/snmalloc/backend_helpers/commitrange.h
+++ b/src/snmalloc/backend_helpers/commitrange.h
@@ -18,9 +18,14 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
 
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+      static_assert(
+        ChunkBounds::address_space_control ==
+        capptr::dimension::AddressSpaceControl::Full);
+
       constexpr Type() = default;
 
-      capptr::Chunk<void> alloc_range(size_t size)
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
         SNMALLOC_ASSERT_MSG(
           (size % PAL::page_size) == 0,
@@ -33,7 +38,7 @@ namespace snmalloc
         return range;
       }
 
-      void dealloc_range(capptr::Chunk<void> base, size_t size)
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
       {
         SNMALLOC_ASSERT_MSG(
           (size % PAL::page_size) == 0,

--- a/src/snmalloc/backend_helpers/defaultpagemapentry.h
+++ b/src/snmalloc/backend_helpers/defaultpagemapentry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../mem/mem.h"
+#include "cheri_slabmetadata_mixin.h"
 
 namespace snmalloc
 {
@@ -63,6 +64,9 @@ namespace snmalloc
     SNMALLOC_FAST_PATH DefaultPagemapEntryT() = default;
   };
 
-  using DefaultPagemapEntry = DefaultPagemapEntryT<FrontendSlabMetadata>;
+  using DefaultPagemapEntry = DefaultPagemapEntryT<std::conditional_t<
+    backend_strict_provenance,
+    StrictProvenanceSlabMetadataMixin<FrontendSlabMetadata>,
+    LaxProvenanceSlabMetadataMixin<FrontendSlabMetadata>>>;
 
 } // namespace snmalloc

--- a/src/snmalloc/backend_helpers/defaultpagemapentry.h
+++ b/src/snmalloc/backend_helpers/defaultpagemapentry.h
@@ -9,7 +9,7 @@ namespace snmalloc
    * The following class could be replaced by:
    *
    * ```
-   * using DefaultPagemapEntry = FrontendMetaEntry<SlabMetadata>;
+   * using DefaultPagemapEntry = FrontendMetaEntry<FrontendSlabMetadata>;
    * ```
    *
    * The full form here provides an example of how to extend the pagemap
@@ -17,7 +17,8 @@ namespace snmalloc
    * constructs meta entries, it only ever reads them or modifies them in
    * place.
    */
-  class DefaultPagemapEntry : public FrontendMetaEntry<FrontendSlabMetadata>
+  template<typename SlabMetadata>
+  class DefaultPagemapEntryT : public FrontendMetaEntry<SlabMetadata>
   {
     /**
      * The private initialising constructor is usable only by this back end.
@@ -43,22 +44,25 @@ namespace snmalloc
      * metadata in meta entries when they are first constructed.
      */
     SNMALLOC_FAST_PATH
-    DefaultPagemapEntry(FrontendSlabMetadata* meta, uintptr_t ras)
-    : FrontendMetaEntry<FrontendSlabMetadata>(meta, ras)
+    DefaultPagemapEntryT(SlabMetadata* meta, uintptr_t ras)
+    : FrontendMetaEntry<SlabMetadata>(meta, ras)
     {}
 
     /**
      * Copy assignment is used only by the pagemap.
      */
-    DefaultPagemapEntry& operator=(const DefaultPagemapEntry& other)
+    DefaultPagemapEntryT& operator=(const DefaultPagemapEntryT& other)
     {
-      FrontendMetaEntry<FrontendSlabMetadata>::operator=(other);
+      FrontendMetaEntry<SlabMetadata>::operator=(other);
       return *this;
     }
 
     /**
      * Default constructor.  This must be callable from the pagemap.
      */
-    SNMALLOC_FAST_PATH DefaultPagemapEntry() = default;
+    SNMALLOC_FAST_PATH DefaultPagemapEntryT() = default;
   };
+
+  using DefaultPagemapEntry = DefaultPagemapEntryT<FrontendSlabMetadata>;
+
 } // namespace snmalloc

--- a/src/snmalloc/backend_helpers/empty_range.h
+++ b/src/snmalloc/backend_helpers/empty_range.h
@@ -3,6 +3,7 @@
 
 namespace snmalloc
 {
+  template<SNMALLOC_CONCEPT(capptr::ConceptBound) B = capptr::bounds::Chunk>
   class EmptyRange
   {
   public:
@@ -10,9 +11,11 @@ namespace snmalloc
 
     static constexpr bool ConcurrencySafe = true;
 
+    using ChunkBounds = B;
+
     constexpr EmptyRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t)
+    CapPtr<void, ChunkBounds> alloc_range(size_t)
     {
       return nullptr;
     }

--- a/src/snmalloc/backend_helpers/empty_range.h
+++ b/src/snmalloc/backend_helpers/empty_range.h
@@ -3,7 +3,7 @@
 
 namespace snmalloc
 {
-  template<SNMALLOC_CONCEPT(capptr::ConceptBound) B = capptr::bounds::Chunk>
+  template<SNMALLOC_CONCEPT(capptr::ConceptBound) B = capptr::bounds::Arena>
   class EmptyRange
   {
   public:

--- a/src/snmalloc/backend_helpers/globalrange.h
+++ b/src/snmalloc/backend_helpers/globalrange.h
@@ -11,7 +11,7 @@ namespace snmalloc
    */
   struct GlobalRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public StaticParent<ParentRange>
     {
       using StaticParent<ParentRange>::parent;
@@ -27,15 +27,17 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = true;
 
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+
       constexpr Type() = default;
 
-      capptr::Chunk<void> alloc_range(size_t size)
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
         FlagLock lock(spin_lock);
         return parent.alloc_range(size);
       }
 
-      void dealloc_range(capptr::Chunk<void> base, size_t size)
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
       {
         FlagLock lock(spin_lock);
         parent.dealloc_range(base, size);

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -208,7 +208,7 @@ namespace snmalloc
       bits::one_at_bit(MIN_REFILL_SIZE_BITS);
 
   public:
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -340,6 +340,8 @@ namespace snmalloc
       static constexpr bool Aligned = true;
 
       static constexpr bool ConcurrencySafe = false;
+
+      using ChunkBounds = capptr::bounds::Chunk;
 
       constexpr Type() = default;
 

--- a/src/snmalloc/backend_helpers/largebuddyrange.h
+++ b/src/snmalloc/backend_helpers/largebuddyrange.h
@@ -262,8 +262,9 @@ namespace snmalloc
       {
         range_to_pow_2_blocks<MIN_CHUNK_BITS>(
           base, length, [this](capptr::Chunk<void> base, size_t align, bool) {
-            auto overflow = capptr::Chunk<void>(reinterpret_cast<void*>(
-              buddy_large.add_block(base.unsafe_uintptr(), align)));
+            auto overflow =
+              capptr::Chunk<void>::unsafe_from(reinterpret_cast<void*>(
+                buddy_large.add_block(base.unsafe_uintptr(), align)));
 
             dealloc_overflow(overflow);
           });
@@ -358,7 +359,7 @@ namespace snmalloc
           return nullptr;
         }
 
-        auto result = capptr::Chunk<void>(
+        auto result = capptr::Chunk<void>::unsafe_from(
           reinterpret_cast<void*>(buddy_large.remove_block(size)));
 
         if (result != nullptr)
@@ -381,8 +382,9 @@ namespace snmalloc
           }
         }
 
-        auto overflow = capptr::Chunk<void>(reinterpret_cast<void*>(
-          buddy_large.add_block(base.unsafe_uintptr(), size)));
+        auto overflow =
+          capptr::Chunk<void>::unsafe_from(reinterpret_cast<void*>(
+            buddy_large.add_block(base.unsafe_uintptr(), size)));
         dealloc_overflow(overflow);
       }
     };

--- a/src/snmalloc/backend_helpers/logrange.h
+++ b/src/snmalloc/backend_helpers/logrange.h
@@ -14,7 +14,7 @@ namespace snmalloc
   template<size_t RangeName>
   struct LogRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -24,9 +24,11 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
 
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+
       constexpr Type() = default;
 
-      capptr::Chunk<void> alloc_range(size_t size)
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
 #ifdef SNMALLOC_TRACING
         message<1024>("Call alloc_range({}) on {}", size, RangeName);
@@ -39,7 +41,7 @@ namespace snmalloc
         return range;
       }
 
-      void dealloc_range(capptr::Chunk<void> base, size_t size)
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
       {
 #ifdef SNMALLOC_TRACING
         message<1024>(

--- a/src/snmalloc/backend_helpers/pagemapregisterrange.h
+++ b/src/snmalloc/backend_helpers/pagemapregisterrange.h
@@ -11,7 +11,7 @@ namespace snmalloc
     bool CanConsolidate = true>
   struct PagemapRegisterRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -23,7 +23,9 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
 
-      capptr::Chunk<void> alloc_range(size_t size)
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
         auto base = parent.alloc_range(size);
 

--- a/src/snmalloc/backend_helpers/palrange.h
+++ b/src/snmalloc/backend_helpers/palrange.h
@@ -28,8 +28,8 @@ namespace snmalloc
       if constexpr (pal_supports<AlignedAllocation, PAL>)
       {
         SNMALLOC_ASSERT(size >= PAL::minimum_alloc_size);
-        auto result =
-          capptr::Chunk<void>(PAL::template reserve_aligned<false>(size));
+        auto result = capptr::Chunk<void>::unsafe_from(
+          PAL::template reserve_aligned<false>(size));
 
 #ifdef SNMALLOC_TRACING
         message<1024>("Pal range alloc: {} ({})", result.unsafe_ptr(), size);
@@ -38,7 +38,7 @@ namespace snmalloc
       }
       else
       {
-        auto result = capptr::Chunk<void>(PAL::reserve(size));
+        auto result = capptr::Chunk<void>::unsafe_from(PAL::reserve(size));
 
 #ifdef SNMALLOC_TRACING
         message<1024>("Pal range alloc: {} ({})", result.unsafe_ptr(), size);

--- a/src/snmalloc/backend_helpers/palrange.h
+++ b/src/snmalloc/backend_helpers/palrange.h
@@ -14,11 +14,11 @@ namespace snmalloc
     // need to be changed.
     static constexpr bool ConcurrencySafe = true;
 
-    using ChunkBounds = capptr::bounds::Chunk;
+    using ChunkBounds = capptr::bounds::Arena;
 
     constexpr PalRange() = default;
 
-    capptr::Chunk<void> alloc_range(size_t size)
+    capptr::Arena<void> alloc_range(size_t size)
     {
       if (bits::next_pow2_bits(size) >= bits::BITS - 1)
       {
@@ -28,7 +28,7 @@ namespace snmalloc
       if constexpr (pal_supports<AlignedAllocation, PAL>)
       {
         SNMALLOC_ASSERT(size >= PAL::minimum_alloc_size);
-        auto result = capptr::Chunk<void>::unsafe_from(
+        auto result = capptr::Arena<void>::unsafe_from(
           PAL::template reserve_aligned<false>(size));
 
 #ifdef SNMALLOC_TRACING
@@ -38,7 +38,7 @@ namespace snmalloc
       }
       else
       {
-        auto result = capptr::Chunk<void>::unsafe_from(PAL::reserve(size));
+        auto result = capptr::Arena<void>::unsafe_from(PAL::reserve(size));
 
 #ifdef SNMALLOC_TRACING
         message<1024>("Pal range alloc: {} ({})", result.unsafe_ptr(), size);

--- a/src/snmalloc/backend_helpers/palrange.h
+++ b/src/snmalloc/backend_helpers/palrange.h
@@ -14,6 +14,8 @@ namespace snmalloc
     // need to be changed.
     static constexpr bool ConcurrencySafe = true;
 
+    using ChunkBounds = capptr::bounds::Chunk;
+
     constexpr PalRange() = default;
 
     capptr::Chunk<void> alloc_range(size_t size)

--- a/src/snmalloc/backend_helpers/range_helpers.h
+++ b/src/snmalloc/backend_helpers/range_helpers.h
@@ -4,8 +4,11 @@
 
 namespace snmalloc
 {
-  template<size_t MIN_BITS, typename F>
-  void range_to_pow_2_blocks(capptr::Chunk<void> base, size_t length, F f)
+  template<
+    size_t MIN_BITS,
+    SNMALLOC_CONCEPT(capptr::ConceptBound) B,
+    typename F>
+  void range_to_pow_2_blocks(CapPtr<void, B> base, size_t length, F f)
   {
     auto end = pointer_offset(base, length);
     base = pointer_align_up(base, bits::one_at_bit(MIN_BITS));

--- a/src/snmalloc/backend_helpers/smallbuddyrange.h
+++ b/src/snmalloc/backend_helpers/smallbuddyrange.h
@@ -145,7 +145,7 @@ namespace snmalloc
 
   struct SmallBuddyRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -186,6 +186,8 @@ namespace snmalloc
       static_assert(ParentRange::Aligned, "ParentRange must be aligned");
 
       static constexpr bool ConcurrencySafe = false;
+
+      using ChunkBounds = capptr::bounds::Chunk;
 
       constexpr Type() = default;
 

--- a/src/snmalloc/backend_helpers/smallbuddyrange.h
+++ b/src/snmalloc/backend_helpers/smallbuddyrange.h
@@ -204,10 +204,7 @@ namespace snmalloc
 
       CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
-        if (size >= MIN_CHUNK_SIZE)
-        {
-          return parent.alloc_range(size);
-        }
+        SNMALLOC_ASSERT(size < MIN_CHUNK_SIZE);
 
         auto result = buddy_small.remove_block(size);
         if (result != nullptr)
@@ -221,7 +218,7 @@ namespace snmalloc
 
       CapPtr<void, ChunkBounds> alloc_range_with_leftover(size_t size)
       {
-        SNMALLOC_ASSERT(size <= MIN_CHUNK_SIZE);
+        SNMALLOC_ASSERT(size < MIN_CHUNK_SIZE);
 
         auto rsize = bits::next_pow2(size);
 
@@ -239,11 +236,7 @@ namespace snmalloc
 
       void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
       {
-        if (size >= MIN_CHUNK_SIZE)
-        {
-          parent.dealloc_range(base, size);
-          return;
-        }
+        SNMALLOC_ASSERT(size < MIN_CHUNK_SIZE);
 
         add_range(base, size);
       }

--- a/src/snmalloc/backend_helpers/smallbuddyrange.h
+++ b/src/snmalloc/backend_helpers/smallbuddyrange.h
@@ -33,7 +33,7 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT((address_cast(r) & MASK) == 0);
       if (r == nullptr)
-        *ptr = capptr::Chunk<FreeChunk>(
+        *ptr = capptr::Chunk<FreeChunk>::unsafe_from(
           reinterpret_cast<FreeChunk*>((*ptr).unsafe_uintptr() & MASK));
       else
         // Preserve lower bit.
@@ -71,7 +71,8 @@ namespace snmalloc
         if (new_is_red)
         {
           if (old_addr == nullptr)
-            *r = capptr::Chunk<FreeChunk>(reinterpret_cast<FreeChunk*>(MASK));
+            *r = capptr::Chunk<FreeChunk>::unsafe_from(
+              reinterpret_cast<FreeChunk*>(MASK));
           else
             *r = pointer_offset(old_addr, MASK).template as_static<FreeChunk>();
         }

--- a/src/snmalloc/backend_helpers/statsrange.h
+++ b/src/snmalloc/backend_helpers/statsrange.h
@@ -12,7 +12,7 @@ namespace snmalloc
    */
   struct StatsRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -25,9 +25,11 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
 
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+
       constexpr Type() = default;
 
-      capptr::Chunk<void> alloc_range(size_t size)
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
       {
         auto result = parent.alloc_range(size);
         if (result != nullptr)
@@ -43,7 +45,7 @@ namespace snmalloc
         return result;
       }
 
-      void dealloc_range(capptr::Chunk<void> base, size_t size)
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
       {
         current_usage -= size;
         parent.dealloc_range(base, size);

--- a/src/snmalloc/backend_helpers/subrange.h
+++ b/src/snmalloc/backend_helpers/subrange.h
@@ -12,7 +12,7 @@ namespace snmalloc
   template<typename PAL, size_t RATIO_BITS>
   struct SubRange
   {
-    template<typename ParentRange = EmptyRange>
+    template<typename ParentRange = EmptyRange<>>
     class Type : public ContainsParent<ParentRange>
     {
       using ContainsParent<ParentRange>::parent;
@@ -24,7 +24,9 @@ namespace snmalloc
 
       static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
 
-      capptr::Chunk<void> alloc_range(size_t sub_size)
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+
+      CapPtr<void, ChunkBounds> alloc_range(size_t sub_size)
       {
         SNMALLOC_ASSERT(bits::is_pow2(sub_size));
 

--- a/src/snmalloc/mem/backend_concept.h
+++ b/src/snmalloc/mem/backend_concept.h
@@ -122,7 +122,7 @@ namespace snmalloc
     {
       Backend::template alloc_meta_data<void*>(local_state, size)
     }
-    ->ConceptSame<capptr::Chunk<void>>;
+    ->ConceptSame<capptr::Arena<void>>;
   }
   &&requires(
     LocalState& local_state,

--- a/src/snmalloc/mem/backend_wrappers.h
+++ b/src/snmalloc/mem/backend_wrappers.h
@@ -102,8 +102,8 @@ namespace snmalloc
       UNUSED(ls);
       return CapPtr<
         T,
-        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>(
-        p.unsafe_ptr());
+        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>::
+        unsafe_from(p.unsafe_ptr());
     }
   }
 } // namespace snmalloc

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -506,10 +506,10 @@ namespace snmalloc
          * The front of the queue has already been validated; just change the
          * annotating type.
          */
-        auto domesticate_first = [](freelist::QueuePtr p)
-                                   SNMALLOC_FAST_PATH_LAMBDA {
-                                     return freelist::HeadPtr(p.unsafe_ptr());
-                                   };
+        auto domesticate_first =
+          [](freelist::QueuePtr p) SNMALLOC_FAST_PATH_LAMBDA {
+            return freelist::HeadPtr::unsafe_from(p.unsafe_ptr());
+          };
         message_queue().dequeue(key_global, domesticate_first, domesticate, cb);
       }
       else

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -270,7 +270,8 @@ namespace snmalloc
       inline static BQueuePtr<BQueue> encode_next(
         address_t curr, BHeadPtr<BView, BQueue> next, const FreeListKey& key)
       {
-        return BQueuePtr<BQueue>(code_next(curr, next.unsafe_ptr(), key));
+        return BQueuePtr<BQueue>::unsafe_from(
+          code_next(curr, next.unsafe_ptr(), key));
       }
 
       /**
@@ -294,7 +295,8 @@ namespace snmalloc
       inline static BHeadPtr<BView, BQueue> decode_next(
         address_t curr, BHeadPtr<BView, BQueue> next, const FreeListKey& key)
       {
-        return BHeadPtr<BView, BQueue>(code_next(curr, next.unsafe_ptr(), key));
+        return BHeadPtr<BView, BQueue>::unsafe_from(
+          code_next(curr, next.unsafe_ptr(), key));
       }
 
       template<
@@ -543,7 +545,7 @@ namespace snmalloc
 
       Object::BHeadPtr<BView, BQueue> cast_head(uint32_t ix)
       {
-        return Object::BHeadPtr<BView, BQueue>(
+        return Object::BHeadPtr<BView, BQueue>::unsafe_from(
           static_cast<Object::T<BQueue>*>(head[ix]));
       }
 
@@ -715,8 +717,8 @@ namespace snmalloc
         // this is doing a CONTAINING_RECORD like cast to get back
         // to the actual object.  This isn't true if the builder is
         // empty, but you are not allowed to call this in the empty case.
-        auto last =
-          Object::BHeadPtr<BView, BQueue>(Object::from_next_ptr(cast_end(0)));
+        auto last = Object::BHeadPtr<BView, BQueue>::unsafe_from(
+          Object::from_next_ptr(cast_end(0)));
         init();
         return {first, last};
       }

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -23,7 +23,7 @@ namespace snmalloc
     /// Used by the pool for chaining together entries when not in use.
     std::atomic<T*> next{nullptr};
     /// Used by the pool to keep the list of all entries ever created.
-    T* list_next;
+    capptr::Alloc<T> list_next;
     std::atomic_flag in_use = ATOMIC_FLAG_INIT;
 
   public:

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -115,7 +115,7 @@ namespace snmalloc
             if constexpr (Config::Options.QueueHeadsAreTame)
             {
               auto domesticate_nop = [](freelist::QueuePtr p) {
-                return freelist::HeadPtr(p.unsafe_ptr());
+                return freelist::HeadPtr::unsafe_from(p.unsafe_ptr());
               };
               remote->enqueue(first, last, key, domesticate_nop);
             }

--- a/src/snmalloc/pal/pal.h
+++ b/src/snmalloc/pal/pal.h
@@ -90,7 +90,8 @@ namespace snmalloc
     CapPtr<T, capptr::user_address_control_type<B>>>
   capptr_to_user_address_control(CapPtr<T, B> p)
   {
-    return CapPtr<T, capptr::user_address_control_type<B>>(p.unsafe_ptr());
+    return CapPtr<T, capptr::user_address_control_type<B>>::unsafe_from(
+      p.unsafe_ptr());
   }
 
   template<

--- a/src/snmalloc/pal/pal_freebsd.h
+++ b/src/snmalloc/pal/pal_freebsd.h
@@ -135,7 +135,7 @@ namespace snmalloc
           return nullptr;
         }
       }
-      return CapPtr<T, capptr::user_address_control_type<B>>(
+      return CapPtr<T, capptr::user_address_control_type<B>>::unsafe_from(
         __builtin_cheri_perms_and(
           p.unsafe_ptr(), ~static_cast<unsigned int>(CHERI_PERM_SW_VMEM)));
     }

--- a/src/test/func/cheri/cheri.cc
+++ b/src/test/func/cheri/cheri.cc
@@ -1,0 +1,153 @@
+#include <iostream>
+
+#if defined(SNMALLOC_PASS_THROUGH) || !defined(__CHERI_PURE_CAPABILITY__)
+// This test does not make sense in pass-through or w/o CHERI
+int main()
+{
+  return 0;
+}
+#else
+
+// #  define SNMALLOC_TRACING
+
+#  include <cheri/cherireg.h>
+#  include <snmalloc/snmalloc.h>
+#  include <stddef.h>
+
+#  if defined(__FreeBSD__)
+#    include <sys/mman.h>
+#  endif
+
+using namespace snmalloc;
+
+bool cap_len_is(void* cap, size_t expected)
+{
+  return __builtin_cheri_length_get(cap) == expected;
+}
+
+bool cap_vmem_perm_is(void* cap, bool expected)
+{
+#  if defined(CHERI_PERM_SW_VMEM)
+  return !!(__builtin_cheri_perms_get(cap) & CHERI_PERM_SW_VMEM) == expected;
+#  else
+#    warning "Don't know how to check VMEM permission bit"
+#  endif
+}
+
+int main()
+{
+
+#  if defined(__FreeBSD__)
+  {
+    size_t pagesize[8];
+    int err = getpagesizes(pagesize, sizeof(pagesize) / sizeof(pagesize[0]));
+    SNMALLOC_CHECK(err > 0);
+    SNMALLOC_CHECK(pagesize[0] == OS_PAGE_SIZE);
+  }
+#  endif
+
+  auto alloc = get_scoped_allocator();
+
+  message("Grab small object");
+  {
+    static const size_t sz = 128;
+    void* o1 = alloc->alloc(sz);
+    SNMALLOC_CHECK(cap_len_is(o1, sz));
+    SNMALLOC_CHECK(cap_vmem_perm_is(o1, false));
+    alloc->dealloc(o1);
+  }
+
+  /*
+   * This large object is sized to end up in our alloc's local buddy allocators
+   * when it's released.
+   */
+  message("Grab large object");
+  ptraddr_t alarge;
+  {
+    static const size_t sz = 1024 * 1024;
+    void* olarge = alloc->alloc(sz);
+    alarge = address_cast(olarge);
+    SNMALLOC_CHECK(cap_len_is(olarge, sz));
+    SNMALLOC_CHECK(cap_vmem_perm_is(olarge, false));
+
+    static_cast<uint8_t*>(olarge)[128] = 'x';
+    static_cast<uint8_t*>(olarge)[128 + OS_PAGE_SIZE] = 'y';
+
+#  if defined(__FreeBSD__)
+    static constexpr int irm =
+      MINCORE_INCORE | MINCORE_REFERENCED | MINCORE_MODIFIED;
+    char ic[2];
+    int err = mincore(olarge, 2 * OS_PAGE_SIZE, ic);
+    SNMALLOC_CHECK(err == 0);
+    SNMALLOC_CHECK((ic[0] & irm) == irm);
+    SNMALLOC_CHECK((ic[1] & irm) == irm);
+    message("Large object in core; good");
+#  endif
+
+    alloc->dealloc(olarge);
+  }
+
+  message("Grab large object again, verify reuse");
+  {
+    static const size_t sz = 1024 * 1024;
+    errno = 0;
+    void* olarge = alloc->alloc<YesZero>(sz);
+    int err = errno;
+
+    SNMALLOC_CHECK(alarge == address_cast(olarge));
+    SNMALLOC_CHECK(err == 0);
+
+#  if defined(__FreeBSD__)
+    /*
+     * Verify that the zeroing took place by mmap, which should mean that the
+     * first two pages are not in core.  This implies that snmalloc successfully
+     * re-derived a Chunk- or Arena-bounded pointer and used that, and its VMAP
+     * permission, to tear pages out of the address space.
+     */
+    static constexpr int irm =
+      MINCORE_INCORE | MINCORE_REFERENCED | MINCORE_MODIFIED;
+    char ic[2];
+    err = mincore(olarge, 2 * OS_PAGE_SIZE, ic);
+    SNMALLOC_CHECK(err == 0);
+    SNMALLOC_CHECK((ic[0] & irm) == 0);
+    SNMALLOC_CHECK((ic[1] & irm) == 0);
+    message("Large object not in core; good");
+#  endif
+
+    SNMALLOC_CHECK(static_cast<uint8_t*>(olarge)[128] == '\0');
+    SNMALLOC_CHECK(static_cast<uint8_t*>(olarge)[128 + OS_PAGE_SIZE] == '\0');
+    SNMALLOC_CHECK(cap_len_is(olarge, sz));
+    SNMALLOC_CHECK(cap_vmem_perm_is(olarge, false));
+
+    alloc->dealloc(olarge);
+  }
+
+  /*
+   * Grab another CoreAlloc pointer from the pool and examine it.
+   *
+   * CoreAlloc-s come from the metadata pools of snmalloc, and so do not flow
+   * through the usual allocation machinery.
+   */
+  message("Grab CoreAlloc from pool for inspection");
+  {
+    static_assert(
+      std::is_same_v<decltype(alloc.alloc), LocalAllocator<StandardConfig>>);
+
+    LocalCache lc{&StandardConfig::unused_remote};
+    auto* ca = AllocPool<StandardConfig>::acquire(&lc);
+
+    SNMALLOC_CHECK(cap_len_is(ca, sizeof(*ca)));
+    SNMALLOC_CHECK(cap_vmem_perm_is(ca, false));
+
+    /*
+     * Putting ca back into the pool would require unhooking our local cache,
+     * and that requires accessing privates.  Since it's pretty harmless to do
+     * so here at the end of our test, just leak it.
+     */
+  }
+
+  message("CHERI checks OK");
+  return 0;
+}
+
+#endif

--- a/src/test/func/domestication/domestication.cc
+++ b/src/test/func/domestication/domestication.cc
@@ -108,8 +108,8 @@ namespace snmalloc
 
       return CapPtr<
         T,
-        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>(
-        p.unsafe_ptr());
+        typename B::template with_wildness<capptr::dimension::Wildness::Tame>>::
+        unsafe_from(p.unsafe_ptr());
     }
   };
 

--- a/src/test/func/malloc/malloc.cc
+++ b/src/test/func/malloc/malloc.cc
@@ -55,6 +55,14 @@ void check_result(size_t size, size_t align, void* p, int err, bool null)
     INFO("Cheri size is {}, but required to be {}.", cheri_size, alloc_size);
     failed = true;
   }
+#  if defined(CHERI_PERM_SW_VMEM)
+  const auto cheri_perms = __builtin_cheri_perms_get(p);
+  if (cheri_perms & CHERI_PERM_SW_VMEM)
+  {
+    INFO("Cheri permissions include VMEM authority");
+    failed = true;
+  }
+#  endif
   if (p != nullptr)
   {
     /*


### PR DESCRIPTION
Here we go again.  This gets easier every time, at least.  Especially after all the recent backend refactoring, I would almost dare suggest it was _straightforward_.  This PR should be reviewable commit-by-commit.  It has a prefix of preparatory NFC commits that don't (well, aren't supposed to) change anything and then the rest that actually do something.

This series re-introduces `capptr::Arena` and friends and pushes that through the backend ranges.  The `LargeBuddyRange`-s always deal with `Arena`-bounded pointers in both directions; their consumers -- the `backend` `chunk_alloc`-ator and the `SmallBuddyRange` -- know how to tighten those down to `Chunk`-bounded pointers.  For chunks that are being handed out to the frontend as such, the backend stashes the `Arena`-bounded authority inside the `SlabMetadata` using a wrapper type (for non-`StrictProvenance` architectures, there is a similar wrapper type in the same place that provides the usual sleight of hand).  For chunks used by the `SmallBuddyRange`, it relies on a `ProvenanceCaptureRange` to hold the `Arena`-bounded authority within the `Pagemap` itself, rather like the `LargeBuddyRange`, while communicating using `Chunk`-bounded pointers with its child range(s).

This is missing the increased care around zeroing out internal pointers present in #510, so for that reason, if no other, is probably not ready to merge.