### PR TITLE
Add a default constructor to seqset nodes.

### DIFF
--- a/src/snmalloc/ds_core/seqset.h
+++ b/src/snmalloc/ds_core/seqset.h
@@ -34,6 +34,9 @@ namespace snmalloc
       constexpr Node(Node* next, Node* prev) : next(next), prev(prev) {}
 
     public:
+      /// Default constructor, creates an invalid node.
+      constexpr Node() : Node(nullptr, nullptr) {}
+
       void invariant()
       {
         SNMALLOC_ASSERT(next != nullptr);


### PR DESCRIPTION
This allows them to exist as fields without invalidating the set.

This should make it possible to remove the undefined behaviour in the creation of FrontendSlabMetadata, which is currently created via a reinterpret_cast from a different-typed allocation. FrontendSlabMetadata has a SeqSet::Node field that is in an unspecified state on construction and which is valid only when inserted into a SeqSet.