### PR TITLE
Move to clang-format 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ function(clangformat_targets)
   # tool.  It does not work with older versions as AfterCaseLabel is not supported
   # in earlier versions.
   find_program(CLANG_FORMAT NAMES
-    clang-format90 clang-format-9)
+    clang-format150 clang-format-15)
 
   # If we've found a clang-format tool, generate a target for it, otherwise emit
   # a warning.

--- a/src/snmalloc/aal/aal_concept.h
+++ b/src/snmalloc/aal/aal_concept.h
@@ -14,87 +14,79 @@ namespace snmalloc
    * machine word size, and an upper bound on the address space size
    */
   template<typename AAL>
-  concept IsAAL_static_members = requires()
-  {
-    typename std::integral_constant<uint64_t, AAL::aal_features>;
-    typename std::integral_constant<int, AAL::aal_name>;
-    typename std::integral_constant<std::size_t, AAL::bits>;
-    typename std::integral_constant<std::size_t, AAL::address_bits>;
-  };
+  concept IsAAL_static_members =
+    requires() {
+      typename std::integral_constant<uint64_t, AAL::aal_features>;
+      typename std::integral_constant<int, AAL::aal_name>;
+      typename std::integral_constant<std::size_t, AAL::bits>;
+      typename std::integral_constant<std::size_t, AAL::address_bits>;
+    };
 
   /**
    * AALs provide a prefetch operation.
    */
   template<typename AAL>
-  concept IsAAL_prefetch = requires(void* ptr)
-  {
-    {
-      AAL::prefetch(ptr)
-    }
-    noexcept->ConceptSame<void>;
-  };
+  concept IsAAL_prefetch = requires(void* ptr) {
+                             {
+                               AAL::prefetch(ptr)
+                               } noexcept -> ConceptSame<void>;
+                           };
 
   /**
    * AALs provide a notion of high-precision timing.
    */
   template<typename AAL>
-  concept IsAAL_tick = requires()
-  {
-    {
-      AAL::tick()
-    }
-    noexcept->ConceptSame<uint64_t>;
-  };
+  concept IsAAL_tick = requires() {
+                         {
+                           AAL::tick()
+                           } noexcept -> ConceptSame<uint64_t>;
+                       };
 
   template<typename AAL>
   concept IsAAL_capptr_methods =
-    requires(capptr::Chunk<void> auth, capptr::AllocFull<void> ret, size_t sz)
-  {
-    /**
-     * Produce a pointer with reduced authority from a more privilged pointer.
-     * The resulting pointer will have base at auth's address and length of
-     * exactly sz.  auth+sz must not exceed auth's limit.
-     */
-    {
-      AAL::template capptr_bound<void, capptr::bounds::Chunk>(auth, sz)
-    }
-    noexcept->ConceptSame<capptr::Chunk<void>>;
+    requires(capptr::Chunk<void> auth, capptr::AllocFull<void> ret, size_t sz) {
+      /**
+       * Produce a pointer with reduced authority from a more privilged pointer.
+       * The resulting pointer will have base at auth's address and length of
+       * exactly sz.  auth+sz must not exceed auth's limit.
+       */
+      {
+        AAL::template capptr_bound<void, capptr::bounds::Chunk>(auth, sz)
+        } noexcept -> ConceptSame<capptr::Chunk<void>>;
 
-    /**
-     * "Amplify" by copying the address of one pointer into one of higher
-     * privilege.  The resulting pointer differs from auth only in address.
-     */
-    {
-      AAL::capptr_rebound(auth, ret)
-    }
-    noexcept->ConceptSame<capptr::Chunk<void>>;
+      /**
+       * "Amplify" by copying the address of one pointer into one of higher
+       * privilege.  The resulting pointer differs from auth only in address.
+       */
+      {
+        AAL::capptr_rebound(auth, ret)
+        } noexcept -> ConceptSame<capptr::Chunk<void>>;
 
-    /**
-     * Round up an allocation size to a size this architecture can represent.
-     * While there may also, in general, be alignment requirements for
-     * representability, in snmalloc so far we have not had reason to consider
-     * these explicitly: when we use our...
-     *
-     * - sizeclass machinery (for user-facing data), we assume that all
-     *   sizeclasses describe architecturally representable aligned-and-sized
-     *   regions
-     *
-     * - Range machinery (for internal meta-data), we always choose NAPOT
-     *   regions big enough for the requested size (returning space above the
-     *   allocation within such regions for use as smaller NAPOT regions).
-     *
-     * That is, capptr_size_round is not needed on the user-facing fast paths,
-     * merely internally for bootstrap and metadata management.
-     */
-    {
-      AAL::capptr_size_round(sz)
-    }
-    noexcept->ConceptSame<size_t>;
-  };
+      /**
+       * Round up an allocation size to a size this architecture can represent.
+       * While there may also, in general, be alignment requirements for
+       * representability, in snmalloc so far we have not had reason to consider
+       * these explicitly: when we use our...
+       *
+       * - sizeclass machinery (for user-facing data), we assume that all
+       *   sizeclasses describe architecturally representable aligned-and-sized
+       *   regions
+       *
+       * - Range machinery (for internal meta-data), we always choose NAPOT
+       *   regions big enough for the requested size (returning space above the
+       *   allocation within such regions for use as smaller NAPOT regions).
+       *
+       * That is, capptr_size_round is not needed on the user-facing fast paths,
+       * merely internally for bootstrap and metadata management.
+       */
+      {
+        AAL::capptr_size_round(sz)
+        } noexcept -> ConceptSame<size_t>;
+    };
 
   template<typename AAL>
-  concept IsAAL = IsAAL_static_members<AAL>&& IsAAL_prefetch<AAL>&&
-    IsAAL_tick<AAL>&& IsAAL_capptr_methods<AAL>;
+  concept IsAAL = IsAAL_static_members<AAL> && IsAAL_prefetch<AAL> &&
+    IsAAL_tick<AAL> && IsAAL_capptr_methods<AAL>;
 
 } // namespace snmalloc
 #endif

--- a/src/snmalloc/backend/fixedglobalconfig.h
+++ b/src/snmalloc/backend/fixedglobalconfig.h
@@ -63,13 +63,11 @@ namespace snmalloc
      * C++, and not just its initializer fragment, to initialize a non-prefix
      * subset of the flags (in any order, at that).
      */
-    static constexpr Flags Options = []() constexpr
-    {
+    static constexpr Flags Options = []() constexpr {
       Flags opts = {};
       opts.HasDomesticate = true;
       return opts;
-    }
-    ();
+    }();
 
     // This needs to be a forward reference as the
     // thread local state will need to know about this.

--- a/src/snmalloc/ds/aba.h
+++ b/src/snmalloc/ds/aba.h
@@ -71,9 +71,10 @@ namespace snmalloc
         error("Only one inflight ABA operation at a time is allowed.");
       operation_in_flight = true;
 #  endif
-      return Cmp{{independent.ptr.load(std::memory_order_relaxed),
-                  independent.aba.load(std::memory_order_relaxed)},
-                 this};
+      return Cmp{
+        {independent.ptr.load(std::memory_order_relaxed),
+         independent.aba.load(std::memory_order_relaxed)},
+        this};
     }
 
     struct Cmp

--- a/src/snmalloc/ds_core/mitigations.h
+++ b/src/snmalloc/ds_core/mitigations.h
@@ -247,10 +247,10 @@ namespace snmalloc
      */
     full_checks + cheri_checks + clear_meta - freelist_forward_edge -
       pal_enforce_access :
-    /**
-     * clear_meta is important on CHERI to avoid leaking capabilities.
-     */
-    sanity_checks + cheri_checks + clear_meta;
+     /**
+      * clear_meta is important on CHERI to avoid leaking capabilities.
+      */
+     sanity_checks + cheri_checks + clear_meta;
 #else
     CHECK_CLIENT ? full_checks : no_checks;
 #endif

--- a/src/snmalloc/ds_core/redblacktree.h
+++ b/src/snmalloc/ds_core/redblacktree.h
@@ -17,11 +17,10 @@ namespace snmalloc
    * ID.
    */
   template<typename Rep>
-  concept RBRepTypes = requires()
-  {
-    typename Rep::Handle;
-    typename Rep::Contents;
-  };
+  concept RBRepTypes = requires() {
+                         typename Rep::Handle;
+                         typename Rep::Contents;
+                       };
 
   /**
    * The representation must define operations on the holder and contents
@@ -41,50 +40,36 @@ namespace snmalloc
    */
   template<typename Rep>
   concept RBRepMethods =
-    requires(typename Rep::Handle hp, typename Rep::Contents k, bool b)
-  {
-    {
-      Rep::get(hp)
-    }
-    ->ConceptSame<typename Rep::Contents>;
-    {
-      Rep::set(hp, k)
-    }
-    ->ConceptSame<void>;
-    {
-      Rep::is_red(k)
-    }
-    ->ConceptSame<bool>;
-    {
-      Rep::set_red(k, b)
-    }
-    ->ConceptSame<void>;
-    {
-      Rep::ref(b, k)
-    }
-    ->ConceptSame<typename Rep::Handle>;
-    {
-      Rep::null
-    }
-    ->ConceptSameModRef<const typename Rep::Contents>;
-    {
-      typename Rep::Handle
+    requires(typename Rep::Handle hp, typename Rep::Contents k, bool b) {
       {
-        const_cast<
+        Rep::get(hp)
+        } -> ConceptSame<typename Rep::Contents>;
+      {
+        Rep::set(hp, k)
+        } -> ConceptSame<void>;
+      {
+        Rep::is_red(k)
+        } -> ConceptSame<bool>;
+      {
+        Rep::set_red(k, b)
+        } -> ConceptSame<void>;
+      {
+        Rep::ref(b, k)
+        } -> ConceptSame<typename Rep::Handle>;
+      {
+        Rep::null
+        } -> ConceptSameModRef<const typename Rep::Contents>;
+      {
+        typename Rep::Handle{const_cast<
           std::remove_const_t<std::remove_reference_t<decltype(Rep::root)>>*>(
-          &Rep::root)
-      }
-    }
-    ->ConceptSame<typename Rep::Handle>;
-  };
+          &Rep::root)}
+        } -> ConceptSame<typename Rep::Handle>;
+    };
 
   template<typename Rep>
   concept RBRep = //
-    RBRepTypes<Rep> //
-      && RBRepMethods<Rep> //
-        && ConceptSame<
-          decltype(Rep::null),
-          std::add_const_t<typename Rep::Contents>>;
+    RBRepTypes<Rep> && RBRepMethods<Rep> &&
+    ConceptSame<decltype(Rep::null), std::add_const_t<typename Rep::Contents>>;
 #endif
 
   /**
@@ -490,8 +475,7 @@ namespace snmalloc
        */
       path.move(true);
       while (path.move(false))
-      {
-      }
+      {}
 
       K curr = path.curr();
 
@@ -742,8 +726,7 @@ namespace snmalloc
 
       auto path = get_root_path();
       while (path.move(true))
-      {
-      }
+      {}
 
       K result = path.curr();
 

--- a/src/snmalloc/override/jemalloc_compat.cc
+++ b/src/snmalloc/override/jemalloc_compat.cc
@@ -116,7 +116,7 @@ extern "C"
    * now, this is always implemented to return an error.
    */
   SNMALLOC_EXPORT int
-    SNMALLOC_NAME_MANGLE(mallctl)(const char*, void*, size_t*, void*, size_t)
+  SNMALLOC_NAME_MANGLE(mallctl)(const char*, void*, size_t*, void*, size_t)
   {
     return ENOENT;
   }
@@ -265,7 +265,7 @@ extern "C"
    * controlling the thread cache and arena are ignored.
    */
   SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(rallocx)(void* ptr, size_t size, int flags)
+  SNMALLOC_NAME_MANGLE(rallocx)(void* ptr, size_t size, int flags)
   {
     auto f = JEMallocFlags(flags);
     size = f.aligned_size(size);

--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -113,7 +113,7 @@ extern "C"
 
 #if !defined(SNMALLOC_NO_REALLOCARRAY)
   SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(reallocarray)(void* ptr, size_t nmemb, size_t size)
+  SNMALLOC_NAME_MANGLE(reallocarray)(void* ptr, size_t nmemb, size_t size)
   {
     bool overflow = false;
     size_t sz = bits::umul(size, nmemb, overflow);
@@ -128,7 +128,7 @@ extern "C"
 
 #if !defined(SNMALLOC_NO_REALLOCARR)
   SNMALLOC_EXPORT int
-    SNMALLOC_NAME_MANGLE(reallocarr)(void* ptr_, size_t nmemb, size_t size)
+  SNMALLOC_NAME_MANGLE(reallocarr)(void* ptr_, size_t nmemb, size_t size)
   {
     int err = errno;
     auto& a = ThreadAlloc::get();
@@ -168,7 +168,7 @@ extern "C"
 #endif
 
   SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
+  SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
   {
     if ((alignment == 0) || (alignment == size_t(-1)))
     {
@@ -186,7 +186,7 @@ extern "C"
   }
 
   SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
+  SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
   {
     SNMALLOC_ASSERT((size % alignment) == 0);
     return SNMALLOC_NAME_MANGLE(memalign)(alignment, size);

--- a/src/snmalloc/override/memcpy.cc
+++ b/src/snmalloc/override/memcpy.cc
@@ -6,7 +6,7 @@ extern "C"
    * Snmalloc checked memcpy.
    */
   SNMALLOC_EXPORT void*
-    SNMALLOC_NAME_MANGLE(memcpy)(void* dst, const void* src, size_t len)
+  SNMALLOC_NAME_MANGLE(memcpy)(void* dst, const void* src, size_t len)
   {
     return snmalloc::memcpy<true>(dst, src, len);
   }

--- a/src/snmalloc/override/new.cc
+++ b/src/snmalloc/override/new.cc
@@ -38,12 +38,12 @@ void* operator new[](size_t size, std::nothrow_t&)
   return ThreadAlloc::get().alloc(size);
 }
 
-void operator delete(void* p)EXCEPTSPEC
+void operator delete(void* p) EXCEPTSPEC
 {
   ThreadAlloc::get().dealloc(p);
 }
 
-void operator delete(void* p, size_t size)EXCEPTSPEC
+void operator delete(void* p, size_t size) EXCEPTSPEC
 {
   if (p == nullptr)
     return;
@@ -96,7 +96,7 @@ void* operator new[](size_t size, std::align_val_t val, std::nothrow_t&)
   return ThreadAlloc::get().alloc(size);
 }
 
-void operator delete(void* p, std::align_val_t)EXCEPTSPEC
+void operator delete(void* p, std::align_val_t) EXCEPTSPEC
 {
   ThreadAlloc::get().dealloc(p);
 }
@@ -106,7 +106,7 @@ void operator delete[](void* p, std::align_val_t) EXCEPTSPEC
   ThreadAlloc::get().dealloc(p);
 }
 
-void operator delete(void* p, size_t size, std::align_val_t val)EXCEPTSPEC
+void operator delete(void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
   size = aligned_size(size_t(val), size);
   ThreadAlloc::get().dealloc(p, size);

--- a/src/snmalloc/override/rust.cc
+++ b/src/snmalloc/override/rust.cc
@@ -10,19 +10,19 @@
 using namespace snmalloc;
 
 extern "C" SNMALLOC_EXPORT void*
-  SNMALLOC_NAME_MANGLE(rust_alloc)(size_t alignment, size_t size)
+SNMALLOC_NAME_MANGLE(rust_alloc)(size_t alignment, size_t size)
 {
   return ThreadAlloc::get().alloc(aligned_size(alignment, size));
 }
 
 extern "C" SNMALLOC_EXPORT void*
-  SNMALLOC_NAME_MANGLE(rust_alloc_zeroed)(size_t alignment, size_t size)
+SNMALLOC_NAME_MANGLE(rust_alloc_zeroed)(size_t alignment, size_t size)
 {
   return ThreadAlloc::get().alloc<YesZero>(aligned_size(alignment, size));
 }
 
 extern "C" SNMALLOC_EXPORT void
-  SNMALLOC_NAME_MANGLE(rust_dealloc)(void* ptr, size_t alignment, size_t size)
+SNMALLOC_NAME_MANGLE(rust_dealloc)(void* ptr, size_t alignment, size_t size)
 {
   ThreadAlloc::get().dealloc(ptr, aligned_size(alignment, size));
 }

--- a/src/snmalloc/pal/pal_concept.h
+++ b/src/snmalloc/pal/pal_concept.h
@@ -19,62 +19,54 @@ namespace snmalloc
    * PALs must advertize the bit vector of their supported features.
    */
   template<typename PAL>
-  concept IsPAL_static_features = requires()
-  {
-    typename std::integral_constant<uint64_t, PAL::pal_features>;
-  };
+  concept IsPAL_static_features =
+    requires() {
+      typename std::integral_constant<uint64_t, PAL::pal_features>;
+    };
 
   /**
    * PALs must advertise the size of the address space and their page size
    */
   template<typename PAL>
-  concept IsPAL_static_sizes = requires()
-  {
-    typename std::integral_constant<std::size_t, PAL::address_bits>;
-    typename std::integral_constant<std::size_t, PAL::page_size>;
-  };
+  concept IsPAL_static_sizes =
+    requires() {
+      typename std::integral_constant<std::size_t, PAL::address_bits>;
+      typename std::integral_constant<std::size_t, PAL::page_size>;
+    };
 
   /**
    * PALs expose an error reporting function which takes a const C string.
    */
   template<typename PAL>
-  concept IsPAL_error = requires(const char* const str)
-  {
-    {
-      PAL::error(str)
-    }
-    ->ConceptSame<void>;
-  };
+  concept IsPAL_error = requires(const char* const str) {
+                          {
+                            PAL::error(str)
+                            } -> ConceptSame<void>;
+                        };
 
   /**
    * PALs expose a basic library of memory operations.
    */
   template<typename PAL>
-  concept IsPAL_memops = requires(void* vp, std::size_t sz)
-  {
-    {
-      PAL::notify_not_using(vp, sz)
-    }
-    noexcept->ConceptSame<void>;
+  concept IsPAL_memops = requires(void* vp, std::size_t sz) {
+                           {
+                             PAL::notify_not_using(vp, sz)
+                             } noexcept -> ConceptSame<void>;
 
-    {
-      PAL::template notify_using<NoZero>(vp, sz)
-    }
-    noexcept->ConceptSame<void>;
-    {
-      PAL::template notify_using<YesZero>(vp, sz)
-    }
-    noexcept->ConceptSame<void>;
+                           {
+                             PAL::template notify_using<NoZero>(vp, sz)
+                             } noexcept -> ConceptSame<void>;
+                           {
+                             PAL::template notify_using<YesZero>(vp, sz)
+                             } noexcept -> ConceptSame<void>;
 
-    {
-      PAL::template zero<false>(vp, sz)
-    }
-    noexcept->ConceptSame<void>;
-    {
-      PAL::template zero<true>(vp, sz)
-    }
-    noexcept->ConceptSame<void>;
-  };
+                           {
+                             PAL::template zero<false>(vp, sz)
+                             } noexcept -> ConceptSame<void>;
+                           {
+                             PAL::template zero<true>(vp, sz)
+                             } noexcept -> ConceptSame<void>;
+                         };
 
   /**
    * The Pal must provide a thread id for debugging.  It should not return
@@ -82,66 +74,55 @@ namespace snmalloc
    * places.
    */
   template<typename PAL>
-  concept IsPAL_tid = requires()
-  {
-    {
-      PAL::get_tid()
-    }
-    noexcept->ConceptSame<typename PAL::ThreadIdentity>;
-  };
+  concept IsPAL_tid =
+    requires() {
+      {
+        PAL::get_tid()
+        } noexcept -> ConceptSame<typename PAL::ThreadIdentity>;
+    };
 
   /**
    * Absent any feature flags, the PAL must support a crude primitive allocator
    */
   template<typename PAL>
-  concept IsPAL_reserve = requires(PAL p, std::size_t sz)
-  {
-    {
-      PAL::reserve(sz)
-    }
-    noexcept->ConceptSame<void*>;
-  };
+  concept IsPAL_reserve = requires(PAL p, std::size_t sz) {
+                            {
+                              PAL::reserve(sz)
+                              } noexcept -> ConceptSame<void*>;
+                          };
 
   /**
    * Some PALs expose a richer allocator which understands aligned allocations
    */
   template<typename PAL>
-  concept IsPAL_reserve_aligned = requires(std::size_t sz)
-  {
-    {
-      PAL::template reserve_aligned<true>(sz)
-    }
-    noexcept->ConceptSame<void*>;
-    {
-      PAL::template reserve_aligned<false>(sz)
-    }
-    noexcept->ConceptSame<void*>;
-  };
+  concept IsPAL_reserve_aligned = requires(std::size_t sz) {
+                                    {
+                                      PAL::template reserve_aligned<true>(sz)
+                                      } noexcept -> ConceptSame<void*>;
+                                    {
+                                      PAL::template reserve_aligned<false>(sz)
+                                      } noexcept -> ConceptSame<void*>;
+                                  };
 
   /**
    * Some PALs can provide memory pressure callbacks.
    */
   template<typename PAL>
-  concept IsPAL_mem_low_notify = requires(PalNotificationObject* pno)
-  {
-    {
-      PAL::expensive_low_memory_check()
-    }
-    ->ConceptSame<bool>;
-    {
-      PAL::register_for_low_memory_callback(pno)
-    }
-    ->ConceptSame<void>;
-  };
+  concept IsPAL_mem_low_notify = requires(PalNotificationObject* pno) {
+                                   {
+                                     PAL::expensive_low_memory_check()
+                                     } -> ConceptSame<bool>;
+                                   {
+                                     PAL::register_for_low_memory_callback(pno)
+                                     } -> ConceptSame<void>;
+                                 };
 
   template<typename PAL>
-  concept IsPAL_get_entropy64 = requires()
-  {
-    {
-      PAL::get_entropy64()
-    }
-    ->ConceptSame<uint64_t>;
-  };
+  concept IsPAL_get_entropy64 = requires() {
+                                  {
+                                    PAL::get_entropy64()
+                                    } -> ConceptSame<uint64_t>;
+                                };
 
   /**
    * PALs ascribe to the conjunction of several concepts.  These are broken

--- a/src/snmalloc/pal/pal_noalloc.h
+++ b/src/snmalloc/pal/pal_noalloc.h
@@ -17,7 +17,7 @@ namespace snmalloc
    * The minimal subset of a PAL that we need for delegation
    */
   template<typename PAL>
-  concept PALNoAllocBase = IsPAL_static_sizes<PAL>&& IsPAL_error<PAL>;
+  concept PALNoAllocBase = IsPAL_static_sizes<PAL> && IsPAL_error<PAL>;
 #endif
 
   /**

--- a/src/test/func/domestication/domestication.cc
+++ b/src/test/func/domestication/domestication.cc
@@ -62,14 +62,12 @@ namespace snmalloc
      * C++, and not just its initializer fragment, to initialize a non-prefix
      * subset of the flags (in any order, at that).
      */
-    static constexpr Flags Options = []() constexpr
-    {
+    static constexpr Flags Options = []() constexpr {
       Flags opts = {};
       opts.QueueHeadsAreTame = false;
       opts.HasDomesticate = true;
       return opts;
-    }
-    ();
+    }();
 
     static GlobalPoolState& pool()
     {

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -172,7 +172,7 @@ namespace
        * sandbox but allocates memory inside.
        */
       struct RemoteAllocator queue;
-    } * shared_state;
+    }* shared_state;
 
     /**
      * The memory provider for this sandbox.
@@ -195,7 +195,7 @@ namespace
     Sandbox(size_t sb_size)
     : start(alloc_sandbox_heap(sb_size)),
       top(pointer_offset(start, sb_size)),
-      shared_state(new (start) SharedState()),
+      shared_state(new(start) SharedState()),
       state(
         pointer_offset(CapPtr<void, CBChunk>(start), sizeof(SharedState)),
         sb_size - sizeof(SharedState)),


### PR DESCRIPTION
The current version requires clang-format-9.  This now getting hard to get. This commit moves it to the clang-format-15, which is the latest in 22.04.