### PR TITLE
Remove unnecessary assertion from aligned_alloc

### DIFF
--- a/src/snmalloc/override/libc.h
+++ b/src/snmalloc/override/libc.h
@@ -153,7 +153,6 @@ namespace snmalloc::libc
 
   inline void* aligned_alloc(size_t alignment, size_t size)
   {
-    SNMALLOC_ASSERT((size % alignment) == 0);
     return memalign(alignment, size);
   }
 


### PR DESCRIPTION
With [DR460](https://open-std.org/JTC1/SC22/WG14/www/docs/summary.htm#dr_460) the undefined behaviour for size not being a multiple of alignment was remove.

The [N2072](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2072.htm) allows for this to return memory.

So we can remove this assert and keep the same conditions as memalign.