### PR TITLE
Conditional range

### DIFF
--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -87,6 +87,12 @@ namespace snmalloc
       auto [heap_base, heap_length] =
         Pagemap::concretePagemap.init(base, length);
 
+      // Make this a alloc_config constant.
+      if (length < 256 * 1024 * 1024)
+      {
+        local_state->set_small_heap();
+      }
+
       Authmap::arena = capptr::Arena<void>::unsafe_from(heap_base);
 
       Pagemap::register_range(Authmap::arena, heap_length);

--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -90,7 +90,7 @@ namespace snmalloc
       // Make this a alloc_config constant.
       if (length < MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY)
       {
-        local_state->set_small_heap();
+        LocalState::set_small_heap();
       }
 
       Authmap::arena = capptr::Arena<void>::unsafe_from(heap_base);

--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -88,7 +88,7 @@ namespace snmalloc
         Pagemap::concretePagemap.init(base, length);
 
       // Make this a alloc_config constant.
-      if (length < 256 * 1024 * 1024)
+      if (length < MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY)
       {
         local_state->set_small_heap();
       }

--- a/src/snmalloc/backend/meta_protected_range.h
+++ b/src/snmalloc/backend/meta_protected_range.h
@@ -120,6 +120,11 @@ namespace snmalloc
       return meta_range;
     }
 
+    void set_small_heap()
+    {
+      error("Not supported! Cannot use a small heap with MetaProtectedRange.");
+    }
+
     // Create global range that can service small meta-data requests.
     // Don't want to add the SmallBuddyRange to the CentralMetaRange as that
     // would require committing memory inside the main global lock.

--- a/src/snmalloc/backend/meta_protected_range.h
+++ b/src/snmalloc/backend/meta_protected_range.h
@@ -120,11 +120,6 @@ namespace snmalloc
       return meta_range;
     }
 
-    void set_small_heap()
-    {
-      error("Not supported! Cannot use a small heap with MetaProtectedRange.");
-    }
-
     // Create global range that can service small meta-data requests.
     // Don't want to add the SmallBuddyRange to the CentralMetaRange as that
     // would require committing memory inside the main global lock.

--- a/src/snmalloc/backend/standard_range.h
+++ b/src/snmalloc/backend/standard_range.h
@@ -49,11 +49,11 @@ namespace snmalloc
     // Use buddy allocators to cache locally.
     using LargeObjectRange = Pipe<
       Stats,
-      LargeBuddyRange<
+      StaticConditionalRange<LargeBuddyRange<
         LocalCacheSizeBits,
         LocalCacheSizeBits,
         Pagemap,
-        page_size_bits>>;
+        page_size_bits>>>;
 
   private:
     using ObjectRange = Pipe<LargeObjectRange, SmallBuddyRange>;
@@ -84,6 +84,12 @@ namespace snmalloc
     {
       // Use the object range to service meta-data requests.
       return object_range;
+    }
+
+    void set_small_heap()
+    {
+      // This disables the thread local caching of large objects.
+      object_range.template ancestor<LargeObjectRange>()->disable_range();
     }
   };
 } // namespace snmalloc

--- a/src/snmalloc/backend/standard_range.h
+++ b/src/snmalloc/backend/standard_range.h
@@ -86,10 +86,10 @@ namespace snmalloc
       return object_range;
     }
 
-    void set_small_heap()
+    static void set_small_heap()
     {
       // This disables the thread local caching of large objects.
-      object_range.template ancestor<LargeObjectRange>()->disable_range();
+      LargeObjectRange::disable_range();
     }
   };
 } // namespace snmalloc

--- a/src/snmalloc/backend_helpers/backend_helpers.h
+++ b/src/snmalloc/backend_helpers/backend_helpers.h
@@ -14,5 +14,6 @@
 #include "palrange.h"
 #include "range_helpers.h"
 #include "smallbuddyrange.h"
+#include "staticconditionalrange.h"
 #include "statsrange.h"
 #include "subrange.h"

--- a/src/snmalloc/backend_helpers/staticconditionalrange.h
+++ b/src/snmalloc/backend_helpers/staticconditionalrange.h
@@ -29,12 +29,21 @@ namespace snmalloc
       static inline bool disable_range_{false};
 
     public:
-      static constexpr bool Aligned = ActualParentRange::Aligned;
+      // Both parent and grandparent must be aligned for this range to be
+      // aligned.
+      static constexpr bool Aligned =
+        ActualParentRange::Aligned && ParentRange::Aligned;
 
+      // Both parent and grandparent must be aligned for this range to be
+      // concurrency safe.
       static constexpr bool ConcurrencySafe =
-        ActualParentRange::ConcurrencySafe;
+        ActualParentRange::ConcurrencySafe && ParentRange::ConcurrencySafe;
 
       using ChunkBounds = typename ActualParentRange::ChunkBounds;
+
+      static_assert(
+        ChunkBounds == ParentRange::ChunkBounds,
+        "Grandparent and optional parent range chunk bounds must be equal");
 
       constexpr Type() = default;
 

--- a/src/snmalloc/backend_helpers/staticconditionalrange.h
+++ b/src/snmalloc/backend_helpers/staticconditionalrange.h
@@ -12,8 +12,8 @@ namespace snmalloc
     // Disabling is global, and not local.
     // This is used to allow disabling thread local buddy allocators when the
     // initial fixed size heap is small.
-    // 
-    // The range builds a more complex parent 
+    //
+    // The range builds a more complex parent
     //    Pipe<ParentRange, OptionalRange>
     // and uses the ancestor functions to bypass the OptionalRange if the flag
     // has been set.
@@ -31,7 +31,8 @@ namespace snmalloc
     public:
       static constexpr bool Aligned = ActualParentRange::Aligned;
 
-      static constexpr bool ConcurrencySafe = ActualParentRange::ConcurrencySafe;
+      static constexpr bool ConcurrencySafe =
+        ActualParentRange::ConcurrencySafe;
 
       using ChunkBounds = typename ActualParentRange::ChunkBounds;
 

--- a/src/snmalloc/backend_helpers/staticconditionalrange.h
+++ b/src/snmalloc/backend_helpers/staticconditionalrange.h
@@ -60,7 +60,7 @@ namespace snmalloc
         parent.dealloc_range(base, size);
       }
 
-      void disable_range()
+      static void disable_range()
       {
         disable_range_ = true;
       }

--- a/src/snmalloc/backend_helpers/staticconditionalrange.h
+++ b/src/snmalloc/backend_helpers/staticconditionalrange.h
@@ -42,7 +42,7 @@ namespace snmalloc
       using ChunkBounds = typename ActualParentRange::ChunkBounds;
 
       static_assert(
-        ChunkBounds == ParentRange::ChunkBounds,
+        std::is_same_v<ChunkBounds, typename ParentRange::ChunkBounds>,
         "Grandparent and optional parent range chunk bounds must be equal");
 
       constexpr Type() = default;

--- a/src/snmalloc/backend_helpers/staticconditionalrange.h
+++ b/src/snmalloc/backend_helpers/staticconditionalrange.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "../pal/pal.h"
+#include "empty_range.h"
+#include "range_helpers.h"
+
+namespace snmalloc
+{
+  template<typename OptionalRange>
+  struct StaticConditionalRange
+  {
+    template<typename ParentRange>
+    class Type : public ContainsParent<Pipe<ParentRange, OptionalRange>>
+    {
+      using ActualParentRange = Pipe<ParentRange, OptionalRange>;
+
+      using ContainsParent<ActualParentRange>::parent;
+
+      static inline bool disable_range_{false};
+
+    public:
+      static constexpr bool Aligned = ActualParentRange::Aligned;
+
+      static constexpr bool ConcurrencySafe = ActualParentRange::ConcurrencySafe;
+
+      using ChunkBounds = typename ActualParentRange::ChunkBounds;
+      static_assert(
+        ChunkBounds::address_space_control ==
+        capptr::dimension::AddressSpaceControl::Full);
+
+      constexpr Type() = default;
+
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
+      {
+        if (disable_range_)
+        {
+          return this->template ancestor<ParentRange>()->alloc_range(size);
+        }
+
+        return parent.alloc_range(size);
+      }
+
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
+      {
+        if (disable_range_)
+        {
+          this->template ancestor<ParentRange>()->dealloc_range(base, size);
+          return;
+        }
+        parent.dealloc_range(base, size);
+      }
+
+      void disable_range()
+      {
+        disable_range_ = true;
+      }
+    };
+  };
+} // namespace snmalloc

--- a/src/snmalloc/ds/allocconfig.h
+++ b/src/snmalloc/ds/allocconfig.h
@@ -92,4 +92,9 @@ namespace snmalloc
     1 << MIN_CHUNK_BITS
 #endif
     ;
+
+  // Used to configure when the backend should use thread local buddies.
+  // This only basically is used to disable some buddy allocators on small
+  // fixed heap scenarios like OpenEnclave.
+  static constexpr size_t MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY = bits::one_at_bit(25);
 } // namespace snmalloc

--- a/src/snmalloc/ds/allocconfig.h
+++ b/src/snmalloc/ds/allocconfig.h
@@ -96,5 +96,6 @@ namespace snmalloc
   // Used to configure when the backend should use thread local buddies.
   // This only basically is used to disable some buddy allocators on small
   // fixed heap scenarios like OpenEnclave.
-  static constexpr size_t MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY = bits::one_at_bit(25);
+  static constexpr size_t MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY =
+    bits::one_at_bit(25);
 } // namespace snmalloc

--- a/src/snmalloc/ds/allocconfig.h
+++ b/src/snmalloc/ds/allocconfig.h
@@ -97,5 +97,5 @@ namespace snmalloc
   // This only basically is used to disable some buddy allocators on small
   // fixed heap scenarios like OpenEnclave.
   static constexpr size_t MIN_HEAP_SIZE_FOR_THREAD_LOCAL_BUDDY =
-    bits::one_at_bit(25);
+    bits::one_at_bit(27);
 } // namespace snmalloc


### PR DESCRIPTION
This PR adds a new type of Range that can allow a range to be disabled dynamically. 

This is used to disable some backend caching if the heap is very small, such as in the OpenEnclave case.