### PR TITLE
Startup speed

### DIFF
--- a/src/snmalloc/backend_helpers/buddy.h
+++ b/src/snmalloc/backend_helpers/buddy.h
@@ -15,7 +15,13 @@ namespace snmalloc
   template<typename Rep, size_t MIN_SIZE_BITS, size_t MAX_SIZE_BITS>
   class Buddy
   {
-    std::array<RBTree<Rep>, MAX_SIZE_BITS - MIN_SIZE_BITS> trees{};
+    struct Entry
+    {
+      typename Rep::Contents cache[3];
+      RBTree<Rep> tree{};
+    };
+
+    std::array<Entry, MAX_SIZE_BITS - MIN_SIZE_BITS> entries{};
     // All RBtrees at or above this index should be empty.
     size_t empty_at_or_above{0};
 
@@ -42,9 +48,10 @@ namespace snmalloc
     void invariant()
     {
 #ifndef NDEBUG
-      for (size_t i = empty_at_or_above; i < trees.size(); i++)
+      for (size_t i = empty_at_or_above; i < entries.size(); i++)
       {
-        SNMALLOC_ASSERT(trees[i].is_empty());
+        SNMALLOC_ASSERT(entries[i].tree.is_empty());
+        // TODO check cache is empty
       }
 #endif
     }
@@ -59,8 +66,21 @@ namespace snmalloc
 
       auto buddy = Rep::buddy(addr, size);
 
-      auto path = trees[idx].get_root_path();
-      bool contains_buddy = trees[idx].find(path, buddy);
+      // Check local cache first
+      for (auto& e : entries[idx].cache)
+      {
+        if (Rep::equal(buddy, e))
+        {
+          if (!Rep::can_consolidate(addr, size))
+            return false;
+
+          e = entries[idx].tree.remove_min();
+          return true;
+        }
+      }
+
+      auto path = entries[idx].tree.get_root_path();
+      bool contains_buddy = entries[idx].tree.find(path, buddy);
 
       if (!contains_buddy)
         return false;
@@ -72,7 +92,7 @@ namespace snmalloc
       if (!Rep::can_consolidate(addr, size))
         return false;
 
-      trees[idx].remove_path(path);
+      entries[idx].tree.remove_path(path);
       return true;
     }
 
@@ -92,7 +112,6 @@ namespace snmalloc
     {
       validate_block(addr, size);
 
-
       if (remove_buddy(addr, size))
       {
         // Add to next level cache
@@ -111,9 +130,19 @@ namespace snmalloc
 
       auto idx = to_index(size);
       empty_at_or_above = bits::max(empty_at_or_above, idx + 1);
-      auto path = trees[idx].get_root_path();
-      trees[idx].find(path, addr);
-      trees[idx].insert_path(path, addr);
+
+      for (auto& e : entries[idx].cache)
+      {
+        if (Rep::equal(Rep::null, e))
+        {
+          e = addr;
+          return Rep::null;
+        }
+      }
+
+      auto path = entries[idx].tree.get_root_path();
+      entries[idx].tree.find(path, addr);
+      entries[idx].tree.insert_path(path, addr);
       invariant();
       return Rep::null;
     }
@@ -130,7 +159,15 @@ namespace snmalloc
       if (idx >= empty_at_or_above)
         return Rep::null;
 
-      auto addr = trees[idx].remove_min();
+      auto addr = entries[idx].tree.remove_min();
+      for (auto& e : entries[idx].cache)
+      {
+        if (Rep::equal(Rep::null, addr) || Rep::compare(e, addr))
+        {
+          addr = std::exchange(e, addr);
+        }
+      }
+
       if (addr != Rep::null)
       {
         validate_block(addr, size);

--- a/src/snmalloc/pal/pal_consts.h
+++ b/src/snmalloc/pal/pal_consts.h
@@ -55,6 +55,12 @@ namespace snmalloc
      * This Pal provides a millisecond time source
      */
     Time = (1 << 5),
+
+    /**
+     * This Pal provides selective core dumps, so
+     * modify which parts get dumped.
+     */
+    CoreDump = (1 << 6),
   };
 
   /**


### PR DESCRIPTION
This improves the startup time for a heavily multi-threaded workload.

There are two improvements that are independent of each other:

1.  Buddy allocator has local cache.  The buddy allocator uses the pagemap as backing store.  This means that a lot of pages are faulted in at startup for the pagemap, when a large unaligned block is added.  This was causing a noticeable time in micro-profiling. The change in this PR makes there be a few entries at the top-level, so we only use the pagemap once a reasonable amount entries are required.
2. DODUMP/DONTDUMP on Linux were costing a noticeable amount of time, and causing a significant slow down.  This PR also exposes a new couple of optional operations on the PAL, and only applies these operations to the Pagemap.