### PR TITLE
Update name of header-only flag in documentation

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -99,7 +99,7 @@ In this section we show how to compile snmalloc into your project such that it r
 Add these lines to your CMake file.
 
 ```cmake
-set(SNMALLOC_ONLY_HEADER_LIBRARY ON)
+set(SNMALLOC_HEADER_ONLY_LIBRARY ON)
 add_subdirectory(snmalloc EXCLUDE_FROM_ALL)
 ```
 


### PR DESCRIPTION
This PR renames the flag used to enable the import of snmalloc as header-only in the documentation, in line with the name of the flag in [`CMakeLists.txt`](https://github.com/microsoft/snmalloc/blob/7f368bd6dabd6349534550df54a4e559b455cfc7/CMakeLists.txt#L35). 