### PR TITLE
memcpy vs StrictProvenance

### DIFF
--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -280,4 +280,14 @@ namespace snmalloc
     return pointer_diff_signed(base.unsafe_ptr(), cursor.unsafe_ptr());
   }
 
+  /**
+   * Compute the degree to which an address is misaligned relative to some
+   * putative alignment.
+   */
+  template<size_t alignment>
+  inline size_t address_misalignment(address_t a)
+  {
+    return static_cast<size_t>(a - pointer_align_down<alignment>(a));
+  }
+
 } // namespace snmalloc


### PR DESCRIPTION
More Lincoln Logs-style work, mostly: assemble existing pieces differently for a `StrictProvenance` / CHERI-aware `memcpy`.  As documented, there are two constraints in tension:

- We must use capability load and store instructions wherever possible, so that our `memcpy` obliviously copies capabilities (and preserves tags) during its operation.
- We cannot use capability load or store instructions at misaligned addresses, since those (are permitted to) trap.

Therefore, we have three cases to consider:
1. copies too small to move a capability: use a jump table of _data word_ copies and be done with it
2. "equally (mis)aligned" source and targets: these may have a (naturally aligned) capability inside the source that would also land at a naturally aligned destination address: perform _data word_ copies to get us up to `alignof(void*)`, perform _capability_ copies, and then go back to doing _data word_ copies to get us up to the end.
3. differently aligned source and targets: since at least one of these must be misaligned relative to capabilities, use exclusively _data word_ copies, which will result in the destination having all capability tags clear.

The only part of this that isn't (relatively) straightforward assembly of existing pieces is the change to `copy_one` to not use `__builtin_memcpy_inline` on `StrictProvenance` architectures to work around (or work with?) https://github.com/CTSRD-CHERI/llvm-project/issues/623 .