### PR TITLE
Template construction of Pool elements

### DIFF
--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -1040,7 +1040,7 @@ namespace snmalloc
 
       auto p = capptr::Alloc<CA>::unsafe_from(new (raw.unsafe_ptr()) CA(r));
 
-      // Remove excess from the permissions.
+      // Remove excess from the bounds.
       p = Aal::capptr_bound<CA, capptr::bounds::Alloc>(p, round_sizeof);
       return p;
     }

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -621,8 +621,7 @@ namespace snmalloc
     template<
       typename Config_ = Config,
       typename = std::enable_if_t<Config_::Options.CoreAllocOwnsLocalState>>
-    CoreAllocator(Range<capptr::bounds::Alloc>& spare, LocalCache* cache)
-    : attached_cache(cache)
+    CoreAllocator(Range<capptr::bounds::Alloc>& spare)
     {
       init(spare);
     }
@@ -1021,7 +1020,7 @@ namespace snmalloc
     using CA = CoreAllocator<Config>;
 
   public:
-    static capptr::Alloc<CA> make(LocalCache* lc)
+    static capptr::Alloc<CA> make()
     {
       size_t size = sizeof(CA);
       size_t round_sizeof = Aal::capptr_size_round(size);
@@ -1039,7 +1038,7 @@ namespace snmalloc
       capptr::Alloc<void> spare_start = pointer_offset(raw, round_sizeof);
       Range<capptr::bounds::Alloc> r{spare_start, spare};
 
-      auto p = capptr::Alloc<CA>::unsafe_from(new (raw.unsafe_ptr()) CA(r, lc));
+      auto p = capptr::Alloc<CA>::unsafe_from(new (raw.unsafe_ptr()) CA(r));
 
       // Remove excess from the permissions.
       p = Aal::capptr_bound<CA, capptr::bounds::Alloc>(p, round_sizeof);

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -1039,8 +1039,7 @@ namespace snmalloc
       capptr::Alloc<void> spare_start = pointer_offset(raw, round_sizeof);
       Range<capptr::bounds::Alloc> r{spare_start, spare};
 
-      auto p = capptr::Alloc<CA>::unsafe_from(
-        new (raw.unsafe_ptr()) CA(r, lc));
+      auto p = capptr::Alloc<CA>::unsafe_from(new (raw.unsafe_ptr()) CA(r, lc));
 
       // Remove excess from the permissions.
       p = Aal::capptr_bound<CA, capptr::bounds::Alloc>(p, round_sizeof);

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -393,7 +393,7 @@ namespace snmalloc
       // Initialise the global allocator structures
       ensure_init();
       // Grab an allocator for this thread.
-      init(AllocPool<Config>::acquire(&(this->local_cache)));
+      init(AllocPool<Config>::acquire());
     }
 
     // Return all state in the fast allocator and release the underlying

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -68,10 +68,9 @@ namespace snmalloc
   class DefaultConstruct
   {
   public:
-    template<typename... Args>
-    static capptr::Alloc<T> make(Args&&... args)
+    static capptr::Alloc<T> make()
     {
-      return capptr::Alloc<T>::unsafe_from(new T(std::forward<Args>(args)...));
+      return capptr::Alloc<T>::unsafe_from(new T());
     }
   };
 
@@ -95,8 +94,7 @@ namespace snmalloc
   class Pool
   {
   public:
-    template<typename... Args>
-    static T* acquire(Args&&... args)
+    static T* acquire()
     {
       PoolState<T>& pool = get_state();
       {
@@ -115,7 +113,7 @@ namespace snmalloc
         }
       }
 
-      auto p = ConstructT::make(std::forward<Args>(args)...);
+      auto p = ConstructT::make();
 
       FlagLock f(pool.lock);
       p->list_next = pool.list;

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -20,10 +20,7 @@ namespace snmalloc
   template<class T>
   class PoolState
   {
-    template<
-      typename TT,
-      typename Construct,
-      PoolState<TT>& get_state()>
+    template<typename TT, typename Construct, PoolState<TT>& get_state()>
     friend class Pool;
 
   private:
@@ -64,8 +61,8 @@ namespace snmalloc
   /**
    * @brief Default construct helper for the pool. Just uses `new`.  This can't
    * be used by the allocator pool as it has not created memory yet.
-   * 
-   * @tparam T 
+   *
+   * @tparam T
    */
   template<typename T>
   class DefaultConstruct

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -20,7 +20,10 @@ namespace snmalloc
   template<class T>
   class PoolState
   {
-    template<typename TT, typename Construct, PoolState<TT>& get_state()>
+    template<
+      typename TT,
+      SNMALLOC_CONCEPT(Constructable<TT>) Construct,
+      PoolState<TT>& get_state()>
     friend class Pool;
 
   private:
@@ -89,7 +92,7 @@ namespace snmalloc
    */
   template<
     typename T,
-    typename ConstructT = DefaultConstruct<T>,
+    SNMALLOC_CONCEPT(Constructable<T>) ConstructT = DefaultConstruct<T>,
     PoolState<T>& get_state() = SingletonPoolState<T>::pool>
   class Pool
   {

--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -22,7 +22,7 @@ namespace snmalloc
   {
     template<
       typename TT,
-      SNMALLOC_CONCEPT(IsConfig) Config,
+      typename Construct,
       PoolState<TT>& get_state()>
     friend class Pool;
 
@@ -45,50 +45,10 @@ namespace snmalloc
    * SingletonPoolState::pool is the default provider for the PoolState within
    * the Pool class.
    */
-  template<typename T, SNMALLOC_CONCEPT(IsConfig) Config>
+  template<typename T>
   class SingletonPoolState
   {
-    /**
-     * SFINAE helper.  Matched only if `T` implements `ensure_init`.  Calls it
-     * if it exists.
-     */
-    template<typename SharedStateHandle_>
-    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle_*, int)
-      -> decltype(SharedStateHandle_::ensure_init())
-    {
-      static_assert(
-        std::is_same<Config, SharedStateHandle_>::value,
-        "SFINAE parameter, should only be used with Config");
-      SharedStateHandle_::ensure_init();
-    }
-
-    /**
-     * SFINAE helper.  Matched only if `T` does not implement `ensure_init`.
-     * Does nothing if called.
-     */
-    template<typename SharedStateHandle_>
-    SNMALLOC_FAST_PATH static auto call_ensure_init(SharedStateHandle_*, long)
-    {
-      static_assert(
-        std::is_same<Config, SharedStateHandle_>::value,
-        "SFINAE parameter, should only be used with Config");
-    }
-
-    /**
-     * Call `Config::ensure_init()` if it is implemented, do nothing
-     * otherwise.
-     */
-    SNMALLOC_FAST_PATH static void ensure_init()
-    {
-      call_ensure_init<Config>(nullptr, 0);
-    }
-
-    static void make_pool(PoolState<T>*) noexcept
-    {
-      ensure_init();
-      // Default initializer already called on PoolState, no need to use
-      // placement new.
-    }
+    static void make_pool(PoolState<T>*) noexcept {}
 
   public:
     /**
@@ -98,6 +58,23 @@ namespace snmalloc
     SNMALLOC_FAST_PATH static PoolState<T>& pool()
     {
       return Singleton<PoolState<T>, &make_pool>::get();
+    }
+  };
+
+  /**
+   * @brief Default construct helper for the pool. Just uses `new`.  This can't
+   * be used by the allocator pool as it has not created memory yet.
+   * 
+   * @tparam T 
+   */
+  template<typename T>
+  class DefaultConstruct
+  {
+  public:
+    template<typename... Args>
+    static capptr::Alloc<T> make(Args&&... args)
+    {
+      return capptr::Alloc<T>::unsafe_from(new T(std::forward<Args>(args)...));
     }
   };
 
@@ -116,8 +93,8 @@ namespace snmalloc
    */
   template<
     typename T,
-    SNMALLOC_CONCEPT(IsConfig) Config,
-    PoolState<T>& get_state() = SingletonPoolState<T, Config>::pool>
+    typename ConstructT = DefaultConstruct<T>,
+    PoolState<T>& get_state() = SingletonPoolState<T>::pool>
   class Pool
   {
   public:
@@ -141,26 +118,7 @@ namespace snmalloc
         }
       }
 
-      size_t request_size = bits::next_pow2(sizeof(T));
-      size_t round_sizeof = Aal::capptr_size_round(sizeof(T));
-      size_t spare = request_size - round_sizeof;
-
-      auto raw =
-        Config::Backend::template alloc_meta_data<T>(nullptr, request_size);
-
-      if (raw == nullptr)
-      {
-        Config::Pal::error("Failed to initialise thread local allocator.");
-      }
-
-      capptr::Alloc<void> spare_start = pointer_offset(raw, round_sizeof);
-      Range<capptr::bounds::Alloc> r{spare_start, spare};
-
-      auto p = capptr::Alloc<T>::unsafe_from(
-        new (raw.unsafe_ptr()) T(r, std::forward<Args>(args)...));
-
-      // Remove excess from the permissions.
-      p = Aal::capptr_bound<T, capptr::bounds::Alloc>(p, round_sizeof);
+      auto p = ConstructT::make(std::forward<Args>(args)...);
 
       FlagLock f(pool.lock);
       p->list_next = pool.list;

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -27,10 +27,7 @@ namespace snmalloc
   class Pooled
   {
   public:
-    template<
-      typename TT,
-      typename Construct,
-      PoolState<TT>& get_state()>
+    template<typename TT, typename Construct, PoolState<TT>& get_state()>
     friend class Pool;
 
     /// Used by the pool for chaining together entries when not in use.

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -15,6 +15,16 @@ namespace snmalloc
   template<class T>
   class PoolState;
 
+#ifdef __cpp_concepts
+  template<typename C, typename T>
+  concept Constructable = requires()
+  {
+    {
+      C::make()
+      } -> ConceptSame<capptr::Alloc<T>>;
+  };
+#endif // __cpp_concepts
+
   /**
    * Required to be implemented by all types that are pooled.
    *
@@ -27,7 +37,10 @@ namespace snmalloc
   class Pooled
   {
   public:
-    template<typename TT, typename Construct, PoolState<TT>& get_state()>
+    template<
+      typename TT,
+      SNMALLOC_CONCEPT(Constructable<TT>) Construct,
+      PoolState<TT>& get_state()>
     friend class Pool;
 
     /// Used by the pool for chaining together entries when not in use.

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -29,7 +29,7 @@ namespace snmalloc
   public:
     template<
       typename TT,
-      SNMALLOC_CONCEPT(IsConfig) Config,
+      typename Construct,
       PoolState<TT>& get_state()>
     friend class Pool;
 

--- a/src/snmalloc/mem/pooled.h
+++ b/src/snmalloc/mem/pooled.h
@@ -17,12 +17,11 @@ namespace snmalloc
 
 #ifdef __cpp_concepts
   template<typename C, typename T>
-  concept Constructable = requires()
-  {
-    {
-      C::make()
-      } -> ConceptSame<capptr::Alloc<T>>;
-  };
+  concept Constructable = requires() {
+                            {
+                              C::make()
+                              } -> ConceptSame<capptr::Alloc<T>>;
+                          };
 #endif // __cpp_concepts
 
   /**

--- a/src/test/func/cheri/cheri.cc
+++ b/src/test/func/cheri/cheri.cc
@@ -133,7 +133,6 @@ int main()
     static_assert(
       std::is_same_v<decltype(alloc.alloc), LocalAllocator<StandardConfig>>);
 
-    LocalCache lc{&StandardConfig::unused_remote};
     auto* ca = AllocPool<StandardConfig>::acquire();
 
     SNMALLOC_CHECK(cap_len_is(ca, sizeof(*ca)));

--- a/src/test/func/cheri/cheri.cc
+++ b/src/test/func/cheri/cheri.cc
@@ -134,7 +134,7 @@ int main()
       std::is_same_v<decltype(alloc.alloc), LocalAllocator<StandardConfig>>);
 
     LocalCache lc{&StandardConfig::unused_remote};
-    auto* ca = AllocPool<StandardConfig>::acquire(&lc);
+    auto* ca = AllocPool<StandardConfig>::acquire();
 
     SNMALLOC_CHECK(cap_len_is(ca, sizeof(*ca)));
     SNMALLOC_CHECK(cap_vmem_perm_is(ca, false));

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -21,7 +21,6 @@ struct PoolBEntry : Pooled<PoolBEntry>
   int field;
 
   PoolBEntry() : field(0){};
-  PoolBEntry(int f) : field(f){};
 };
 
 using PoolB = Pool<PoolBEntry>;
@@ -48,7 +47,7 @@ struct PoolSortEntry : Pooled<PoolSortEntry<order>>
 {
   int field;
 
-  PoolSortEntry(int f) : field(f){};
+  PoolSortEntry() : field(1){};
 };
 
 template<bool order>
@@ -73,13 +72,8 @@ void test_constructor()
   SNMALLOC_CHECK(ptr2 != nullptr);
   SNMALLOC_CHECK(ptr2->field == 0);
 
-  auto ptr3 = PoolB::acquire(1);
-  SNMALLOC_CHECK(ptr3 != nullptr);
-  SNMALLOC_CHECK(ptr3->field == 1);
-
   PoolA::release(ptr1);
   PoolB::release(ptr2);
-  PoolB::release(ptr3);
 }
 
 void test_alloc_many()
@@ -181,8 +175,8 @@ void test_sort()
 
   // This test checks that `sort` puts the elements in the right order,
   // so it is the same as if they had been allocated in that order.
-  auto a1 = PoolSort<order>::acquire(1);
-  auto a2 = PoolSort<order>::acquire(1);
+  auto a1 = PoolSort<order>::acquire();
+  auto a2 = PoolSort<order>::acquire();
 
   auto position1 = position(a1);
   auto position2 = position(a2);
@@ -201,8 +195,8 @@ void test_sort()
 
   PoolSort<order>::sort();
 
-  auto b1 = PoolSort<order>::acquire(1);
-  auto b2 = PoolSort<order>::acquire(1);
+  auto b1 = PoolSort<order>::acquire();
+  auto b2 = PoolSort<order>::acquire();
 
   SNMALLOC_CHECK(position1 == position(b1));
   SNMALLOC_CHECK(position2 == position(b2));

--- a/src/test/func/pool/pool.cc
+++ b/src/test/func/pool/pool.cc
@@ -11,26 +11,26 @@ struct PoolAEntry : Pooled<PoolAEntry>
 {
   int field;
 
-  PoolAEntry(Range<capptr::bounds::Alloc>&) : field(1){};
+  PoolAEntry() : field(1){};
 };
 
-using PoolA = Pool<PoolAEntry, Alloc::Config>;
+using PoolA = Pool<PoolAEntry>;
 
 struct PoolBEntry : Pooled<PoolBEntry>
 {
   int field;
 
-  PoolBEntry(Range<capptr::bounds::Alloc>&) : field(0){};
-  PoolBEntry(Range<capptr::bounds::Alloc>&, int f) : field(f){};
+  PoolBEntry() : field(0){};
+  PoolBEntry(int f) : field(f){};
 };
 
-using PoolB = Pool<PoolBEntry, Alloc::Config>;
+using PoolB = Pool<PoolBEntry>;
 
 struct PoolLargeEntry : Pooled<PoolLargeEntry>
 {
   std::array<int, 2'000'000> payload;
 
-  PoolLargeEntry(Range<capptr::bounds::Alloc>&)
+  PoolLargeEntry()
   {
     printf(".");
     fflush(stdout);
@@ -41,18 +41,18 @@ struct PoolLargeEntry : Pooled<PoolLargeEntry>
   };
 };
 
-using PoolLarge = Pool<PoolLargeEntry, Alloc::Config>;
+using PoolLarge = Pool<PoolLargeEntry>;
 
 template<bool order>
 struct PoolSortEntry : Pooled<PoolSortEntry<order>>
 {
   int field;
 
-  PoolSortEntry(Range<capptr::bounds::Alloc>&, int f) : field(f){};
+  PoolSortEntry(int f) : field(f){};
 };
 
 template<bool order>
-using PoolSort = Pool<PoolSortEntry<order>, Alloc::Config>;
+using PoolSort = Pool<PoolSortEntry<order>>;
 
 void test_alloc()
 {


### PR DESCRIPTION
The Pool class is used by verona-rt.  The recent changes made this less nice to consume as an API.

This change makes the construction logic a template parameter to the Pool. This enables standard allocation to be used from Verona.

Fixes #603 