### PR TITLE
Towards heap walk

### DIFF
--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -291,8 +291,9 @@ namespace snmalloc
   }
 
   /**
-   * Convert an address_t to a pointer.  The returned pointer should never be followed.
-   * On CHERI following this pointer will result in a capability violation.
+   * Convert an address_t to a pointer.  The returned pointer should never be
+   * followed. On CHERI following this pointer will result in a capability
+   * violation.
    */
   template<typename T>
   SNMALLOC_FAST_PATH_INLINE T* useless_ptr_from_addr(address_t p)

--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -290,4 +290,13 @@ namespace snmalloc
     return static_cast<size_t>(a - pointer_align_down<alignment>(a));
   }
 
+  /**
+   * Convert an address_t to a pointer.  The returned pointer should never be followed.
+   * On CHERI following this pointer will result in a capability violation.
+   */
+  template<typename T>
+  SNMALLOC_FAST_PATH_INLINE T* useless_ptr_from_addr(address_t p)
+  {
+    return reinterpret_cast<T*>(p);
+  }
 } // namespace snmalloc

--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -298,6 +298,6 @@ namespace snmalloc
   template<typename T>
   SNMALLOC_FAST_PATH_INLINE T* useless_ptr_from_addr(address_t p)
   {
-    return reinterpret_cast<T*>(p);
+    return reinterpret_cast<T*>(static_cast<uintptr_t>(p));
   }
 } // namespace snmalloc

--- a/src/snmalloc/ds_core/seqset.h
+++ b/src/snmalloc/ds_core/seqset.h
@@ -83,6 +83,12 @@ namespace snmalloc
 #endif
     }
 
+  public:
+    /**
+     * Empty queue
+     */
+    constexpr SeqSet() = default;
+
     /**
      * Check for empty
      */
@@ -94,12 +100,6 @@ namespace snmalloc
       head.invariant();
       return head.next == &head;
     }
-
-  public:
-    /**
-     * Empty queue
-     */
-    constexpr SeqSet() = default;
 
     /**
      * Remove an element from the queue

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -811,7 +811,7 @@ namespace snmalloc
 
       // Set meta slab to empty.
       meta->initialise(
-        sizeclass, address_cast(slab), entropy.get_free_list_key());
+        sizeclass, slab.unsafe_ptr(), entropy.get_free_list_key());
 
       // Build a free list for the slab
       alloc_new_list(slab, meta, rsize, slab_size, entropy);

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -885,14 +885,13 @@ namespace snmalloc
         dealloc_local_slabs<true>(sizeclass);
       }
 
-      laden.iterate([this, domesticate](BackendSlabMetadata* meta)
-                           SNMALLOC_FAST_PATH_LAMBDA {
-                             if (!meta->is_large())
-                             {
-                               meta->free_queue.validate(
-                                 entropy.get_free_list_key(), domesticate);
-                             }
-                           });
+      laden.iterate([this, domesticate](
+                      BackendSlabMetadata* meta) SNMALLOC_FAST_PATH_LAMBDA {
+        if (!meta->is_large())
+        {
+          meta->free_queue.validate(entropy.get_free_list_key(), domesticate);
+        }
+      });
 
       return posted;
     }
@@ -925,7 +924,6 @@ namespace snmalloc
       auto& key = entropy.get_free_list_key();
 
       auto error = [&result, &key](auto slab_metadata) {
-
         auto slab_interior = slab_metadata->get_slab_interior(key);
         const PagemapEntry& entry =
           Config::Backend::get_metaentry(slab_interior);

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -927,6 +927,7 @@ namespace snmalloc
         auto slab_interior = slab_metadata->get_slab_interior(key);
         const PagemapEntry& entry =
           Config::Backend::get_metaentry(slab_interior);
+        SNMALLOC_ASSERT(slab_metadata == entry.get_slab_metadata());
         auto size_class = entry.get_sizeclass();
         auto slab_size = sizeclass_full_to_slab_size(size_class);
         auto slab_start = bits::align_down(slab_interior, slab_size);

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -811,7 +811,7 @@ namespace snmalloc
 
       // Set meta slab to empty.
       meta->initialise(
-        sizeclass, slab.unsafe_ptr(), entropy.get_free_list_key());
+        sizeclass, address_cast(slab), entropy.get_free_list_key());
 
       // Build a free list for the slab
       alloc_new_list(slab, meta, rsize, slab_size, entropy);

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -678,7 +678,7 @@ namespace snmalloc
       /**
        * Set the builder to a not building state.
        */
-      constexpr void init(address_t slab, const FreeListKey& key)
+      constexpr void init(void* slab, const FreeListKey& key)
       {
         for (size_t i = 0; i < LENGTH; i++)
         {
@@ -718,7 +718,7 @@ namespace snmalloc
         // empty, but you are not allowed to call this in the empty case.
         auto last = Object::BHeadPtr<BView, BQueue>::unsafe_from(
           Object::from_next_ptr(cast_end(0)));
-        init(address_cast(head[0]), key);
+        init(head[0], key);
         return {first, last};
       }
 

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -547,7 +547,7 @@ namespace snmalloc
       std::array<uint16_t, RANDOM ? 2 : 0> length{};
 
     public:
-      constexpr Builder() {}
+      constexpr Builder() = default;
 
       /**
        * Checks if the builder contains any elements.

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -695,7 +695,7 @@ namespace snmalloc
           // the Freelist builder always knows which block it is referring too.
           head[i] = Object::code_next(
             address_cast(&head[i]),
-            reinterpret_cast<Object::T<BQueue>*>(slab),
+            useless_ptr_from_addr<Object::T<BQueue>>(address_cast(slab)),
             key);
         }
       }

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -678,7 +678,7 @@ namespace snmalloc
       /**
        * Set the builder to a not building state.
        */
-      constexpr void init(void* slab, const FreeListKey& key)
+      constexpr void init(address_t slab, const FreeListKey& key)
       {
         for (size_t i = 0; i < LENGTH; i++)
         {
@@ -695,7 +695,7 @@ namespace snmalloc
           // the Freelist builder always knows which block it is referring too.
           head[i] = Object::code_next(
             address_cast(&head[i]),
-            useless_ptr_from_addr<Object::T<BQueue>>(address_cast(slab)),
+            useless_ptr_from_addr<Object::T<BQueue>>(slab),
             key);
         }
       }
@@ -718,7 +718,7 @@ namespace snmalloc
         // empty, but you are not allowed to call this in the empty case.
         auto last = Object::BHeadPtr<BView, BQueue>::unsafe_from(
           Object::from_next_ptr(cast_end(0)));
-        init(head[0], key);
+        init(address_cast(head[0]), key);
         return {first, last};
       }
 

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -528,7 +528,7 @@ namespace snmalloc
       // This enables branch free enqueuing.
       std::array<void**, LENGTH> end{nullptr};
 
-      Object::BQueuePtr<BQueue>* cast_end(uint32_t ix)
+      [[nodiscard]] Object::BQueuePtr<BQueue>* cast_end(uint32_t ix) const
       {
         return reinterpret_cast<Object::BQueuePtr<BQueue>*>(end[ix]);
       }
@@ -538,7 +538,7 @@ namespace snmalloc
         end[ix] = reinterpret_cast<void**>(p);
       }
 
-      Object::BHeadPtr<BView, BQueue> cast_head(uint32_t ix) const
+      [[nodiscard]] Object::BHeadPtr<BView, BQueue> cast_head(uint32_t ix) const
       {
         return Object::BHeadPtr<BView, BQueue>::unsafe_from(
           static_cast<Object::T<BQueue>*>(head[ix]));
@@ -619,7 +619,7 @@ namespace snmalloc
        * and is thus subject to encoding if the next_object pointers
        * encoded.
        */
-      Object::BHeadPtr<BView, BQueue>
+      [[nodiscard]] Object::BHeadPtr<BView, BQueue>
       read_head(uint32_t index, const FreeListKey& key) const
       {
         return Object::decode_next(

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -199,7 +199,10 @@ namespace snmalloc
 
         // Initialise meta data for a successful large allocation.
         if (meta != nullptr)
+        {
           meta->initialise_large();
+          core_alloc->laden.insert(meta);
+        }
 
         if (zero_mem == YesZero && chunk.unsafe_ptr() != nullptr)
         {

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -201,7 +201,7 @@ namespace snmalloc
         if (meta != nullptr)
         {
           meta->initialise_large(
-            chunk.unsafe_ptr(), local_cache.entropy.get_free_list_key());
+            address_cast(chunk), local_cache.entropy.get_free_list_key());
           core_alloc->laden.insert(meta);
         }
 

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -200,7 +200,8 @@ namespace snmalloc
         // Initialise meta data for a successful large allocation.
         if (meta != nullptr)
         {
-          meta->initialise_large();
+          meta->initialise_large(
+            address_cast(chunk), local_cache.entropy.get_free_list_key());
           core_alloc->laden.insert(meta);
         }
 

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -201,7 +201,7 @@ namespace snmalloc
         if (meta != nullptr)
         {
           meta->initialise_large(
-            address_cast(chunk), local_cache.entropy.get_free_list_key());
+            chunk.unsafe_ptr(), local_cache.entropy.get_free_list_key());
           core_alloc->laden.insert(meta);
         }
 

--- a/src/snmalloc/mem/metadata.h
+++ b/src/snmalloc/mem/metadata.h
@@ -583,7 +583,7 @@ namespace snmalloc
 
     // Returns a pointer to somewhere in the slab. May not be the
     // start of the slab.
-    address_t get_slab_interior(const FreeListKey& key) const
+    [[nodiscard]] address_t get_slab_interior(const FreeListKey& key) const
     {
       return address_cast(free_queue.read_head(0, key));
     }

--- a/src/snmalloc/mem/metadata.h
+++ b/src/snmalloc/mem/metadata.h
@@ -440,8 +440,8 @@ namespace snmalloc
     /**
      * Initialise FrontendSlabMetadata for a slab.
      */
-    void
-    initialise(smallsizeclass_t sizeclass, void* slab, const FreeListKey& key)
+    void initialise(
+      smallsizeclass_t sizeclass, address_t slab, const FreeListKey& key)
     {
       static_assert(
         std::is_base_of<FrontendSlabMetadata_Trait, BackendType>::value,
@@ -462,7 +462,7 @@ namespace snmalloc
      *
      * Set needed so immediately moves to slow path.
      */
-    void initialise_large(void* slab, const FreeListKey& key)
+    void initialise_large(address_t slab, const FreeListKey& key)
     {
       // We will push to this just to make the fast path clean.
       free_queue.init(slab, key);

--- a/src/snmalloc/mem/metadata.h
+++ b/src/snmalloc/mem/metadata.h
@@ -440,8 +440,8 @@ namespace snmalloc
     /**
      * Initialise FrontendSlabMetadata for a slab.
      */
-    void initialise(
-      smallsizeclass_t sizeclass, void* slab, const FreeListKey& key)
+    void
+    initialise(smallsizeclass_t sizeclass, void* slab, const FreeListKey& key)
     {
       static_assert(
         std::is_base_of<FrontendSlabMetadata_Trait, BackendType>::value,

--- a/src/snmalloc/mem/metadata.h
+++ b/src/snmalloc/mem/metadata.h
@@ -441,7 +441,7 @@ namespace snmalloc
      * Initialise FrontendSlabMetadata for a slab.
      */
     void initialise(
-      smallsizeclass_t sizeclass, address_t slab, const FreeListKey& key)
+      smallsizeclass_t sizeclass, void* slab, const FreeListKey& key)
     {
       static_assert(
         std::is_base_of<FrontendSlabMetadata_Trait, BackendType>::value,
@@ -462,7 +462,7 @@ namespace snmalloc
      *
      * Set needed so immediately moves to slow path.
      */
-    void initialise_large(address_t slab, const FreeListKey& key)
+    void initialise_large(void* slab, const FreeListKey& key)
     {
       // We will push to this just to make the fast path clean.
       free_queue.init(slab, key);

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -173,8 +173,8 @@ namespace snmalloc
       for (auto& l : list)
       {
         // We do not need to initialise with a particular slab, so pass
-        // an address of 0.
-        l.init(0, key);
+        // a nullptr.
+        l.init(nullptr, key);
       }
       capacity = REMOTE_CACHE;
     }

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -173,8 +173,8 @@ namespace snmalloc
       for (auto& l : list)
       {
         // We do not need to initialise with a particular slab, so pass
-        // a nullptr.
-        l.init(nullptr, key);
+        // a null address.
+        l.init(0, key);
       }
       capacity = REMOTE_CACHE;
     }

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -17,7 +17,7 @@ namespace snmalloc
    */
   struct RemoteDeallocCache
   {
-    std::array<freelist::Builder<false, false>, REMOTE_SLOTS> list;
+    std::array<freelist::Builder<false>, REMOTE_SLOTS> list;
 
     /**
      * The total amount of memory we are waiting for before we will dispatch
@@ -165,14 +165,16 @@ namespace snmalloc
      * Must be called before anything else to ensure actually initialised
      * not just zero init.
      */
-    void init()
+    void init(const FreeListKey& key)
     {
 #ifndef NDEBUG
       initialised = true;
 #endif
       for (auto& l : list)
       {
-        l.init();
+        // We do not need to initialise with a particular slab, so pass
+        // an address of 0.
+        l.init(0, key);
       }
       capacity = REMOTE_CACHE;
     }

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -63,7 +63,7 @@ void debug_check_empty_2()
 
   for (size_t i = 0; i < count; i++)
   {
-    auto r = a.alloc(128);
+    auto r = a.alloc(size);
     allocs.push_back(r);
     snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
     if (result != false)

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -59,7 +59,8 @@ void debug_check_empty_2()
   snmalloc::Alloc& a = snmalloc::ThreadAlloc::get();
   bool result;
   std::vector<void*> allocs;
-  size_t count = 2048;
+  // 2GB of allocations
+  size_t count = 2048 * 1024 * 1024 / size;
 
   for (size_t i = 0; i < count; i++)
   {

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -59,8 +59,8 @@ void debug_check_empty_2()
   snmalloc::Alloc& a = snmalloc::ThreadAlloc::get();
   bool result;
   std::vector<void*> allocs;
-  // 2GB of allocations
-  size_t count = 2048 * 1024 * 1024 / size;
+  // 1GB of allocations
+  size_t count = 1024 * 1024 * 1024 / size;
 
   for (size_t i = 0; i < count; i++)
   {

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -1,16 +1,26 @@
-#include <snmalloc/snmalloc.h>
-
+#ifdef SNMALLOC_PASS_THROUGH // This test depends on snmalloc internals
 int main()
 {
-#ifndef SNMALLOC_PASS_THROUGH // This test depends on snmalloc internals
+  return 0;
+}
+#else
+#  include <iostream>
+#  include <snmalloc/snmalloc.h>
+#  include <vector>
+
+template<size_t size>
+void debug_check_empty_1()
+{
   snmalloc::Alloc& a = snmalloc::ThreadAlloc::get();
   bool result;
 
-  auto r = a.alloc(16);
+  auto r = a.alloc(size);
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != false)
   {
+    std::cout << "debug_check_empty failed to detect leaked memory:" << size
+              << std::endl;
     abort();
   }
 
@@ -19,14 +29,17 @@ int main()
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != true)
   {
+    std::cout << "debug_check_empty failed to say empty:" << size << std::endl;
     abort();
   }
 
-  r = a.alloc(16);
+  r = a.alloc(size);
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != false)
   {
+    std::cout << "debug_check_empty failed to detect leaked memory:" << size
+              << std::endl;
     abort();
   }
 
@@ -35,7 +48,46 @@ int main()
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != true)
   {
+    std::cout << "debug_check_empty failed to say empty:" << size << std::endl;
     abort();
   }
-#endif
 }
+
+template<size_t size>
+void debug_check_empty_2()
+{
+  snmalloc::Alloc& a = snmalloc::ThreadAlloc::get();
+  bool result;
+  std::vector<void*> allocs;
+  size_t count = 2048;
+
+  for (size_t i = 0; i < count; i++)
+  {
+    auto r = a.alloc(128);
+    allocs.push_back(r);
+    snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
+    if (result != false)
+    {
+      std::cout << "False empty after " << i << " allocations of " << size
+                << std::endl;
+      abort();
+    }
+  }
+
+  for (size_t i = 0; i < count; i++)
+  {
+    a.dealloc(allocs[i]);
+  }
+  snmalloc::debug_check_empty<snmalloc::StandardConfig>();
+}
+
+int main()
+{
+  debug_check_empty_1<16>();
+  debug_check_empty_1<1024 * 1024 * 32>();
+
+  debug_check_empty_2<32>();
+  debug_check_empty_2<1024 * 1024 * 32>();
+  return 0;
+}
+#endif


### PR DESCRIPTION
This includes a two changes that are on the way to implementing heap walk.  The changes performed are:

* Track the `laden` ranges of memory: the full and almost full slabs and large allocations.
* Ensure each slab metadata knows what range of memory it is describing.  This was not previously the case for a fully used slab where there is no free list.