### PR TITLE
In Checked mode use nullptr for malloc(0)

### DIFF
--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -178,7 +178,11 @@ namespace snmalloc
         // Deal with alloc zero of with a small object here.
         // Alternative semantics giving nullptr is also allowed by the
         // standard.
+#ifdef SNMALLOC_CHECK_CLIENT
+        return nullptr;
+#else
         return small_alloc<NoZero>(1);
+#endif
       }
 
       return check_init([&](CoreAlloc* core_alloc) {


### PR DESCRIPTION
The spec allows malloc(0) to return an actual allocation, or nullptr.
Some code has compatibility issues with assuming if malloc returns nullptr
then the memory is full.  Hence, we normally use malloc(0) to return an
allocation.

In the checked client it seems better to return nullptr, and I believe
we have more opportunity for clients to find errors with it.