### PR TITLE
Object stats

### DIFF
--- a/src/snmalloc/backend_helpers/statsrange.h
+++ b/src/snmalloc/backend_helpers/statsrange.h
@@ -17,7 +17,7 @@ namespace snmalloc
     {
       using ContainsParent<ParentRange>::parent;
 
-    static inline Stat usage{};
+      static inline Stat usage{};
 
     public:
       static constexpr bool Aligned = ParentRange::Aligned;

--- a/src/snmalloc/backend_helpers/statsrange.h
+++ b/src/snmalloc/backend_helpers/statsrange.h
@@ -17,8 +17,7 @@ namespace snmalloc
     {
       using ContainsParent<ParentRange>::parent;
 
-      static inline std::atomic<size_t> current_usage{};
-      static inline std::atomic<size_t> peak_usage{};
+    static inline Stat usage{};
 
     public:
       static constexpr bool Aligned = ParentRange::Aligned;
@@ -29,36 +28,28 @@ namespace snmalloc
 
       constexpr Type() = default;
 
-      CapPtr<void, ChunkBounds> alloc_range(size_t size)
+      capptr::Arena<void> alloc_range(size_t size)
       {
-        auto result = parent.alloc_range(size);
-        if (result != nullptr)
-        {
-          auto prev = current_usage.fetch_add(size);
-          auto curr = peak_usage.load();
-          while (curr < prev + size)
-          {
-            if (peak_usage.compare_exchange_weak(curr, prev + size))
-              break;
-          }
-        }
-        return result;
+        auto r = parent.alloc_range(size);
+        if (r != nullptr)
+          usage += size;
+        return r;
       }
 
-      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
+      void dealloc_range(capptr::Arena<void> base, size_t size)
       {
-        current_usage -= size;
+        usage -= size;
         parent.dealloc_range(base, size);
       }
 
       size_t get_current_usage()
       {
-        return current_usage.load();
+        return usage.get_curr();
       }
 
       size_t get_peak_usage()
       {
-        return peak_usage.load();
+        return usage.get_peak();
       }
     };
   };

--- a/src/snmalloc/ds_core/ds_core.h
+++ b/src/snmalloc/ds_core/ds_core.h
@@ -15,3 +15,4 @@
 #include "ptrwrap.h"
 #include "redblacktree.h"
 #include "seqset.h"
+#include "stats.h"

--- a/src/snmalloc/ds_core/stats.h
+++ b/src/snmalloc/ds_core/stats.h
@@ -28,7 +28,9 @@ namespace snmalloc
     void decrease(size_t amount)
     {
       size_t prev = curr.fetch_sub(amount);
-      SNMALLOC_ASSERT(prev >= amount);
+// TODO Fix this to be true.
+//      SNMALLOC_ASSERT_MSG(prev >= amount, "prev = {}, amount = {}", prev, amount);
+      UNUSED(prev);
     }
 
     size_t get_curr()

--- a/src/snmalloc/ds_core/stats.h
+++ b/src/snmalloc/ds_core/stats.h
@@ -1,0 +1,64 @@
+#include <atomic>
+#include <cstddef>
+#include "defines.h"
+
+namespace snmalloc
+{
+  /**
+   * Very basic statistic that tracks current and peak values.
+   */
+  class Stat
+  {
+  private:
+    std::atomic<size_t> curr{0};
+    std::atomic<size_t> peak{0};
+
+  public:
+    void increase(size_t amount)
+    {
+      size_t c = (curr += amount);
+      size_t p = peak.load(std::memory_order_relaxed);
+      while (c > p)
+      {
+        if (peak.compare_exchange_strong(p, c))
+          break;
+      }
+    }
+
+    void decrease(size_t amount)
+    {
+      size_t prev = curr.fetch_sub(amount);
+      SNMALLOC_ASSERT(prev >= amount);
+    }
+
+    size_t get_curr()
+    {
+      return curr.load(std::memory_order_relaxed);
+    }
+
+    size_t get_peak()
+    {
+      return peak.load(std::memory_order_relaxed);
+    }
+
+    void operator+=(size_t amount)
+    {
+      increase(amount);
+    }
+
+    void operator-=(size_t amount)
+    {
+      decrease(amount);
+    }
+
+    void operator++()
+    {
+      increase(1);
+    }
+
+    void operator--()
+    {
+      decrease(1);
+    }
+  };
+} // namespace snmalloc

--- a/src/snmalloc/ds_core/stats.h
+++ b/src/snmalloc/ds_core/stats.h
@@ -1,6 +1,7 @@
+#include "defines.h"
+
 #include <atomic>
 #include <cstddef>
-#include "defines.h"
 
 namespace snmalloc
 {
@@ -28,8 +29,9 @@ namespace snmalloc
     void decrease(size_t amount)
     {
       size_t prev = curr.fetch_sub(amount);
-// TODO Fix this to be true.
-//      SNMALLOC_ASSERT_MSG(prev >= amount, "prev = {}, amount = {}", prev, amount);
+      // TODO Fix this to be true.
+      //      SNMALLOC_ASSERT_MSG(prev >= amount, "prev = {}, amount = {}",
+      //      prev, amount);
       UNUSED(prev);
     }
 

--- a/src/snmalloc/mem/allocstats.h
+++ b/src/snmalloc/mem/allocstats.h
@@ -1,0 +1,64 @@
+#include "../ds_core/ds_core.h"
+#include <array>
+#include "sizeclasstable.h"
+
+namespace snmalloc
+{
+  class MonotoneStat
+  {
+    size_t value{0};
+  public:
+    void operator++(int)
+    {
+      value++;
+    }
+
+    void operator+=(const MonotoneStat& other)
+    {
+      value += other.value;
+    }
+
+    size_t operator*()
+    {
+      return value;
+    }
+  };
+
+  struct AllocStat
+  {
+    MonotoneStat objects_allocated{};
+    MonotoneStat objects_deallocated{};
+    // MonotoneStat slabs_allocated;
+    // MonotoneStat slabs_deallocated;
+  };
+
+  class AllocStats
+  {
+    std::array<AllocStat, SIZECLASS_REP_SIZE> sizeclass{};
+
+  public:
+    AllocStat& operator[](sizeclass_t index)
+    {
+      auto i = index.raw();
+      return sizeclass[i];
+    }
+
+    AllocStat& operator[](smallsizeclass_t index)
+    {
+      return sizeclass[sizeclass_t::from_small_class(index).raw()];
+    }
+
+    AllocStat operator+=(const AllocStats& other)
+    {
+      AllocStat result;
+      for (size_t i = 0; i < SIZECLASS_REP_SIZE; i++)
+      {
+        sizeclass[i].objects_allocated += other.sizeclass[i].objects_allocated;
+        sizeclass[i].objects_deallocated += other.sizeclass[i].objects_deallocated;
+        // result.slabs_allocated += other.sizeclass[i].slabs_allocated;
+        // result.slabs_deallocated += other.sizeclass[i].slabs_deallocated;
+      }
+      return result;
+    }
+  };
+} // namespace snmalloc

--- a/src/snmalloc/mem/allocstats.h
+++ b/src/snmalloc/mem/allocstats.h
@@ -1,12 +1,14 @@
 #include "../ds_core/ds_core.h"
-#include <array>
 #include "sizeclasstable.h"
+
+#include <array>
 
 namespace snmalloc
 {
   class MonotoneStat
   {
     size_t value{0};
+
   public:
     void operator++(int)
     {
@@ -53,7 +55,8 @@ namespace snmalloc
       for (size_t i = 0; i < SIZECLASS_REP_SIZE; i++)
       {
         sizeclass[i].objects_allocated += other.sizeclass[i].objects_allocated;
-        sizeclass[i].objects_deallocated += other.sizeclass[i].objects_deallocated;
+        sizeclass[i].objects_deallocated +=
+          other.sizeclass[i].objects_deallocated;
         sizeclass[i].slabs_allocated += other.sizeclass[i].slabs_allocated;
         sizeclass[i].slabs_deallocated += other.sizeclass[i].slabs_deallocated;
       }

--- a/src/snmalloc/mem/allocstats.h
+++ b/src/snmalloc/mem/allocstats.h
@@ -28,8 +28,8 @@ namespace snmalloc
   {
     MonotoneStat objects_allocated{};
     MonotoneStat objects_deallocated{};
-    // MonotoneStat slabs_allocated;
-    // MonotoneStat slabs_deallocated;
+    MonotoneStat slabs_allocated{};
+    MonotoneStat slabs_deallocated{};
   };
 
   class AllocStats
@@ -48,17 +48,15 @@ namespace snmalloc
       return sizeclass[sizeclass_t::from_small_class(index).raw()];
     }
 
-    AllocStat operator+=(const AllocStats& other)
+    void operator+=(const AllocStats& other)
     {
-      AllocStat result;
       for (size_t i = 0; i < SIZECLASS_REP_SIZE; i++)
       {
         sizeclass[i].objects_allocated += other.sizeclass[i].objects_allocated;
         sizeclass[i].objects_deallocated += other.sizeclass[i].objects_deallocated;
-        // result.slabs_allocated += other.sizeclass[i].slabs_allocated;
-        // result.slabs_deallocated += other.sizeclass[i].slabs_deallocated;
+        sizeclass[i].slabs_allocated += other.sizeclass[i].slabs_allocated;
+        sizeclass[i].slabs_deallocated += other.sizeclass[i].slabs_deallocated;
       }
-      return result;
     }
   };
 } // namespace snmalloc

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -370,7 +370,7 @@ namespace snmalloc
         auto start = clear_slab(meta, sizeclass);
 
         stats[sizeclass].slabs_deallocated++;
-        
+
         Config::Backend::dealloc_chunk(
           get_backend_local_state(),
           *meta,

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -478,14 +478,18 @@ namespace snmalloc
                            SNMALLOC_FAST_PATH_LAMBDA {
                              return capptr_domesticate<Config>(local_state, p);
                            };
-      auto cb = [this,
-                 &need_post](freelist::HeadPtr msg) SNMALLOC_FAST_PATH_LAMBDA {
+
+      size_t received_bytes = 0;
+
+      auto cb = [this, &need_post, &received_bytes](
+                  freelist::HeadPtr msg) SNMALLOC_FAST_PATH_LAMBDA {
 #ifdef SNMALLOC_TRACING
         message<1024>("Handling remote");
 #endif
 
         auto& entry =
           Config::Backend::template get_metaentry(snmalloc::address_cast(msg));
+        received_bytes += sizeclass_full_to_size(entry.get_sizeclass());
 
         handle_dealloc_remote(entry, msg.as_void(), need_post);
 
@@ -513,6 +517,9 @@ namespace snmalloc
       {
         post();
       }
+
+      // Push size to global statistics
+      RemoteDeallocCache::remote_inflight -= received_bytes;
 
       return action(args...);
     }
@@ -542,10 +549,7 @@ namespace snmalloc
       }
       else
       {
-        if (
-          !need_post &&
-          !attached_cache->remote_dealloc_cache.reserve_space(entry))
-          need_post = true;
+        need_post = attached_cache->remote_dealloc_cache.reserve_space(entry);
         attached_cache->remote_dealloc_cache
           .template dealloc<sizeof(CoreAllocator)>(
             entry.get_remote()->trunc_id(), p.as_void());
@@ -834,7 +838,7 @@ namespace snmalloc
       {
         auto p_wild = message_queue().destroy();
         auto p_tame = domesticate(p_wild);
-
+        size_t received_bytes = 0;
         while (p_tame != nullptr)
         {
           bool need_post = true; // Always going to post, so ignore.
@@ -842,9 +846,11 @@ namespace snmalloc
             p_tame->atomic_read_next(RemoteAllocator::key_global, domesticate);
           const PagemapEntry& entry =
             Config::Backend::get_metaentry(snmalloc::address_cast(p_tame));
+          received_bytes += sizeclass_full_to_size(entry.get_sizeclass());
           handle_dealloc_remote(entry, p_tame.as_void(), need_post);
           p_tame = n_tame;
         }
+        RemoteDeallocCache::remote_inflight -= received_bytes;
       }
       else
       {

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -369,6 +369,8 @@ namespace snmalloc
         // don't touch the cache lines at this point in snmalloc_check_client.
         auto start = clear_slab(meta, sizeclass);
 
+        stats[sizeclass].slabs_deallocated++;
+        
         Config::Backend::dealloc_chunk(
           get_backend_local_state(),
           *meta,
@@ -404,6 +406,8 @@ namespace snmalloc
 
         // Remove from set of fully used slabs.
         meta->node.remove();
+
+        stats[entry.get_sizeclass()].slabs_deallocated++;
 
         Config::Backend::dealloc_chunk(
           get_backend_local_state(), *meta, p, size);
@@ -830,6 +834,7 @@ namespace snmalloc
       auto r = finish_alloc<zero_mem, Config>(p, sizeclass);
 
       stats[sizeclass].objects_allocated++;
+      stats[sizeclass].slabs_allocated++;
       return ticker.check_tick(r);
     }
 

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -87,6 +87,9 @@ namespace snmalloc
       }
     }
 
+    if (result == nullptr  && RemoteDeallocCache::remote_inflight.load() != 0)
+      error("ERROR: RemoteDeallocCache::remote_inflight != 0");
+
     if (result != nullptr)
     {
       *result = okay;

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -165,7 +165,7 @@ namespace snmalloc
       auto size =
         snmalloc::sizeclass_full_to_size(snmalloc::sizeclass_t::from_raw(i));
       auto in_use = allocated - deallocated;
-      snmalloc::message<1024>("{},{},{},{},{}", i, size, allocated, deallocated, in_use);
+      snmalloc::message<1024>("SNMALLOCallocs,{},{},{},{},{}", i, size, allocated, deallocated, in_use);
     }
 #endif
   }

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -87,7 +87,7 @@ namespace snmalloc
       }
     }
 
-    if (result == nullptr  && RemoteDeallocCache::remote_inflight.load() != 0)
+    if (result == nullptr  && RemoteDeallocCache::remote_inflight.get_curr() != 0)
       error("ERROR: RemoteDeallocCache::remote_inflight != 0");
 
     if (result != nullptr)

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -87,7 +87,8 @@ namespace snmalloc
       }
     }
 
-    if (result == nullptr  && RemoteDeallocCache::remote_inflight.get_curr() != 0)
+    if (
+      result == nullptr && RemoteDeallocCache::remote_inflight.get_curr() != 0)
       error("ERROR: RemoteDeallocCache::remote_inflight != 0");
 
     if (result != nullptr)
@@ -158,8 +159,12 @@ namespace snmalloc
     auto l_dump = dump++;
     if (l_dump == 0)
     {
-      message<1024>("snmalloc_allocs,dumpid,sizeclass,size,allocated,deallocated,in_use,bytes,slabs allocated,slabs deallocated,slabs in_use,slabs bytes");
-      message<1024>("snmalloc_totals,dumpid,backend bytes,peak backend bytes,requested,slabs requested bytes");
+      message<1024>(
+        "snmalloc_allocs,dumpid,sizeclass,size,allocated,deallocated,in_use,"
+        "bytes,slabs allocated,slabs deallocated,slabs in_use,slabs bytes");
+      message<1024>(
+        "snmalloc_totals,dumpid,backend bytes,peak backend "
+        "bytes,requested,slabs requested bytes");
     }
 
     auto stats = snmalloc::get_stats<Config>();
@@ -183,8 +188,26 @@ namespace snmalloc
       auto amount_slabs = in_use_slabs * slab_size;
       total_live_slabs += amount_slabs;
 
-      snmalloc::message<1024>("snmalloc_allocs,{},{},{},{},{},{},{},{},{},{},{}", l_dump, i, size, allocated, deallocated, in_use, amount, slabs_allocated, slabs_deallocated, in_use_slabs, amount_slabs);
+      snmalloc::message<1024>(
+        "snmalloc_allocs,{},{},{},{},{},{},{},{},{},{},{}",
+        l_dump,
+        i,
+        size,
+        allocated,
+        deallocated,
+        in_use,
+        amount,
+        slabs_allocated,
+        slabs_deallocated,
+        in_use_slabs,
+        amount_slabs);
     }
-    snmalloc::message<1024>("snmalloc_totals,{},{},{},{},{}", l_dump, Config::Backend::get_current_usage(), Config::Backend::get_peak_usage(), total_live, total_live_slabs);
+    snmalloc::message<1024>(
+      "snmalloc_totals,{},{},{},{},{}",
+      l_dump,
+      Config::Backend::get_current_usage(),
+      Config::Backend::get_peak_usage(),
+      total_live,
+      total_live_slabs);
   }
 } // namespace snmalloc

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -164,7 +164,7 @@ namespace snmalloc
         "bytes,slabs allocated,slabs deallocated,slabs in_use,slabs bytes");
       message<1024>(
         "snmalloc_totals,dumpid,backend bytes,peak backend "
-        "bytes,requested,slabs requested bytes");
+        "bytes,requested,slabs requested bytes,remote inflight bytes,allocator count");
     }
 
     auto stats = snmalloc::get_stats<Config>();
@@ -203,11 +203,13 @@ namespace snmalloc
         amount_slabs);
     }
     snmalloc::message<1024>(
-      "snmalloc_totals,{},{},{},{},{}",
+      "snmalloc_totals,{},{},{},{},{},{},{}",
       l_dump,
       Config::Backend::get_current_usage(),
       Config::Backend::get_peak_usage(),
       total_live,
-      total_live_slabs);
+      total_live_slabs,
+      RemoteDeallocCache::remote_inflight.get_curr(),
+      Config::pool().get_count());
   }
 } // namespace snmalloc

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -164,7 +164,8 @@ namespace snmalloc
         "bytes,slabs allocated,slabs deallocated,slabs in_use,slabs bytes");
       message<1024>(
         "snmalloc_totals,dumpid,backend bytes,peak backend "
-        "bytes,requested,slabs requested bytes,remote inflight bytes,allocator count");
+        "bytes,requested,slabs requested bytes,remote inflight bytes,allocator "
+        "count");
     }
 
     auto stats = snmalloc::get_stats<Config>();

--- a/src/snmalloc/mem/globalalloc.h
+++ b/src/snmalloc/mem/globalalloc.h
@@ -137,24 +137,23 @@ namespace snmalloc
     }
   }
 
-  template<SNMALLOC_CONCEPT(ConceptBackendGlobals) SharedStateHandle>
+  template<SNMALLOC_CONCEPT(IsConfig) Config>
   inline static AllocStats get_stats()
   {
-    auto alloc = AllocPool<SharedStateHandle>::iterate();
+    auto alloc = AllocPool<Config>::iterate();
     AllocStats stats;
     while (alloc != nullptr)
     {
       stats += alloc->get_stats();
-      alloc = AllocPool<SharedStateHandle>::iterate(alloc);
+      alloc = AllocPool<Config>::iterate(alloc);
     }
     return stats;
   }
 
-  template<SNMALLOC_CONCEPT(ConceptBackendGlobals) SharedStateHandle>
+  template<SNMALLOC_CONCEPT(IsConfig) Config>
   inline static void print_alloc_stats()
   {
-#ifndef SNMALLOC_PASS_THROUGH // This test depends on snmalloc internals
-    auto stats = snmalloc::get_stats<SharedStateHandle>();
+    auto stats = snmalloc::get_stats<Config>();
     for (size_t i = 0; i < snmalloc::SIZECLASS_REP_SIZE; i++)
     {
       auto sc = snmalloc::sizeclass_t::from_raw(i);
@@ -167,6 +166,5 @@ namespace snmalloc
       auto in_use = allocated - deallocated;
       snmalloc::message<1024>("SNMALLOCallocs,{},{},{},{},{}", i, size, allocated, deallocated, in_use);
     }
-#endif
   }
 } // namespace snmalloc

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -212,8 +212,11 @@ namespace snmalloc
         }
 
         if (chunk.unsafe_ptr() != nullptr)
-          core_alloc->stats[size_to_sizeclass_full(size)].objects_allocated++;
-
+        {
+          auto sc = size_to_sizeclass_full(size);
+          core_alloc->stats[sc].objects_allocated++;
+          core_alloc->stats[sc].slabs_allocated++;
+        }
         return capptr_chunk_is_alloc(capptr_to_user_address_control(chunk));
       });
     }

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -211,6 +211,9 @@ namespace snmalloc
             chunk.unsafe_ptr(), bits::next_pow2(size));
         }
 
+        if (chunk.unsafe_ptr() != nullptr)
+          core_alloc->stats[size_to_sizeclass_full(size)].objects_allocated++;
+
         return capptr_chunk_is_alloc(capptr_to_user_address_control(chunk));
       });
     }
@@ -246,7 +249,7 @@ namespace snmalloc
       };
 
       return local_cache.template alloc<zero_mem, Config>(
-        domesticate, size, slowpath);
+        domesticate, core_alloc->stats, size, slowpath);
     }
 
     /**
@@ -648,7 +651,7 @@ namespace snmalloc
       {
         dealloc_cheri_checks(p_tame.unsafe_ptr());
 
-        if (SNMALLOC_LIKELY(CoreAlloc::dealloc_local_object_fast(
+        if (SNMALLOC_LIKELY(core_alloc->dealloc_local_object_fast(
               entry, p_tame, local_cache.entropy)))
           return;
         core_alloc->dealloc_local_object_slow(p_tame, entry);

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -418,7 +418,7 @@ namespace snmalloc
         message<1024>("flush(): core_alloc={}", core_alloc);
 #endif
         local_cache.remote_allocator = &Config::unused_remote;
-        local_cache.remote_dealloc_cache.capacity = 0;
+        local_cache.remote_dealloc_cache.cache_bytes = REMOTE_CACHE;
       }
     }
 

--- a/src/snmalloc/mem/localcache.h
+++ b/src/snmalloc/mem/localcache.h
@@ -95,8 +95,11 @@ namespace snmalloc
       typename Config,
       typename Slowpath,
       typename Domesticator>
-    SNMALLOC_FAST_PATH capptr::Alloc<void>
-    alloc(Domesticator domesticate, AllocStats& stats, size_t size, Slowpath slowpath)
+    SNMALLOC_FAST_PATH capptr::Alloc<void> alloc(
+      Domesticator domesticate,
+      AllocStats& stats,
+      size_t size,
+      Slowpath slowpath)
     {
       auto& key = entropy.get_free_list_key();
       smallsizeclass_t sizeclass = size_to_sizeclass(size);

--- a/src/snmalloc/mem/localcache.h
+++ b/src/snmalloc/mem/localcache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../ds/ds.h"
+#include "allocstats.h"
 #include "freelist.h"
 #include "remotecache.h"
 #include "sizeclasstable.h"
@@ -95,7 +96,7 @@ namespace snmalloc
       typename Slowpath,
       typename Domesticator>
     SNMALLOC_FAST_PATH capptr::Alloc<void>
-    alloc(Domesticator domesticate, size_t size, Slowpath slowpath)
+    alloc(Domesticator domesticate, AllocStats& stats, size_t size, Slowpath slowpath)
     {
       auto& key = entropy.get_free_list_key();
       smallsizeclass_t sizeclass = size_to_sizeclass(size);
@@ -103,6 +104,7 @@ namespace snmalloc
       if (SNMALLOC_LIKELY(!fl.empty()))
       {
         auto p = fl.take(key, domesticate);
+        stats[sizeclass].objects_allocated++;
         return finish_alloc<zero_mem, Config>(p, sizeclass);
       }
       return slowpath(sizeclass, &fl);

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -34,9 +34,15 @@ namespace snmalloc
 
     FlagWord lock{};
     capptr::Alloc<T> list{nullptr};
+    std::atomic<size_t> count{0};
 
   public:
     constexpr PoolState() = default;
+
+    size_t get_count()
+    {
+      return count.load(std::memory_order_relaxed);
+    }
   };
 
   /**
@@ -155,6 +161,8 @@ namespace snmalloc
       FlagLock f(pool.lock);
       p->list_next = pool.list;
       pool.list = p;
+
+      pool.count++;
 
       p->set_in_use();
       return p.unsafe_ptr();

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -19,7 +19,7 @@ namespace snmalloc
   {
     std::array<freelist::Builder<false>, REMOTE_SLOTS> list;
 
-    static inline std::atomic<size_t> remote_inflight{0};
+    static inline Stat remote_inflight;
 
     /**
      * The total amount of bytes of memory in the cache.

--- a/src/snmalloc/mem/remotecache.h
+++ b/src/snmalloc/mem/remotecache.h
@@ -19,14 +19,17 @@ namespace snmalloc
   {
     std::array<freelist::Builder<false>, REMOTE_SLOTS> list;
 
+    static inline std::atomic<size_t> remote_inflight{0};
+
     /**
-     * The total amount of memory we are waiting for before we will dispatch
-     * to other allocators. Zero can mean we have not initialised the allocator
-     * yet. This is initialised to the 0 so that we always hit a slow path to
-     * start with, when we hit the slow path and need to dispatch everything, we
-     * can check if we are a real allocator and lazily provide a real allocator.
+     * The total amount of bytes of memory in the cache.
+     *
+     * REMOTE_CACHE is used as the initial value, so that we always hit a slow
+     * path to start with, when we hit the slow path and need to dispatch
+     * everything, we can check if we are a real allocator and lazily provide a
+     * real allocator.
      */
-    int64_t capacity{0};
+    size_t cache_bytes{REMOTE_CACHE};
 
 #ifndef NDEBUG
     bool initialised = false;
@@ -56,13 +59,10 @@ namespace snmalloc
     template<typename Entry>
     SNMALLOC_FAST_PATH bool reserve_space(const Entry& entry)
     {
-      auto size =
-        static_cast<int64_t>(sizeclass_full_to_size(entry.get_sizeclass()));
+      auto size = sizeclass_full_to_size(entry.get_sizeclass());
 
-      bool result = capacity > size;
-      if (result)
-        capacity -= size;
-      return result;
+      cache_bytes += size;
+      return cache_bytes < REMOTE_CACHE;
     }
 
     template<size_t allocator_size>
@@ -91,6 +91,8 @@ namespace snmalloc
                              return capptr_domesticate<Config>(local_state, p);
                            };
 
+      // We are about to post cache_bytes bytes to other allocators.
+      remote_inflight += cache_bytes;
       while (true)
       {
         auto my_slot = get_slot<allocator_size>(id, post_round);
@@ -152,7 +154,7 @@ namespace snmalloc
       }
 
       // Reset capacity as we have empty everything
-      capacity = REMOTE_CACHE;
+      cache_bytes = 0;
 
       return sent_something;
     }
@@ -177,7 +179,7 @@ namespace snmalloc
         // a null address.
         l.init(0, RemoteAllocator::key_global);
       }
-      capacity = REMOTE_CACHE;
+      cache_bytes = 0;
     }
   };
 } // namespace snmalloc

--- a/src/test/func/cleanup/cleanup.cc
+++ b/src/test/func/cleanup/cleanup.cc
@@ -1,0 +1,56 @@
+#include <snmalloc/snmalloc.h>
+
+#include <iostream>
+#include <thread>
+
+void ecall()
+{
+    snmalloc::ScopedAllocator a;
+    std::vector<void*> allocs;
+    size_t count = 0;
+    for (size_t j = 0; j < 1000; j++)
+    {
+        allocs.push_back(a.alloc.alloc(j % 1024));
+        count += j % 1024;
+    }
+    auto p = a.alloc.alloc(1 * 1024 * 1024);
+    memset(p, 0, 1 * 1024 * 1024);
+
+    for (size_t j = 0; j < allocs.size(); j++)
+        a.alloc.dealloc(allocs[j]);
+    
+    a.alloc.dealloc(p);
+}
+
+void thread_body()
+{
+  for (int i = 0; i < 10000; i++) {
+    ecall();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+void monitor_body()
+{
+   for (int i = 0; i < 10000; i++) { 
+    std::cout << "Current: " << snmalloc::Alloc::StateHandle::get_current_usage() << std::endl;
+    std::cout << "Peak   : " << snmalloc::Alloc::StateHandle::get_peak_usage() << std::endl;
+    std::cout << "Allocs : " << snmalloc::Alloc::StateHandle::pool().get_count() << std::endl;
+    std::cout << "--------------------------------------------" << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+   }
+}
+
+int main()
+{
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 8; i++)
+  {
+    threads.push_back(std::thread(thread_body));
+  }
+  threads.push_back(std::thread(monitor_body));
+
+  for (auto& t : threads)
+    t.join();
+  return 0;
+}

--- a/src/test/func/cleanup/cleanup.cc
+++ b/src/test/func/cleanup/cleanup.cc
@@ -1,30 +1,30 @@
-#include <snmalloc/snmalloc.h>
-
 #include <iostream>
+#include <snmalloc/snmalloc.h>
 #include <thread>
 
 void ecall()
 {
-    snmalloc::ScopedAllocator a;
-    std::vector<void*> allocs;
-    size_t count = 0;
-    for (size_t j = 0; j < 1000; j++)
-    {
-        allocs.push_back(a.alloc.alloc(j % 1024));
-        count += j % 1024;
-    }
-    auto p = a.alloc.alloc(1 * 1024 * 1024);
-    memset(p, 0, 1 * 1024 * 1024);
+  snmalloc::ScopedAllocator a;
+  std::vector<void*> allocs;
+  size_t count = 0;
+  for (size_t j = 0; j < 1000; j++)
+  {
+    allocs.push_back(a.alloc.alloc(j % 1024));
+    count += j % 1024;
+  }
+  auto p = a.alloc.alloc(1 * 1024 * 1024);
+  memset(p, 0, 1 * 1024 * 1024);
 
-    for (size_t j = 0; j < allocs.size(); j++)
-        a.alloc.dealloc(allocs[j]);
-    
-    a.alloc.dealloc(p);
+  for (size_t j = 0; j < allocs.size(); j++)
+    a.alloc.dealloc(allocs[j]);
+
+  a.alloc.dealloc(p);
 }
 
 void thread_body()
 {
-  for (int i = 0; i < 10000; i++) {
+  for (int i = 0; i < 10000; i++)
+  {
     ecall();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
@@ -32,13 +32,19 @@ void thread_body()
 
 void monitor_body()
 {
-   for (int i = 0; i < 10000; i++) { 
-    std::cout << "Current: " << snmalloc::Alloc::Config::Backend::get_current_usage() << std::endl;
-    std::cout << "Peak   : " << snmalloc::Alloc::Config::Backend::get_peak_usage() << std::endl;
-    std::cout << "Allocs : " << snmalloc::Alloc::Config::pool().get_count() << std::endl;
+  for (int i = 0; i < 10000; i++)
+  {
+    std::cout << "Current: "
+              << snmalloc::Alloc::Config::Backend::get_current_usage()
+              << std::endl;
+    std::cout << "Peak   : "
+              << snmalloc::Alloc::Config::Backend::get_peak_usage()
+              << std::endl;
+    std::cout << "Allocs : " << snmalloc::Alloc::Config::pool().get_count()
+              << std::endl;
     std::cout << "--------------------------------------------" << std::endl;
     std::this_thread::sleep_for(std::chrono::seconds(1));
-   }
+  }
 }
 
 int main()

--- a/src/test/func/cleanup/cleanup.cc
+++ b/src/test/func/cleanup/cleanup.cc
@@ -33,9 +33,9 @@ void thread_body()
 void monitor_body()
 {
    for (int i = 0; i < 10000; i++) { 
-    std::cout << "Current: " << snmalloc::Alloc::StateHandle::get_current_usage() << std::endl;
-    std::cout << "Peak   : " << snmalloc::Alloc::StateHandle::get_peak_usage() << std::endl;
-    std::cout << "Allocs : " << snmalloc::Alloc::StateHandle::pool().get_count() << std::endl;
+    std::cout << "Current: " << snmalloc::Alloc::Config::Backend::get_current_usage() << std::endl;
+    std::cout << "Peak   : " << snmalloc::Alloc::Config::Backend::get_peak_usage() << std::endl;
+    std::cout << "Allocs : " << snmalloc::Alloc::Config::pool().get_count() << std::endl;
     std::cout << "--------------------------------------------" << std::endl;
     std::this_thread::sleep_for(std::chrono::seconds(1));
    }

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -26,11 +26,11 @@ void debug_check_empty_1()
     abort();
   }
 
-  snmalloc::print_alloc_stats<snmalloc::Globals>();
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
    a.dealloc(r);
 
-  snmalloc::print_alloc_stats<snmalloc::Globals>();
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != true)
@@ -53,7 +53,7 @@ void debug_check_empty_1()
     abort();
   }
 
-  snmalloc::print_alloc_stats<snmalloc::Globals>();
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
   a.dealloc(r);
 
@@ -67,7 +67,6 @@ void debug_check_empty_1()
   }
 
   snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
-#endif
 }
 
 template<size_t size>

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -28,7 +28,7 @@ void debug_check_empty_1()
 
   snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
-   a.dealloc(r);
+  a.dealloc(r);
 
   snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 

--- a/src/test/func/statistics/stats.cc
+++ b/src/test/func/statistics/stats.cc
@@ -18,6 +18,7 @@ void debug_check_empty_1()
   auto r = a.alloc(size);
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
   if (result != false)
   {
     std::cout << "debug_check_empty failed to detect leaked memory:" << size
@@ -25,7 +26,11 @@ void debug_check_empty_1()
     abort();
   }
 
-  a.dealloc(r);
+  snmalloc::print_alloc_stats<snmalloc::Globals>();
+
+   a.dealloc(r);
+
+  snmalloc::print_alloc_stats<snmalloc::Globals>();
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != true)
@@ -34,7 +39,11 @@ void debug_check_empty_1()
     abort();
   }
 
-  r = a.alloc(size);
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
+
+  r = a.alloc(16);
+
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != false)
@@ -44,7 +53,11 @@ void debug_check_empty_1()
     abort();
   }
 
+  snmalloc::print_alloc_stats<snmalloc::Globals>();
+
   a.dealloc(r);
+
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
 
   snmalloc::debug_check_empty<snmalloc::StandardConfig>(&result);
   if (result != true)
@@ -52,6 +65,9 @@ void debug_check_empty_1()
     std::cout << "debug_check_empty failed to say empty:" << size << std::endl;
     abort();
   }
+
+  snmalloc::print_alloc_stats<snmalloc::StandardConfig>();
+#endif
 }
 
 template<size_t size>

--- a/src/test/perf/churn/churn.cc
+++ b/src/test/perf/churn/churn.cc
@@ -1,0 +1,86 @@
+#include <iostream>
+#include <queue>
+#include <snmalloc/snmalloc.h>
+#include <thread>
+#include <vector>
+
+int main()
+{
+  std::vector<std::thread> threads;
+  std::atomic<size_t> running;
+  snmalloc::Stat requests;
+
+  for (size_t i = 0; i < 16; i++)
+  {
+    std::thread([&running, &requests]() {
+      std::queue<size_t*> q;
+      while (true)
+      {
+        snmalloc::ScopedAllocator alloc;
+        running++;
+
+        if (rand() % 1000 == 0)
+        {
+          // Deallocate everything in the queue
+          while (q.size() > 0)
+          {
+            auto p = q.front();
+            requests -= *p;
+            alloc->dealloc(p);
+            q.pop();
+          }
+        }
+
+        for (size_t j = 0; j < 1000; j++)
+        {
+          if (q.size() >= 20000 || (q.size() > 0 && (rand() % 10 == 0)))
+          {
+            auto p = q.front();
+            requests -= *p;
+            alloc->dealloc(p);
+            q.pop();
+          }
+          else
+          {
+            size_t size =
+              (rand() % 1024 == 0) ? 16 * 1024 * (1 << (rand() % 3)) : 48;
+            requests += size;
+            auto p = (size_t*)alloc->alloc(size);
+            *p = size;
+            q.push(p);
+          }
+        }
+
+        running--;
+        std::this_thread::sleep_for(std::chrono::microseconds(rand() % 2000));
+      }
+    }).detach();
+  }
+
+  std::thread([&requests]() {
+    size_t count = 0;
+    while (count < 2000)
+    {
+      count++;
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      // std::cout << "Inflight:            " <<
+      // snmalloc::RemoteDeallocCache::remote_inflight << std::endl; std::cout
+      // << "Current reservation: " << snmalloc::Globals::get_current_usage() <<
+      // std::endl; std::cout << "Peak reservation:    " <<
+      // snmalloc::Globals::get_peak_usage() << std::endl; std::cout <<
+      // "Allocator count:     " << snmalloc::Globals::pool().get_count() <<
+      // std::endl; std::cout << "Running threads:     " << running <<
+      // std::endl; std::cout << "Index:               " << count << std::endl;
+      // std::cout << "------------------------------------------" << std::endl;
+      std::cout << count << "," << snmalloc::Alloc::Config::Backend::get_peak_usage() << ","
+                << snmalloc::Alloc::Config::Backend::get_current_usage() << "," << requests.get_curr()
+                << "," << requests.get_peak() << ","
+                << snmalloc::RemoteDeallocCache::remote_inflight.get_peak()
+                << "," << snmalloc::RemoteDeallocCache::remote_inflight.get_curr()
+                << std::endl;
+      snmalloc::print_alloc_stats<snmalloc::Alloc::Config>();
+    }
+  }).join();
+
+  return 0;
+}

--- a/src/test/perf/churn/churn.cc
+++ b/src/test/perf/churn/churn.cc
@@ -72,11 +72,13 @@ int main()
       // std::endl; std::cout << "Running threads:     " << running <<
       // std::endl; std::cout << "Index:               " << count << std::endl;
       // std::cout << "------------------------------------------" << std::endl;
-      std::cout << count << "," << snmalloc::Alloc::Config::Backend::get_peak_usage() << ","
-                << snmalloc::Alloc::Config::Backend::get_current_usage() << "," << requests.get_curr()
-                << "," << requests.get_peak() << ","
+      std::cout << count << ","
+                << snmalloc::Alloc::Config::Backend::get_peak_usage() << ","
+                << snmalloc::Alloc::Config::Backend::get_current_usage() << ","
+                << requests.get_curr() << "," << requests.get_peak() << ","
                 << snmalloc::RemoteDeallocCache::remote_inflight.get_peak()
-                << "," << snmalloc::RemoteDeallocCache::remote_inflight.get_curr()
+                << ","
+                << snmalloc::RemoteDeallocCache::remote_inflight.get_curr()
                 << std::endl;
       snmalloc::print_alloc_stats<snmalloc::Alloc::Config>();
     }


### PR DESCRIPTION
This adds some statistic for tracking
* How many deallocations are in message queues.
* How many allocators have been created.
* Per sizeclass statistics
  - Number of objects allocated
  - Number of objects deallocated
  - Number of slabs allocated
  - Number of slabs deallocated

The per sizeclass statistics are tracked per allocator, and a racy read is done to combine the results for displaying.

These statistics were used to debug #615 to calculate the fragmentation.

The displayed statistics are intended for post processing to calculate the fragmentation/utilisation. 

The interface just prints the results using `message`.  This could be improved with a better logging infrastructure.