### PR TITLE
Using exclusive mode prefetch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,10 +387,9 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
       target_compile_options(${name} PRIVATE
         -fomit-frame-pointer -ffunction-sections)
 
-      if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+      check_cxx_compiler_flag(-mprfchw SUPPORT_PREFETCH_WRITE)
+      if (SUPPORT_PREFETCH_WRITE)
         target_compile_options(${name} PRIVATE -mprfchw)
-      else()
-        message(STATUS "Disabling -mprfchw for ${name} on ${CMAKE_SYSTEM_PROCESSOR}")
       endif()
       # Static TLS model is unsupported on Haiku.
       if (NOT CMAKE_SYSTEM_NAME STREQUAL "Haiku")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
       target_compile_options(${name} PRIVATE
         -fomit-frame-pointer -ffunction-sections)
 
-      check_cxx_compiler_flag(-mprfchw SUPPORT_PREFETCH_WRITE)
+      check_cxx_compiler_flag("-Werror -Wextra -Wall -mprfchw" SUPPORT_PREFETCH_WRITE)
       if (SUPPORT_PREFETCH_WRITE)
         target_compile_options(${name} PRIVATE -mprfchw)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,8 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
 
       if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
         target_compile_options(${name} PRIVATE -mprfchw)
+      else()
+        message(STATUS "Disabling -mprfchw for ${name} on ${CMAKE_SYSTEM_PROCESSOR}")
       endif()
       # Static TLS model is unsupported on Haiku.
       if (NOT CMAKE_SYSTEM_NAME STREQUAL "Haiku")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,10 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
       target_compile_definitions(${name} PRIVATE "SNMALLOC_EXPORT=__attribute__((visibility(\"default\")))")
       target_compile_options(${name} PRIVATE
         -fomit-frame-pointer -ffunction-sections)
+
+      if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        target_compile_options(${name} PRIVATE -mprfchw)
+      endif()
       # Static TLS model is unsupported on Haiku.
       if (NOT CMAKE_SYSTEM_NAME STREQUAL "Haiku")
         target_compile_options(${name} PRIVATE -ftls-model=initial-exec)

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -147,7 +147,7 @@ namespace snmalloc
     static inline void prefetch(void* ptr) noexcept
     {
 #if __has_builtin(__builtin_prefetch) && !defined(SNMALLOC_NO_AAL_BUILTINS)
-      __builtin_prefetch(ptr);
+      __builtin_prefetch(ptr, 1, 3);
 #else
       Arch::prefetch(ptr);
 #endif

--- a/src/snmalloc/aal/aal_arm.h
+++ b/src/snmalloc/aal/aal_arm.h
@@ -54,7 +54,7 @@ namespace snmalloc
 #elif __has_builtin(__builtin_prefetch) && !defined(SNMALLOC_NO_AAL_BUILTINS)
       __builtin_prefetch(ptr);
 #elif defined(SNMALLOC_VA_BITS_64)
-      __asm__ volatile("prfm pldl1keep, [%0]" : "=r"(ptr));
+      __asm__ volatile("prfm pstl1keep, [%0]" : "=r"(ptr));
 #else
       __asm__ volatile("pld\t[%0]" : "=r"(ptr));
 #endif

--- a/src/snmalloc/aal/aal_x86.h
+++ b/src/snmalloc/aal/aal_x86.h
@@ -78,7 +78,7 @@ namespace snmalloc
      */
     static inline void prefetch(void* ptr)
     {
-      _mm_prefetch(reinterpret_cast<const char*>(ptr), _MM_HINT_T0);
+      _m_prefetchw(ptr);
     }
 
     /**

--- a/src/snmalloc/aal/aal_x86.h
+++ b/src/snmalloc/aal/aal_x86.h
@@ -78,7 +78,11 @@ namespace snmalloc
      */
     static inline void prefetch(void* ptr)
     {
+#if defined(_MSC_VER)
       _m_prefetchw(ptr);
+#else
+      _mm_prefetch(reinterpret_cast<const char*>(ptr), _MM_HINT_T0);
+#endif
     }
 
     /**

--- a/src/snmalloc/aal/aal_x86.h
+++ b/src/snmalloc/aal/aal_x86.h
@@ -81,7 +81,7 @@ namespace snmalloc
 #if defined(_MSC_VER)
       _m_prefetchw(ptr);
 #else
-      _mm_prefetch(reinterpret_cast<const char*>(ptr), _MM_HINT_T0);
+      _mm_prefetch(reinterpret_cast<const char*>(ptr), _MM_HINT_ET0);
 #endif
     }
 


### PR DESCRIPTION
The prefetching is always used to move the cache line to the current core for writing.  This change makes it use exclusive mode prefetch and enables it as a feature flag for x64.