### PR TITLE
Make smallbuddy handle larger requests correctly

### DIFF
--- a/src/snmalloc/aal/aal_cheri.h
+++ b/src/snmalloc/aal/aal_cheri.h
@@ -86,6 +86,10 @@ namespace snmalloc
       }
 
       void* pb = __builtin_cheri_bounds_set_exact(a.unsafe_ptr(), size);
+
+      SNMALLOC_ASSERT(
+        __builtin_cheri_tag_get(pb) && "capptr_bound exactness failed.");
+
       return CapPtr<T, BOut>::unsafe_from(static_cast<T*>(pb));
     }
 

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -39,7 +39,7 @@ namespace snmalloc
      * does not avail itself of this degree of freedom.
      */
     template<typename T>
-    static capptr::Arena<void>
+    static capptr::Alloc<void>
     alloc_meta_data(LocalState* local_state, size_t size)
     {
       capptr::Arena<void> p;
@@ -61,9 +61,13 @@ namespace snmalloc
       }
 
       if (p == nullptr)
+      {
         errno = ENOMEM;
+        return nullptr;
+      }
 
-      return p;
+      return capptr_to_user_address_control(
+        Aal::capptr_bound<void, capptr::bounds::AllocFull>(p, size));
     }
 
     /**

--- a/src/snmalloc/mem/backend_concept.h
+++ b/src/snmalloc/mem/backend_concept.h
@@ -122,7 +122,7 @@ namespace snmalloc
     {
       Backend::template alloc_meta_data<void*>(local_state, size)
     }
-    ->ConceptSame<capptr::Arena<void>>;
+    ->ConceptSame<capptr::Alloc<void>>;
   }
   &&requires(
     LocalState& local_state,

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -137,11 +137,8 @@ namespace snmalloc
         Config::Pal::error("Failed to initialise thread local allocator.");
       }
 
-      p = capptr_to_user_address_control(
-        Aal::capptr_bound<T, capptr::bounds::AllocFull>(
-          capptr::Arena<T>::unsafe_from(new (raw.unsafe_ptr())
-                                          T(std::forward<Args>(args)...)),
-          sizeof(T)));
+      p = capptr::Alloc<T>::unsafe_from(new (raw.unsafe_ptr())
+                                          T(std::forward<Args>(args)...));
 
       FlagLock f(pool.lock);
       p->list_next = pool.list;

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -1,3 +1,5 @@
+#include <array>
+#include <iostream>
 #include <snmalloc/snmalloc.h>
 #include <test/opt.h>
 #include <test/setup.h>
@@ -23,6 +25,23 @@ struct PoolBEntry : Pooled<PoolBEntry>
 };
 
 using PoolB = Pool<PoolBEntry, Alloc::Config>;
+
+struct PoolLargeEntry : Pooled<PoolLargeEntry>
+{
+  std::array<int, 2'000'000> payload;
+
+  PoolLargeEntry()
+  {
+    printf(".");
+    fflush(stdout);
+    payload[0] = 1;
+    printf("first %d\n", payload[0]);
+    payload[1'999'999] = 1;
+    printf("last %d\n", payload[1'999'999]);
+  };
+};
+
+using PoolLarge = Pool<PoolLargeEntry, Alloc::Config>;
 
 void test_alloc()
 {
@@ -116,6 +135,18 @@ void test_iterator()
   PoolA::release(after_iteration_ptr);
 }
 
+void test_large()
+{
+  printf(".");
+  fflush(stdout);
+  PoolLargeEntry* p = PoolLarge::acquire();
+  printf(".");
+  fflush(stdout);
+  PoolLarge::release(p);
+  printf(".");
+  fflush(stdout);
+}
+
 int main(int argc, char** argv)
 {
   setup();
@@ -128,10 +159,18 @@ int main(int argc, char** argv)
 #endif
 
   test_alloc();
+  std::cout << "test_alloc passed" << std::endl;
   test_constructor();
+  std::cout << "test_constructor passed" << std::endl;
   test_alloc_many();
+  std::cout << "test_alloc_many passed" << std::endl;
   test_double_alloc();
+  std::cout << "test_double_alloc passed" << std::endl;
   test_different_alloc();
+  std::cout << "test_different_alloc passed" << std::endl;
   test_iterator();
+  std::cout << "test_iterator passed" << std::endl;
+  test_large();
+  std::cout << "test_large passed" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Verona was using a pool allocator to requests large pieces of meta-data. This was broken with the current design, so the smallbuddy can now pass requests up if they are too large.