### PR TITLE
DNM: github/morello: catch up to 2023.11

### DIFF
--- a/.github/workflows/morello.yml
+++ b/.github/workflows/morello.yml
@@ -39,7 +39,7 @@ jobs:
           - os: "morello"
             caps: Hybrid
             dependencies: >-
-              llvm-localbase cmake ninja
+              llvm llvm-localbase cmake ninja
             cmake-flags: >
               -DCMAKE_CXX_COMPILER=/usr/local64/bin/clang++
               -DCMAKE_C_COMPILER=/usr/local64/bin/clang
@@ -48,7 +48,7 @@ jobs:
           - os: "morello"
             caps: Purecap
             dependencies: >-
-              llvm-localbase cmake ninja
+              llvm llvm-localbase cmake ninja
             cmake-flags: >
               -DCMAKE_CXX_COMPILER=/usr/local64/bin/clang++
               -DCMAKE_C_COMPILER=/usr/local64/bin/clang

--- a/src/test/func/jemalloc/jemalloc.cc
+++ b/src/test/func/jemalloc/jemalloc.cc
@@ -23,6 +23,17 @@
  * exported from libc.
  */
 #  define TEST_JEMALLOC_MALLOCX
+
+#  if !defined(__CHERI_PURE_CAPABILITY__)
+/**
+ * CheriBSD 2023.11 removes the exports of jemalloc's {,r,s,d,n}allocm
+ * functions, so be slightly more judicious about where we test those.  There's
+ * relatively little utility in testing those on older CheriBSD releases, so
+ * just notch out all of CheriBSD.
+ */
+#    define TEST_JEMALLOC_ALLOCM
+#  endif
+
 #endif
 
 #define OUR_MALLOCX_LG_ALIGN(la) (static_cast<int>(la))
@@ -365,6 +376,8 @@ int main()
   test_size<mallocx, dallocx, sallocx, nallocx>();
   test_zeroing<mallocx, dallocx, rallocx>();
   test_xallocx<mallocx, dallocx, xallocx>();
+#endif
+#ifdef TEST_JEMALLOC_ALLOCM
   test_legacy_experimental_apis<allocm, rallocm, sallocm, dallocm, nallocm>();
 #endif
 }


### PR DESCRIPTION
The 2023.11 ports tree no longer has llvm-localbase depend on llvm, so go ahead and install that too.

CI on this PR will make sure that it still works with 2022.12, and I'll go manually test that it works on 2023.11, too.