### PR TITLE
Startup improvements

### DIFF
--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -71,6 +71,16 @@ namespace snmalloc
     }
 
     /**
+     * Returns unused meta-data to the system.  This must have come from a call
+     * to alloc_meta_data, but can be a sub-range of the original allocation.
+     */
+    static void dealloc_meta_data(
+      LocalState& local_state, capptr::Arena<void> p, size_t size)
+    {
+      local_state.get_meta_range().dealloc_range(p, size);
+    }
+
+    /**
      * Returns a chunk of memory with alignment and size of `size`, and a
      * block containing metadata about the slab.
      *

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -141,8 +141,11 @@ namespace snmalloc
         }
       }
 
+      size_t request_size = bits::next_pow2(sizeof(T));
+      size_t spare = request_size - sizeof(T);
+
       auto raw =
-        Config::Backend::template alloc_meta_data<T>(nullptr, sizeof(T));
+        Config::Backend::template alloc_meta_data<T>(nullptr, request_size);
 
       if (raw == nullptr)
       {
@@ -150,7 +153,7 @@ namespace snmalloc
       }
 
       auto p = capptr::Alloc<T>::unsafe_from(new (raw.unsafe_ptr())
-                                               T(std::forward<Args>(args)...));
+                                               T(spare, std::forward<Args>(args)...));
 
       FlagLock f(pool.lock);
       p->list_next = pool.list;

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -152,8 +152,8 @@ namespace snmalloc
         Config::Pal::error("Failed to initialise thread local allocator.");
       }
 
-      auto p = capptr::Alloc<T>::unsafe_from(new (raw.unsafe_ptr())
-                                               T(spare, std::forward<Args>(args)...));
+      auto p = capptr::Alloc<T>::unsafe_from(
+        new (raw.unsafe_ptr()) T(spare, std::forward<Args>(args)...));
 
       FlagLock f(pool.lock);
       p->list_next = pool.list;

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -10,11 +10,11 @@ namespace snmalloc
 
   /**
    * Required to be implemented by all types that are pooled.
-   * 
+   *
    * The constructor of any inherited type must take a size_t as its first
-   * argument.  This represents the leftover from pool allocation rounding up to the
-   * nearest power of 2. It is valid to ignore this argument, but can be used to
-   * optimise meta-data usage at startup.
+   * argument.  This represents the leftover from pool allocation rounding up to
+   * the nearest power of 2. It is valid to ignore this argument, but can be
+   * used to optimise meta-data usage at startup.
    */
   template<class T>
   class Pooled

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -8,6 +8,14 @@ namespace snmalloc
   template<class T>
   class PoolState;
 
+  /**
+   * Required to be implemented by all types that are pooled.
+   * 
+   * The constructor of any inherited type must take a size_t as its first
+   * argument.  This represents the leftover from pool allocation rounding up to the
+   * nearest power of 2. It is valid to ignore this argument, but can be used to
+   * optimise meta-data usage at startup.
+   */
   template<class T>
   class Pooled
   {

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -11,7 +11,7 @@ struct PoolAEntry : Pooled<PoolAEntry>
 {
   int field;
 
-  PoolAEntry() : field(1){};
+  PoolAEntry(size_t) : field(1){};
 };
 
 using PoolA = Pool<PoolAEntry, Alloc::Config>;
@@ -20,8 +20,8 @@ struct PoolBEntry : Pooled<PoolBEntry>
 {
   int field;
 
-  PoolBEntry() : field(0){};
-  PoolBEntry(int f) : field(f){};
+  PoolBEntry(size_t) : field(0){};
+  PoolBEntry(size_t, int f) : field(f){};
 };
 
 using PoolB = Pool<PoolBEntry, Alloc::Config>;
@@ -30,7 +30,7 @@ struct PoolLargeEntry : Pooled<PoolLargeEntry>
 {
   std::array<int, 2'000'000> payload;
 
-  PoolLargeEntry()
+  PoolLargeEntry(size_t)
   {
     printf(".");
     fflush(stdout);
@@ -48,7 +48,7 @@ struct PoolSortEntry : Pooled<PoolSortEntry<order>>
 {
   int field;
 
-  PoolSortEntry(int f) : field(f){};
+  PoolSortEntry(size_t, int f) : field(f){};
 };
 
 template<bool order>

--- a/src/test/perf/startup/startup.cc
+++ b/src/test/perf/startup/startup.cc
@@ -1,0 +1,91 @@
+#include "test/opt.h"
+#include "test/setup.h"
+#include "test/usage.h"
+#include "test/xoroshiro.h"
+
+#include <iostream>
+#include <snmalloc/snmalloc.h>
+#include <thread>
+
+using namespace snmalloc;
+
+std::array<size_t, 72> counters;
+
+template<typename F>
+class ParallelTest
+{
+private:
+  std::atomic<bool> flag = false;
+  std::atomic<size_t> ready = 0;
+  uint64_t start;
+  uint64_t end;
+  std::atomic<size_t> complete = 0;
+  size_t cores;
+  F f;
+
+  void run(size_t id)
+  {
+    auto prev = ready.fetch_add(1);
+    if (prev + 1 == cores)
+    {
+      start = Aal::tick();
+      flag = true;
+    }
+    while (!flag)
+      Aal::pause();
+
+    f(id);
+
+    prev = complete.fetch_add(1);
+    if (prev + 1 == cores)
+    {
+      end = Aal::tick();
+    }
+  }
+
+public:
+  ParallelTest(F&& f, size_t cores) : cores(cores), f(std::forward<F>(f))
+  {
+    std::thread* t = new std::thread[cores];
+
+    for (size_t i = 0; i < cores; i++)
+    {
+      t[i] = std::thread(&ParallelTest::run, this, i);
+    }
+    // Wait for all the threads.
+    for (size_t i = 0; i < cores; i++)
+    {
+      t[i].join();
+    }
+
+    delete[] t;
+  }
+
+  uint64_t time()
+  {
+    return end - start;
+  }
+};
+
+int main()
+{
+  ParallelTest test(
+    [](size_t id) {
+      auto start = Aal::tick();
+      auto& alloc = snmalloc::ThreadAlloc::get();
+      alloc.dealloc(alloc.alloc(1));
+      auto end = Aal::tick();
+      counters[id] = end - start;
+    },
+    72);
+
+  std::cout << "Taken: " << test.time() << std::endl;
+  std::sort(counters.begin(), counters.end());
+  size_t start = 0;
+  for (size_t i = 0; i < 72; i++)
+  {
+    std::cout << "Thread time " << counters[i] << " (" << counters[i] - start
+              << ")" << std::endl;
+    start = counters[i];
+  }
+}


### PR DESCRIPTION
This PR improves the startup cost of snmalloc.

It adds a benchmark for profiling startup by starting a lot of threads, waiting for them to reach a stable point, each perform a single allocation deallocation pair, and terminate.  It measure the time taken from all threads starting allocation until the last one has completed its deallocation.

The second commit makes the Pool pass the `spare` memory in a meta-data allocation to the constructor of that type. This is then used to seed the local state in the backend with a small amount of meta-data, and means the first allocation does not need to request more meta-data memory.

The benchmark goes from taking ~2.5M cycles to ~1.3M cycles for the checked build, and ~1.4M cycles to ~1.1M cycles for the fast build (wall clock cycles).