### PR TITLE
Replace fragile and wrong check for library feature.

### DIFF
--- a/src/snmalloc/ds_core/defines.h
+++ b/src/snmalloc/ds_core/defines.h
@@ -109,8 +109,7 @@ namespace snmalloc
 #define TOSTRING(expr) TOSTRING2(expr)
 #define TOSTRING2(expr) #expr
 
-#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 11) || \
-  (defined(__clang__) && __clang_major__ >= 15)
+#ifdef __cpp_lib_source_location
 #  include <source_location>
 #  define SNMALLOC_CURRENT_LINE std::source_location::current().line()
 #  define SNMALLOC_CURRENT_FILE std::source_location::current().file_name()


### PR DESCRIPTION
Compiler versions do not imply standard library versions, and even where the compiler and standard library versions were matched, this check was wrong.