### PR TITLE
Remote stub

### DIFF
--- a/src/snmalloc/ds_core/ptrwrap.h
+++ b/src/snmalloc/ds_core/ptrwrap.h
@@ -471,6 +471,11 @@ namespace snmalloc
     {}
 
     /**
+     * default to nullptr
+     */
+    constexpr SNMALLOC_FAST_PATH AtomicCapPtr() : AtomicCapPtr(nullptr) {}
+
+    /**
      * Interconversion with CapPtr
      */
     constexpr SNMALLOC_FAST_PATH AtomicCapPtr(CapPtr<T, bounds> p)

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -479,7 +479,19 @@ namespace snmalloc
      */
     SNMALLOC_FAST_PATH bool has_messages()
     {
-      return !(message_queue().is_empty());
+      auto domesticate = [local_state = backend_state_ptr()](
+                           freelist::QueuePtr p) SNMALLOC_FAST_PATH_LAMBDA {
+        if constexpr (Config::Options.QueueHeadsAreTame)
+        {
+          return freelist::HeadPtr::unsafe_from(p.unsafe_ptr());
+        }
+        else
+        {
+          return capptr_domesticate<Config>(local_state, p);
+        }
+      };
+
+      return !(message_queue().can_dequeue(key_global, domesticate));
     }
 
     /**

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -132,10 +132,12 @@ namespace snmalloc
         // Encoded representation of a back pointer.
         // Hard to fake, and provides consistency on
         // the next pointers.
-        address_t prev_encoded;
+        address_t prev_encoded{};
 #endif
 
       public:
+        constexpr T() : next_object(){};
+
         template<
           SNMALLOC_CONCEPT(capptr::IsBound) BView = typename BQueue::
             template with_wildness<capptr::dimension::Wildness::Tame>,

--- a/src/snmalloc/mem/remoteallocator.h
+++ b/src/snmalloc/mem/remoteallocator.h
@@ -76,11 +76,11 @@ namespace snmalloc
       return fnt;
     }
 
-    inline bool is_empty()
+    template<typename Domesticator_head>
+    inline bool
+    can_dequeue(const FreeListKey& key, Domesticator_head domesticate_head)
     {
-      freelist::QueuePtr bk = back.load(std::memory_order_relaxed);
-
-      return bk == front;
+      return nullptr == domesticate_head(front)->read_next(key, domesticate_head);
     }
 
     /**

--- a/src/snmalloc/mem/remoteallocator.h
+++ b/src/snmalloc/mem/remoteallocator.h
@@ -51,28 +51,34 @@ namespace snmalloc
     alignas(CACHELINE_SIZE) freelist::AtomicQueuePtr back{nullptr};
     // Store the two ends on different cache lines as access by different
     // threads.
-    alignas(CACHELINE_SIZE) freelist::QueuePtr front{nullptr};
+    alignas(CACHELINE_SIZE) freelist::AtomicQueuePtr front{nullptr};
+    // Fake first entry
+    freelist::Object::T<capptr::bounds::AllocWild> stub{};
 
     constexpr RemoteAllocator() = default;
 
     void invariant()
     {
-      SNMALLOC_ASSERT(back != nullptr);
+      SNMALLOC_ASSERT(
+        (back != nullptr) ||
+        (address_cast(front.load()) == address_cast(&stub)));
     }
 
-    void init(freelist::HeadPtr stub)
+    void init()
     {
-      freelist::Object::atomic_store_null(stub, key_global);
-      front = capptr_rewild(stub);
-      back.store(front, std::memory_order_relaxed);
+      freelist::HeadPtr stub_ptr = freelist::HeadPtr::unsafe_from(&stub);
+      freelist::Object::atomic_store_null(stub_ptr, key_global);
+      front.store(freelist::QueuePtr::unsafe_from(&stub));
+      back.store(nullptr, std::memory_order_relaxed);
       invariant();
     }
 
     freelist::QueuePtr destroy()
     {
-      freelist::QueuePtr fnt = front;
+      freelist::QueuePtr fnt = front.load();
       back.store(nullptr, std::memory_order_relaxed);
-      front = nullptr;
+      if (address_cast(front.load()) == address_cast(&stub))
+        return nullptr;
       return fnt;
     }
 
@@ -80,7 +86,8 @@ namespace snmalloc
     inline bool
     can_dequeue(const FreeListKey& key, Domesticator_head domesticate_head)
     {
-      return nullptr == domesticate_head(front)->read_next(key, domesticate_head);
+      return domesticate_head(front.load())
+               ->atomic_read_next(key, domesticate_head) == nullptr;
     }
 
     /**
@@ -107,12 +114,13 @@ namespace snmalloc
       freelist::QueuePtr prev =
         back.exchange(capptr_rewild(last), std::memory_order_acq_rel);
 
-      freelist::Object::atomic_store_next(domesticate_head(prev), first, key);
-    }
+      if (SNMALLOC_LIKELY(prev != nullptr))
+      {
+        freelist::Object::atomic_store_next(domesticate_head(prev), first, key);
+        return;
+      }
 
-    freelist::QueuePtr peek()
-    {
-      return front;
+      front.store(capptr_rewild(first));
     }
 
     /**
@@ -134,11 +142,11 @@ namespace snmalloc
       Cb cb)
     {
       invariant();
-      SNMALLOC_ASSERT(front != nullptr);
+      SNMALLOC_ASSERT(front.load() != nullptr);
 
       // Use back to bound, so we don't handle new entries.
       auto b = back.load(std::memory_order_relaxed);
-      freelist::HeadPtr curr = domesticate_head(front);
+      freelist::HeadPtr curr = domesticate_head(front.load());
 
       while (address_cast(curr) != address_cast(b))
       {


### PR DESCRIPTION
This partially address #586.  It provides a branch on the enqueue path, which simplifies the code.

This removes the need for the smallest size class to be create when the allocator is first initialised.