### PR TITLE
Fix wrong ifdef in pal_linux.h

### DIFF
--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -46,7 +46,7 @@ namespace snmalloc
      * Fallback to MADV_DONTNEED on older kernels
      */
     static constexpr int madvise_free_flags =
-#  ifdef SNMALLOC_HAS_LINUX_RANDOM_H
+#  if defined(MADV_FREE)
       MADV_FREE
 #  else
       MADV_DONTNEED


### PR DESCRIPTION
Horribly sorry, i fatfingered the wrong ifdef around the missing `MADV_FREE` flag on older linux systems (kernel-headers < 4.5).