### PR TITLE
{WIP] Loongarch Support

### DIFF
--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -41,6 +41,10 @@
 #  define PLATFORM_IS_RISCV
 #endif
 
+#if defined (__loongarch__)
+#  define PLATFORM_IS_LOONGARCH
+#endif
+
 namespace snmalloc
 {
   /**
@@ -230,6 +234,8 @@ namespace snmalloc
 #  include "aal_sparc.h"
 #elif defined(PLATFORM_IS_RISCV)
 #  include "aal_riscv.h"
+#elif defined(PLATFORM_IS_LOONGARCH)
+#  include "aal_loongarch.h"
 #endif
 
 #if defined(__CHERI_PURE_CAPABILITY__)

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -41,7 +41,7 @@
 #  define PLATFORM_IS_RISCV
 #endif
 
-#if defined (__loongarch__)
+#if defined(__loongarch__)
 #  define PLATFORM_IS_LOONGARCH
 #endif
 

--- a/src/snmalloc/aal/aal_consts.h
+++ b/src/snmalloc/aal/aal_consts.h
@@ -33,6 +33,7 @@ namespace snmalloc
     X86,
     X86_SGX,
     Sparc,
-    RISCV
+    RISCV,
+    LoongArch
   };
 } // namespace snmalloc

--- a/src/snmalloc/aal/aal_loongarch.h
+++ b/src/snmalloc/aal/aal_loongarch.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#if __SIZEOF_POINTER__ == 8
+#  define SNMALLOC_VA_BITS_64
+#else
+#  define SNMALLOC_VA_BITS_32
+#endif
+
+#include <cstddef>
+namespace snmalloc
+{
+  /**
+   * Loongarch-specific architecture abstraction layer.
+   */
+  class AAL_LoongArch
+  {
+  public:
+    /**
+     * Bitmap of AalFeature flags
+     */
+    static constexpr uint64_t aal_features =
+      IntegerPointers | NoCpuCycleCounters;
+
+    static constexpr enum AalName aal_name = LoongArch;
+
+    static constexpr size_t smallest_page_size = 0x1000;
+
+    /**
+     * On pipelined processors, notify the core that we are in a spin loop and
+     * that speculative execution past this point may not be a performance gain.
+     */
+    static inline void pause()
+    {
+      __asm__ __volatile__("dbar 0" : : : "memory");
+    }
+
+    /**
+     * PRELD reads a cache-line of data from memory in advance into the Cache.
+     * The access address is the 12bit immediate number of the value in the
+     * general register rj plus the symbol extension.
+     *
+     * The processor learns from the hint in the PRELD instruction what type
+     * will be acquired and which level of Cache the data to be taken back fill
+     * in, hint has 32 optional values (0 to 31), 0 represents load to level 1
+     * Cache If the Cache attribute of the access address of the PRELD
+     * instruction is not cached, then the instruction cannot generate a memory
+     * access action and is treated as a NOP instruction. The PRELD instruction
+     * will not trigger any exceptions related to MMU or address.
+     */
+    static inline void prefetch(void* ptr)
+    {
+      __asm__ volatile("preld 0, %0, 0" : "=r"(ptr));
+    }
+  };
+
+  using AAL_Arch = AAL_LoongArch;
+} // namespace snmalloc


### PR DESCRIPTION
QEMU 7.1 will begin loongarch support: https://wiki.qemu.org/ChangeLog/7.1#LoongArch.

Currently, everything works but all `check` variants:

```
qemu-loongarch64 -strace /home/schrodinger/Downloads/loongarch64-clfs-6.0-cross-tools-gcc_and_clang-full/cross-tools/target/usr/lib64/ld-linux-loongarch-lp64d.so.1 --library-path /home/schrodinger/Downloads/loongarch64-clfs-6.0-cross-tools-gcc_and_clang-full/cross-tools/target/usr/lib64 ./func-thread_alloc_external-check
```

![image](https://user-images.githubusercontent.com/20108837/185958770-eae0091b-6dbf-499d-a5ea-408a8873023c.png)
