### PR TITLE
aligned_alloc: Permit alignment values smaller than sizeof(uintptr_t)

### DIFF
--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -145,8 +145,7 @@ namespace snmalloc::libc
 
   inline void* memalign(size_t alignment, size_t size)
   {
-    if (SNMALLOC_UNLIKELY(
-          alignment < sizeof(uintptr_t) || !bits::is_pow2(alignment)))
+    if (SNMALLOC_UNLIKELY(alignment == 0 || !bits::is_pow2(alignment)))
     {
       return set_error(EINVAL);
     }


### PR DESCRIPTION
posix_memalign() requires alignment values of at least sizeof(uintptr_t), but aligned_alloc() does not.  memalign() regressed to require larger alignment in commit
6cbc50fe2c255b5b47ea63f4cf759a6a20f6e7a6.

Fixes #668