### PR TITLE
Pagemap Rounding

### DIFF
--- a/src/snmalloc/backend_helpers/pagemap.h
+++ b/src/snmalloc/backend_helpers/pagemap.h
@@ -145,8 +145,8 @@ namespace snmalloc
       // TODO CHERI capability bound here!
       auto heap_base = pointer_offset(b, pagemap_size);
 
-      // The following assert prevents the corner case where the pagemap occupies
-      // the entire address space, and this 
+      // The following assert prevents the corner case where the pagemap
+      // occupies the entire address space, and this
       //     s - pagemap_size
       // can underflow.
       static_assert(

--- a/src/snmalloc/backend_helpers/pagemap.h
+++ b/src/snmalloc/backend_helpers/pagemap.h
@@ -17,6 +17,7 @@ namespace snmalloc
   {
   private:
     static constexpr size_t SHIFT = GRANULARITY_BITS;
+    static constexpr size_t GRANULARITY = bits::one_at_bit(GRANULARITY_BITS);
 
     /**
      * Before init is called will contain a single entry
@@ -121,20 +122,18 @@ namespace snmalloc
       // pagemap as well as the left over. This is not ideal, and we should
       // really calculate the division with
       //
-      //  bits::one_at_bit(GRANULARITY_BITS) + sizeof(T)
+      //  GRANULARITY + sizeof(T)
       //
       // There are awkward corner cases for the alignment of the start and
       // the end that are hard to calculate. So this is not currently done.
 
       // Calculate range in pagemap that is associated to this space.
       // Over calculate to cover any unaligned parts at either end.
-      auto b_align = pointer_align_down(b, bits::one_at_bit(GRANULARITY_BITS));
-      auto end = pointer_align_up(
-        pointer_offset(b, s), bits::one_at_bit(GRANULARITY_BITS));
+      base = bits::align_down(address_cast(b), GRANULARITY);
+      auto end = bits::align_up(address_cast(b) + s, GRANULARITY);
+      size = end - base;
 
       // Setup the pagemap.
-      base = address_cast(b_align);
-      size = pointer_diff(b_align, end);
       body = static_cast<T*>(b);
       body_opt = body;
 
@@ -152,6 +151,12 @@ namespace snmalloc
       static_assert(
         sizeof(T) < (1 << SHIFT),
         "Pagemap entry too large relative to granularity");
+
+      if (pagemap_size > s)
+      {
+        // The pagemap is larger than the available space.
+        error("Pagemap is larger than the available space.");
+      }
 
       return {heap_base, s - pagemap_size};
     }

--- a/src/snmalloc/backend_helpers/pagemap.h
+++ b/src/snmalloc/backend_helpers/pagemap.h
@@ -145,6 +145,14 @@ namespace snmalloc
       // TODO CHERI capability bound here!
       auto heap_base = pointer_offset(b, pagemap_size);
 
+      // The following assert prevents the corner case where the pagemap occupies
+      // the entire address space, and this 
+      //     s - pagemap_size
+      // can underflow.
+      static_assert(
+        sizeof(T) < (1 << SHIFT),
+        "Pagemap entry too large relative to granularity");
+
       return {heap_base, s - pagemap_size};
     }
 

--- a/src/snmalloc/backend_helpers/pagemap.h
+++ b/src/snmalloc/backend_helpers/pagemap.h
@@ -119,12 +119,12 @@ namespace snmalloc
       // TODO take account of pagemap size in the calculation of how big it
       // needs to be.  The following code creates a pagemap that covers the
       // pagemap as well as the left over. This is not ideal, and we should
-      // really calculate the division with 
+      // really calculate the division with
       //
       //  bits::one_at_bit(GRANULARITY_BITS) + sizeof(T)
       //
       // There are awkward corner cases for the alignment of the start and
-      // the end that are hard to calculate. So this is not currently done. 
+      // the end that are hard to calculate. So this is not currently done.
 
       // Calculate range in pagemap that is associated to this space.
       // Over calculate to cover any unaligned parts at either end.

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -74,6 +74,8 @@ void test_pagemap(bool bounded)
               << " end: " << pointer_offset(heap_base, heap_size) << std::endl;
     low = address_cast(heap_base);
     high = low + heap_size;
+    // Store a pattern in heap.
+    memset((void*)low, 0x23, high - low);
   }
   else
   {
@@ -99,6 +101,20 @@ void test_pagemap(bool bounded)
 
   // Check pattern is correctly stored
   std::cout << std::endl;
+
+  if (bounded)
+  {
+    // Check we have not corrupted the heap.
+    for (address_t ptr = low; ptr < high; ptr++)
+    {
+      auto* p = (char*)ptr;
+      if (*p != 0x23)
+        abort();
+      // Overwrite with a different pattern.
+      *p = 0x56;
+    }
+  }
+
   value = 1;
   for (address_t ptr = low; ptr < high;
        ptr += bits::one_at_bit(GRANULARITY_BITS + 3))

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -104,17 +104,23 @@ void test_pagemap(bool bounded)
 
   if (bounded)
   {
+    std::cout << "Checking heap" << std::endl;
     // Check we have not corrupted the heap.
     for (address_t ptr = low; ptr < high; ptr++)
     {
       auto* p = (char*)ptr;
       if (*p != 0x23)
+      {
+        printf("Heap and pagemap have collided at %p", p);
         abort();
-      // Overwrite with a different pattern.
-      *p = 0x56;
+      }
     }
+
+    // Store a different pattern in heap.
+    memset((void*)low, 0x23, high - low);
   }
 
+  std::cout << "Checking pagemap contents" << std::endl;
   value = 1;
   for (address_t ptr = low; ptr < high;
        ptr += bits::one_at_bit(GRANULARITY_BITS + 3))

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -108,6 +108,8 @@ void test_pagemap(bool bounded)
     // Check we have not corrupted the heap.
     for (address_t ptr = low; ptr < high; ptr++)
     {
+      if (((ptr - low) % (1ULL << 26)) == 0)
+        std::cout << "." << std::flush;
       auto* p = (char*)ptr;
       if (*p != 0x23)
       {
@@ -116,6 +118,8 @@ void test_pagemap(bool bounded)
       }
     }
 
+    std::cout << std::endl;
+    std::cout << "Storing new pattern" << std::endl;
     // Store a different pattern in heap.
     memset((void*)low, 0x23, high - low);
   }

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -55,8 +55,8 @@ void set(bool bounded, address_t address, T new_value)
 
 void test_pagemap(bool bounded)
 {
-  address_t low = bits::one_at_bit(23);
-  address_t high = bits::one_at_bit(30);
+  uintptr_t low = bits::one_at_bit(23);
+  uintptr_t high = bits::one_at_bit(30);
 
   // Nullptr needs to work before initialisation
   CHECK_GET(bounded, 0, T());

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -88,7 +88,7 @@ void test_pagemap(bool bounded)
 
   // Store a pattern into page map
   T value = 1;
-  for (address_t ptr = low; ptr < high;
+  for (uintptr_t ptr = low; ptr < high;
        ptr += bits::one_at_bit(GRANULARITY_BITS + 3))
   {
     set(bounded, ptr, value);
@@ -106,7 +106,7 @@ void test_pagemap(bool bounded)
   {
     std::cout << "Checking heap" << std::endl;
     // Check we have not corrupted the heap.
-    for (address_t ptr = low; ptr < high; ptr++)
+    for (uintptr_t ptr = low; ptr < high; ptr++)
     {
       if (((ptr - low) % (1ULL << 26)) == 0)
         std::cout << "." << std::flush;

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -56,7 +56,7 @@ void set(bool bounded, address_t address, T new_value)
 void test_pagemap(bool bounded)
 {
   uintptr_t low = bits::one_at_bit(23);
-  uintptr_t high = bits::one_at_bit(30);
+  uintptr_t high = bits::one_at_bit(29);
 
   // Nullptr needs to work before initialisation
   CHECK_GET(bounded, 0, T());
@@ -64,7 +64,7 @@ void test_pagemap(bool bounded)
   // Initialise the pagemap
   if (bounded)
   {
-    auto size = bits::one_at_bit(30);
+    auto size = bits::one_at_bit(29);
     auto base = DefaultPal::reserve(size);
     DefaultPal::notify_using<NoZero>(base, size);
     std::cout << "Fixed base: " << base << " (" << size << ") "

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -66,7 +66,7 @@ void test_pagemap(bool bounded)
   if (bounded)
   {
     auto size = bits::one_at_bit(29);
-    auto base = DefaultPal::reserve(size);
+    base = DefaultPal::reserve(size);
     DefaultPal::notify_using<NoZero>(base, size);
     std::cout << "Fixed base: " << base << " (" << size << ") "
               << " end: " << pointer_offset(base, size) << std::endl;


### PR DESCRIPTION
This PR ensures that if a pagemap is used in a fixed region that has very large granularity it does require undue additional alignment.