### PR TITLE
Refactor new/delete overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,8 +447,10 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
 
   endfunction()
 
-  set(SHIM_FILES src/snmalloc/override/new.cc)
+  set(SHIM_FILES src/snmalloc/override/malloc.cc src/snmalloc/override/new.cc)
   set(SHIM_FILES_MEMCPY src/snmalloc/override/memcpy.cc)
+
+  add_shim(snmalloc-new-override STATIC src/snmalloc/override/new.cc)
 
   if (SNMALLOC_STATIC_LIBRARY)
     add_shim(snmallocshim-static STATIC ${SHIM_FILES})

--- a/src/snmalloc/override/new.cc
+++ b/src/snmalloc/override/new.cc
@@ -1,4 +1,4 @@
-#include "malloc.cc"
+#include "libc.h"
 
 #ifdef _WIN32
 #  ifdef __clang__
@@ -15,8 +15,6 @@
 #    define EXCEPTSPEC
 #  endif
 #endif
-
-using namespace snmalloc;
 
 void* operator new(size_t size)
 {
@@ -70,25 +68,25 @@ void operator delete[](void* p, std::nothrow_t&)
 
 void* operator new(size_t size, std::align_val_t val)
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::libc::malloc(size);
 }
 
 void* operator new[](size_t size, std::align_val_t val)
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::libc::malloc(size);
 }
 
 void* operator new(size_t size, std::align_val_t val, std::nothrow_t&)
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::libc::malloc(size);
 }
 
 void* operator new[](size_t size, std::align_val_t val, std::nothrow_t&)
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::libc::malloc(size);
 }
 
@@ -104,12 +102,12 @@ void operator delete[](void* p, std::align_val_t) EXCEPTSPEC
 
 void operator delete(void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   snmalloc::libc::free_sized(p, size);
 }
 
 void operator delete[](void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
-  size = aligned_size(size_t(val), size);
+  size = snmalloc::aligned_size(size_t(val), size);
   snmalloc::libc::free_sized(p, size);
 }


### PR DESCRIPTION
Produce static library that only overrides new and delete. This allows for a static library to be added that only overrides new and delete.