### PR TITLE
Fix incorrect aligned_size invocations in operator overrides

### DIFF
--- a/src/snmalloc/override/new.cc
+++ b/src/snmalloc/override/new.cc
@@ -74,25 +74,25 @@ void operator delete[](void* p, std::nothrow_t&)
 
 void* operator new(size_t size, std::align_val_t val)
 {
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   return ThreadAlloc::get().alloc(size);
 }
 
 void* operator new[](size_t size, std::align_val_t val)
 {
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   return ThreadAlloc::get().alloc(size);
 }
 
 void* operator new(size_t size, std::align_val_t val, std::nothrow_t&)
 {
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   return ThreadAlloc::get().alloc(size);
 }
 
 void* operator new[](size_t size, std::align_val_t val, std::nothrow_t&)
 {
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   return ThreadAlloc::get().alloc(size);
 }
 
@@ -108,7 +108,7 @@ void operator delete[](void* p, std::align_val_t) EXCEPTSPEC
 
 void operator delete(void* p, size_t size, std::align_val_t val)EXCEPTSPEC
 {
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   ThreadAlloc::get().dealloc(p, size);
 }
 
@@ -116,6 +116,6 @@ void operator delete[](void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
   if (p == nullptr)
     return;
-  size = aligned_size(size, size_t(val));
+  size = aligned_size(size_t(val), size);
   ThreadAlloc::get().dealloc(p, size);
 }


### PR DESCRIPTION
The order of the arguments passed to aligned_size is reversed, causing the assertion `bits::is_pow2(alignment)` to fail. The fix is to simply change the order.