### PR TITLE
Support older linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
-include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 include(CMakeDependentOption)
 
 option(SNMALLOC_HEADER_ONLY_LIBRARY "Use snmalloc has a header-only library" OFF)
@@ -112,7 +112,7 @@ int main() {
 # but some might provide the necessary flags via linux/random.h
 # the __has_include macro isn't working properly on all platforms for that header
 # this is why we check its existence here
-CHECK_INCLUDE_FILE(linux/random.h SNMALLOC_HAS_LINUX_RANDOM_H)
+CHECK_INCLUDE_FILE_CXX(linux/random.h SNMALLOC_HAS_LINUX_RANDOM_H)
 
 # Provide as function so other projects can reuse
 # FIXME: This modifies some variables that may or may not be the ones that

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
+include(CheckIncludeFile)
 include(CMakeDependentOption)
 
 option(SNMALLOC_HEADER_ONLY_LIBRARY "Use snmalloc has a header-only library" OFF)
@@ -105,6 +106,14 @@ int main() {
   return res;
 }
 " SNMALLOC_PLATFORM_HAS_GETENTROPY)
+
+# check if linux/random.h is available
+# older libcs might not have sys/random.h
+# but some might provide the necessary flags via linux/random.h
+# the __has_include macro isn't working properly on all platforms for that header
+# this is why we check its existence here
+CHECK_INCLUDE_FILE(linux/random.h SNMALLOC_HAS_LINUX_RANDOM_H)
+
 # Provide as function so other projects can reuse
 # FIXME: This modifies some variables that may or may not be the ones that
 # provide flags and so is broken by design.  It should be removed once Verona
@@ -203,6 +212,7 @@ add_as_define(SNMALLOC_QEMU_WORKAROUND)
 add_as_define(SNMALLOC_TRACING)
 add_as_define(SNMALLOC_CI_BUILD)
 add_as_define(SNMALLOC_PLATFORM_HAS_GETENTROPY)
+add_as_define(SNMALLOC_HAS_LINUX_RANDOM_H)
 if (SNMALLOC_NO_REALLOCARRAY)
   add_as_define(SNMALLOC_NO_REALLOCARRAY)
 endif()

--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -8,7 +8,9 @@
 #  include <sys/mman.h>
 #  include <sys/prctl.h>
 #  include <syscall.h>
-#  if !defined(GRND_NONBLOCK) && __has_include(<linux/random.h>)
+// __has_include does not reliably determine if we actually have linux/random.h
+// available
+#  if defined(SNMALLOC_HAS_LINUX_RANDOM_H)
 #    include <linux/random.h>
 #  endif
 


### PR DESCRIPTION
The particular system to support here is centos 7 with 

* kernel-headers for kernel 3.10.0
* glibc 2.17
Issued with that platform:

* `MADV_FREE` undefined
* `GRND_NONBLOCK` not defined as there is no `sys/random.h`

Fixes #544 