### PR TITLE
TSAN CI changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,7 +294,7 @@ jobs:
         fi
 
   all-checks:
-    needs: [unixlike, qemu-crossbuild, windows, format]
+    needs: [unixlike, qemu-crossbuild, windows, format, sanitizer]
     runs-on: ubuntu-latest
     steps:
     - name: Dummy step

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,9 +113,9 @@ jobs:
   sanitizer:
     strategy:
       matrix:
-        # Build each combination of OS and release/debug variants
+        # Build just release variant as Debug is too slow.
         os: [ "ubuntu-latest"]
-        build-type: [ Release, Debug ]
+        build-type: [ Release ]
         include:
           - os: "ubuntu-latest"
             continue-on-error: # Don't class as an error if this fails, until we have a more reliablity.


### PR DESCRIPTION
* Remove TSAN Debug - it takes too long, and it is not clear it adds any additional checking over TSAN Release build
* Require TSAN to pass for approval - TSAN this was not initially enabled as there were issues, but it has been stable for a long time, so can be part of the approval process.