### PR TITLE
Various changes to improve startup times for lots of threads

### DIFF
--- a/src/snmalloc/aal/address.h
+++ b/src/snmalloc/aal/address.h
@@ -14,7 +14,7 @@ namespace snmalloc
   /**
    * Perform arithmetic on a uintptr_t.
    */
-  inline uintptr_t pointer_offset(uintptr_t base, size_t diff)
+  SNMALLOC_FAST_PATH inline uintptr_t pointer_offset(uintptr_t base, size_t diff)
   {
     return base + diff;
   }
@@ -23,7 +23,7 @@ namespace snmalloc
    * Perform pointer arithmetic and return the adjusted pointer.
    */
   template<typename U = void, typename T>
-  inline U* pointer_offset(T* base, size_t diff)
+  SNMALLOC_FAST_PATH inline U* pointer_offset(T* base, size_t diff)
   {
     SNMALLOC_ASSERT(base != nullptr); /* Avoid UB */
     return unsafe_from_uintptr<U>(
@@ -32,7 +32,7 @@ namespace snmalloc
 
   template<SNMALLOC_CONCEPT(capptr::IsBound) bounds, typename T>
   inline CapPtr<void, bounds>
-  pointer_offset(CapPtr<T, bounds> base, size_t diff)
+  SNMALLOC_FAST_PATH pointer_offset(CapPtr<T, bounds> base, size_t diff)
   {
     return CapPtr<void, bounds>::unsafe_from(
       pointer_offset(base.unsafe_ptr(), diff));
@@ -42,7 +42,7 @@ namespace snmalloc
    * Perform pointer arithmetic and return the adjusted pointer.
    */
   template<typename U = void, typename T>
-  inline U* pointer_offset_signed(T* base, ptrdiff_t diff)
+  SNMALLOC_FAST_PATH inline U* pointer_offset_signed(T* base, ptrdiff_t diff)
   {
     SNMALLOC_ASSERT(base != nullptr); /* Avoid UB */
     return reinterpret_cast<U*>(reinterpret_cast<char*>(base) + diff);
@@ -50,7 +50,7 @@ namespace snmalloc
 
   template<SNMALLOC_CONCEPT(capptr::IsBound) bounds, typename T>
   inline CapPtr<void, bounds>
-  pointer_offset_signed(CapPtr<T, bounds> base, ptrdiff_t diff)
+  SNMALLOC_FAST_PATH pointer_offset_signed(CapPtr<T, bounds> base, ptrdiff_t diff)
   {
     return CapPtr<void, bounds>::unsafe_from(
       pointer_offset_signed(base.unsafe_ptr(), diff));
@@ -60,7 +60,7 @@ namespace snmalloc
    * Cast from a pointer type to an address.
    */
   template<typename T>
-  inline SNMALLOC_FAST_PATH address_t address_cast(T* ptr)
+  SNMALLOC_FAST_PATH inline SNMALLOC_FAST_PATH address_t address_cast(T* ptr)
   {
     return reinterpret_cast<address_t>(ptr);
   }
@@ -73,12 +73,12 @@ namespace snmalloc
    * capptr_bound.
    */
   template<typename T, SNMALLOC_CONCEPT(capptr::IsBound) bounds>
-  inline SNMALLOC_FAST_PATH address_t address_cast(CapPtr<T, bounds> a)
+  SNMALLOC_FAST_PATH inline SNMALLOC_FAST_PATH address_t address_cast(CapPtr<T, bounds> a)
   {
     return address_cast(a.unsafe_ptr());
   }
 
-  inline SNMALLOC_FAST_PATH address_t address_cast(uintptr_t a)
+  SNMALLOC_FAST_PATH inline SNMALLOC_FAST_PATH address_t address_cast(uintptr_t a)
   {
     return static_cast<address_t>(a);
   }

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -57,6 +57,9 @@ namespace snmalloc
           GlobalMetaRange::ConcurrencySafe,
           "Global meta data range needs to be concurrency safe.");
         GlobalMetaRange global_state;
+        // This assert is not necessary for correctness, but if
+        // this is not true, we will be wasting a lot of space.
+        SNMALLOC_ASSERT(size >= (MIN_CHUNK_SIZE / 4));
         auto rsize = bits::max(bits::next_pow2(size), MIN_CHUNK_SIZE);
         p = global_state.alloc_range(rsize);
       }

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -57,7 +57,8 @@ namespace snmalloc
           GlobalMetaRange::ConcurrencySafe,
           "Global meta data range needs to be concurrency safe.");
         GlobalMetaRange global_state;
-        p = global_state.alloc_range(bits::next_pow2(size));
+        auto rsize = bits::max(bits::next_pow2(size), MIN_CHUNK_SIZE);
+        p = global_state.alloc_range(rsize);
       }
 
       if (p == nullptr)

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -57,9 +57,14 @@ namespace snmalloc
           GlobalMetaRange::ConcurrencySafe,
           "Global meta data range needs to be concurrency safe.");
         GlobalMetaRange global_state;
+        // TODO - this cannot be uncommented currently due to some use cases.
+        //   We should allow the Pool to use the allocator or the backend for 
+        //   other scenarios.  E.g. the Pool is used by Verona-rt where an 
+        //   allocator has already been created. See #603
+        //   
         // This assert is not necessary for correctness, but if
         // this is not true, we will be wasting a lot of space.
-        SNMALLOC_ASSERT(size >= (MIN_CHUNK_SIZE / 16));
+        // SNMALLOC_ASSERT_MSG(size >= (MIN_CHUNK_SIZE / 16), "Size request will waste space (size = {})\n", size);
         auto rsize = bits::max(bits::next_pow2(size), MIN_CHUNK_SIZE);
         p = global_state.alloc_range(rsize);
       }

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -59,7 +59,7 @@ namespace snmalloc
         GlobalMetaRange global_state;
         // This assert is not necessary for correctness, but if
         // this is not true, we will be wasting a lot of space.
-        SNMALLOC_ASSERT(size >= (MIN_CHUNK_SIZE / 4));
+        SNMALLOC_ASSERT(size >= (MIN_CHUNK_SIZE / 16));
         auto rsize = bits::max(bits::next_pow2(size), MIN_CHUNK_SIZE);
         p = global_state.alloc_range(rsize);
       }

--- a/src/snmalloc/backend/standard_range.h
+++ b/src/snmalloc/backend/standard_range.h
@@ -62,7 +62,7 @@ namespace snmalloc
 
   public:
     // Expose a global range for the initial allocation of meta-data.
-    using GlobalMetaRange = Pipe<ObjectRange, GlobalRange>;
+    using GlobalMetaRange = Stats;
 
     /**
      * Where we turn for allocations of user chunks.

--- a/src/snmalloc/backend_helpers/range_helpers.h
+++ b/src/snmalloc/backend_helpers/range_helpers.h
@@ -16,7 +16,7 @@ namespace snmalloc
 
     // Find the minimum set of maximally aligned blocks in this range.
     // Each block's alignment and size are equal.
-    while (length >= sizeof(void*))
+    while (length >= bits::one_at_bit(MIN_BITS))
     {
       size_t base_align_bits = bits::ctz(address_cast(base));
       size_t length_align_bits = (bits::BITS - 1) - bits::clz(length);

--- a/src/snmalloc/ds_core/ptrwrap.h
+++ b/src/snmalloc/ds_core/ptrwrap.h
@@ -471,6 +471,11 @@ namespace snmalloc
     {}
 
     /**
+     * default to nullptr
+     */
+    constexpr SNMALLOC_FAST_PATH AtomicCapPtr() : AtomicCapPtr(nullptr) {}
+
+    /**
      * Interconversion with CapPtr
      */
     constexpr SNMALLOC_FAST_PATH AtomicCapPtr(CapPtr<T, bounds> p)

--- a/src/snmalloc/ds_core/redblacktree.h
+++ b/src/snmalloc/ds_core/redblacktree.h
@@ -730,9 +730,14 @@ namespace snmalloc
       invariant();
     }
 
+    bool is_empty()
+    {
+      return get_root().is_null();
+    }
+
     K remove_min()
     {
-      if (get_root().is_null())
+      if (is_empty())
         return Rep::null;
 
       auto path = get_root_path();
@@ -748,7 +753,7 @@ namespace snmalloc
 
     bool remove_elem(K value)
     {
-      if (get_root().is_null())
+      if (is_empty())
         return false;
 
       auto path = get_root_path();

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -155,6 +155,7 @@ namespace snmalloc
               signed_prev(address_cast(this), address_cast(n_tame), key));
           }
 #endif
+          Aal::prefetch(&(n_tame->next_object));
           return n_tame;
         }
 

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -132,10 +132,12 @@ namespace snmalloc
         // Encoded representation of a back pointer.
         // Hard to fake, and provides consistency on
         // the next pointers.
-        address_t prev_encoded;
+        address_t prev_encoded{};
 #endif
 
       public:
+        constexpr T() : next_object(){};
+
         template<
           SNMALLOC_CONCEPT(capptr::IsBound) BView = typename BQueue::
             template with_wildness<capptr::dimension::Wildness::Tame>,

--- a/src/snmalloc/mem/remoteallocator.h
+++ b/src/snmalloc/mem/remoteallocator.h
@@ -76,11 +76,11 @@ namespace snmalloc
       return fnt;
     }
 
-    inline bool is_empty()
+    template<typename Domesticator_head>
+    inline bool
+    can_dequeue(const FreeListKey& key, Domesticator_head domesticate_head)
     {
-      freelist::QueuePtr bk = back.load(std::memory_order_relaxed);
-
-      return bk == front;
+      return nullptr == domesticate_head(front)->read_next(key, domesticate_head);
     }
 
     /**

--- a/src/snmalloc/mem/remoteallocator.h
+++ b/src/snmalloc/mem/remoteallocator.h
@@ -80,7 +80,7 @@ namespace snmalloc
     inline bool
     can_dequeue(const FreeListKey& key, Domesticator_head domesticate_head)
     {
-      return nullptr == domesticate_head(front)->read_next(key, domesticate_head);
+      return domesticate_head(front)->read_next(key, domesticate_head) == nullptr;
     }
 
     /**

--- a/src/snmalloc/mem/remoteallocator.h
+++ b/src/snmalloc/mem/remoteallocator.h
@@ -51,28 +51,34 @@ namespace snmalloc
     alignas(CACHELINE_SIZE) freelist::AtomicQueuePtr back{nullptr};
     // Store the two ends on different cache lines as access by different
     // threads.
-    alignas(CACHELINE_SIZE) freelist::QueuePtr front{nullptr};
+    alignas(CACHELINE_SIZE) freelist::AtomicQueuePtr front{nullptr};
+    // Fake first entry
+    freelist::Object::T<capptr::bounds::AllocWild> stub{};
 
     constexpr RemoteAllocator() = default;
 
     void invariant()
     {
-      SNMALLOC_ASSERT(back != nullptr);
+      SNMALLOC_ASSERT(
+        (back != nullptr) ||
+        (address_cast(front.load()) == address_cast(&stub)));
     }
 
-    void init(freelist::HeadPtr stub)
+    void init()
     {
-      freelist::Object::atomic_store_null(stub, key_global);
-      front = capptr_rewild(stub);
-      back.store(front, std::memory_order_relaxed);
+      freelist::HeadPtr stub_ptr = freelist::HeadPtr::unsafe_from(&stub);
+      freelist::Object::atomic_store_null(stub_ptr, key_global);
+      front.store(freelist::QueuePtr::unsafe_from(&stub));
+      back.store(nullptr, std::memory_order_relaxed);
       invariant();
     }
 
     freelist::QueuePtr destroy()
     {
-      freelist::QueuePtr fnt = front;
+      freelist::QueuePtr fnt = front.load();
       back.store(nullptr, std::memory_order_relaxed);
-      front = nullptr;
+      if (address_cast(front.load()) == address_cast(&stub))
+        return nullptr;
       return fnt;
     }
 
@@ -80,7 +86,8 @@ namespace snmalloc
     inline bool
     can_dequeue(const FreeListKey& key, Domesticator_head domesticate_head)
     {
-      return domesticate_head(front)->read_next(key, domesticate_head) == nullptr;
+      return domesticate_head(front.load())
+               ->atomic_read_next(key, domesticate_head) == nullptr;
     }
 
     /**
@@ -107,12 +114,13 @@ namespace snmalloc
       freelist::QueuePtr prev =
         back.exchange(capptr_rewild(last), std::memory_order_acq_rel);
 
-      freelist::Object::atomic_store_next(domesticate_head(prev), first, key);
-    }
+      if (SNMALLOC_LIKELY(prev != nullptr))
+      {
+        freelist::Object::atomic_store_next(domesticate_head(prev), first, key);
+        return;
+      }
 
-    freelist::QueuePtr peek()
-    {
-      return front;
+      front.store(capptr_rewild(first));
     }
 
     /**
@@ -134,11 +142,11 @@ namespace snmalloc
       Cb cb)
     {
       invariant();
-      SNMALLOC_ASSERT(front != nullptr);
+      SNMALLOC_ASSERT(front.load() != nullptr);
 
       // Use back to bound, so we don't handle new entries.
       auto b = back.load(std::memory_order_relaxed);
-      freelist::HeadPtr curr = domesticate_head(front);
+      freelist::HeadPtr curr = domesticate_head(front.load());
 
       while (address_cast(curr) != address_cast(b))
       {


### PR DESCRIPTION
While profiling starting a lot of threads, I found a few bits that could be improved.  This PR attempts to reduce the contention on startup.  By

* Reducing work under locks
   - ~~Removing a lock from the pool implementation~~
   - Optimising the buddy allocator to only look as high as it has blocks of memory
   - Making the global meta range not perform madvise under a lock.  
* Implementing a proper MCS queue lock
