### PR TITLE
Provide option to CMake for Page Size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ endif()
 set(SNMALLOC_MIN_ALLOC_SIZE "" CACHE STRING "Minimum allocation bytes (power of 2)")
 set(SNMALLOC_MIN_ALLOC_STEP_SIZE "" CACHE STRING "Minimum allocation step (power of 2)")
 
+set(SNMALLOC_PAGESIZE "" CACHE STRING "Page size in bytes")
+
 if(MSVC AND SNMALLOC_STATIC_LIBRARY AND (SNMALLOC_STATIC_LIBRARY_PREFIX STREQUAL ""))
   message(FATAL_ERROR "Empty static library prefix not supported on MSVC")
 endif()
@@ -248,6 +250,8 @@ if (SNMALLOC_NO_REALLOCARR)
 endif()
 add_as_define_value(SNMALLOC_MIN_ALLOC_SIZE)
 add_as_define_value(SNMALLOC_MIN_ALLOC_STEP_SIZE)
+
+add_as_define_value(SNMALLOC_PAGESIZE)
 
 target_compile_definitions(snmalloc INTERFACE $<$<BOOL:CONST_QUALIFIED_MALLOC_USABLE_SIZE>:MALLOC_USABLE_SIZE_QUALIFIER=const>)
 

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -130,7 +130,11 @@ namespace snmalloc
 #endif
       ;
 
+#ifdef PAGESIZE
+    static constexpr size_t page_size = PAGESIZE;
+#else
     static constexpr size_t page_size = Aal::smallest_page_size;
+#endif
 
     /**
      * Address bits are potentially mediated by some POSIX OSes, but generally

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -8,6 +8,7 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
@@ -129,8 +130,11 @@ namespace snmalloc
       | Entropy
 #endif
       ;
-
-#ifdef PAGESIZE
+#ifdef SNMALLOC_PAGESIZE
+    static_assert(
+      bits::is_pow2(SNMALLOC_PAGESIZE), "Page size must be a power of 2");
+    static constexpr size_t page_size = SNMALLOC_PAGESIZE;
+#elif defined(PAGESIZE)
     static constexpr size_t page_size = PAGESIZE;
 #else
     static constexpr size_t page_size = Aal::smallest_page_size;

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -135,7 +135,7 @@ namespace snmalloc
       bits::is_pow2(SNMALLOC_PAGESIZE), "Page size must be a power of 2");
     static constexpr size_t page_size = SNMALLOC_PAGESIZE;
 #elif defined(PAGESIZE)
-    static constexpr size_t page_size = PAGESIZE;
+    static constexpr size_t page_size = max(Aal::smallest_page_size, PAGESIZE);
 #else
     static constexpr size_t page_size = Aal::smallest_page_size;
 #endif


### PR DESCRIPTION
This uses the PAGESIZE constant from the unistd.h on POSIX. This should make the code more resilient to being compiled on platforms with different page sizes.