### PR TITLE
Add Windows ARM64 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         # Build each combination of OS and release/debug variants
         os: [ windows-2019 ]
         build-type: [ Release, Debug ]
-        arch: [ Win32, x64 ]
+        arch: [ Win32, x64, ARM64, ARM64EC ]
         toolchain: [ "", "-T ClangCL" ]
         extra-cmake-flags: [ "" ]
         # Add an extra check for the Windows 8 compatible PAL
@@ -388,6 +388,24 @@ jobs:
             build-type: Debug
             arch: x64
             toolchain: ""
+          - os: windows-2022
+            build-type: Release
+            arch: ARM64
+            toolchain: ""
+          - os: windows-2022
+            build-type: Debug
+            arch: ARM64
+            toolchain: ""
+          - os: windows-2022
+            build-type: Release
+            arch: ARM64EC
+            toolchain: ""
+            extra-cmake-flags: -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+          - os: windows-2022
+            build-type: Debug
+            arch: ARM64EC
+            toolchain: ""
+            extra-cmake-flags: -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
         
       # Don't abort runners if a single one fails
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
         # Build each combination of OS and release/debug variants
         os: [ windows-2019 ]
         build-type: [ Release, Debug ]
-        arch: [ Win32, x64, ARM64, ARM64EC ]
+        arch: [ Win32, x64 ]
         toolchain: [ "", "-T ClangCL" ]
         extra-cmake-flags: [ "" ]
         # Add an extra check for the Windows 8 compatible PAL
@@ -392,20 +392,24 @@ jobs:
             build-type: Release
             arch: ARM64
             toolchain: ""
+            build-only: yes
           - os: windows-2022
             build-type: Debug
             arch: ARM64
             toolchain: ""
+            build-only: yes
           - os: windows-2022
             build-type: Release
             arch: ARM64EC
             toolchain: ""
             extra-cmake-flags: -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+            build-only: yes
           - os: windows-2022
             build-type: Debug
             arch: ARM64EC
             toolchain: ""
             extra-cmake-flags: -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+            build-only: yes
         
       # Don't abort runners if a single one fails
       fail-fast: false
@@ -421,6 +425,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build -- /m /p:Configuration=${{ matrix.build-type }}
       # Run the tests.
     - name: Test
+      if: ${{ matrix.build-only != 'yes' }}
       working-directory: ${{ github.workspace }}/build
       run: ctest -j 2 --interactive-debug-mode 0 --output-on-failure -C ${{ matrix.build-type }} --timeout 400
       timeout-minutes: 20

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -14,9 +14,11 @@
 #include <cstdint>
 #include <utility>
 
-#if (defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
+#if ( \
+  defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
   defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || \
-  defined(_M_AMD64)) && !defined(_M_ARM64EC)
+  defined(_M_AMD64)) && \
+  !defined(_M_ARM64EC)
 #  if defined(SNMALLOC_SGX)
 #    define PLATFORM_IS_X86_SGX
 #    define SNMALLOC_NO_AAL_BUILTINS
@@ -25,7 +27,8 @@
 #  endif
 #endif
 
-#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || \
+  defined(_M_ARM64EC)
 #  define PLATFORM_IS_ARM
 #endif
 

--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -14,9 +14,9 @@
 #include <cstdint>
 #include <utility>
 
-#if defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
+#if (defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
   defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || \
-  defined(_M_AMD64)
+  defined(_M_AMD64)) && !defined(_M_ARM64EC)
 #  if defined(SNMALLOC_SGX)
 #    define PLATFORM_IS_X86_SGX
 #    define SNMALLOC_NO_AAL_BUILTINS
@@ -25,7 +25,7 @@
 #  endif
 #endif
 
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  define PLATFORM_IS_ARM
 #endif
 

--- a/src/snmalloc/aal/aal_arm.h
+++ b/src/snmalloc/aal/aal_arm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  define SNMALLOC_VA_BITS_64
 #  ifdef _MSC_VER
 #    include <arm64_neon.h>

--- a/src/snmalloc/ds_core/bits.h
+++ b/src/snmalloc/ds_core/bits.h
@@ -158,7 +158,11 @@ namespace snmalloc
       SNMALLOC_ASSERT(x != 0); // Calling with 0 is UB on some implementations
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#  ifdef _WIN64
+#  if defined(_M_ARM64) || defined(_M_ARM64EC)
+      unsigned long n = 0;
+      _BitScanForward64(&n, static_cast<unsigned __int64>(x));
+      return static_cast<size_t>(n);
+#  elif defined(_WIN64)
       return _tzcnt_u64(static_cast<unsigned __int64>(x));
 #  else
       return _tzcnt_u32(static_cast<unsigned int>(x));
@@ -203,7 +207,12 @@ namespace snmalloc
       overflow = __builtin_mul_overflow(x, y, &prod);
       return prod;
 #elif defined(_MSC_VER)
-#  ifdef _WIN64
+#  if defined(_M_ARM64) || defined(_M_ARM64EC)
+      size_t high_prod = __umulh(x, y);
+      size_t prod = x * y;
+      overflow = high_prod != 0;
+      return prod;
+#  elif defined(_WIN64)
       size_t high_prod;
       size_t prod = _umul128(x, y, &high_prod);
       overflow = high_prod != 0;


### PR DESCRIPTION
This PR solves a few issues when building for Windows on ARM:

1. No detection for the Windows ARM64 architecture, resulting in no AAL being selected.
2. A compilation error in `bits.h` due to the use of Intel intrinsics that don't exist on ARM.
3. A misdetection of the ARM64EC ABI as AMD64, leading to the use of an unsupported Intel intrinsic.

The first two issues manifest as follows. You can repro in an [ARM64 Visual Studio Developer Command Prompt](https://devblogs.microsoft.com/cppblog/arm64ec-support-in-visual-studio/#developer-command-prompt):

```
> cl /nologo /diagnostics:caret /EHsc /std:c++20 /c malloc.cc

ds_core\bits.h(162,14): error C3861: '_tzcnt_u64': identifier not found
      return _tzcnt_u64(static_cast<unsigned __int64>(x));
             ^
ds_core\bits.h(208,21): error C3861: '_umul128': identifier not found
      size_t prod = _umul128(x, y, &high_prod);
                    ^
pal\../aal/aal.h(259,50): error C2065: 'AAL_Arch': undeclared identifier
  using Aal = AAL_Generic<AAL_NoStrictProvenance<AAL_Arch>>;
```

To fix these two issues, this change adds detection of the Windows ARM64 architecture so the ARM AAL is selected. It also adds implementations of `snmalloc::bits::ctz` and `snmalloc::bits::umul` that work on Windows ARM64 under MSVC.

The third issue shows up like this:

```
> cl /nologo /diagnostics:caret /EHsc /std:c++20 /c /arm64EC malloc.cc

aal\aal_x86.h(82,7): error C3861: '_m_prefetchw': identifier not found
      _m_prefetchw(ptr);
      ^
```

When building for the [ARM64EC ABI](https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/), the compiler [defines the `_M_X64` macro and _not_ the `_M_ARM64` macro](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/getting-to-know-arm64ec-defines-and-intrinsic-functions/ba-p/2957235), to make incremental porting existing X64 Windows code to ARM easier.

This means that the library was detecting ARM64EC as AMD64 and defining `PLATFORM_IS_X86` instead of `PLATFORM_IS_ARM`. This causes the library to compile in the x86 AAL and use several Intel intrinsics, which actually does work in almost all cases because Windows provides [an emulated implementation of Intel SIMD instruction sets](http://www.emulators.com/docs/abc_arm64ec_explained.htm) up to SSE4.2 in the `softintrin.lib` library. However, it does not provide an implementation of `_m_prefetchw`.

To fix this issue, the CPU architecture detection in `aal.h` is now aware of the ARM64EC ABI.