### PR TITLE
0-length arrays in Buddy ranges

### DIFF
--- a/src/snmalloc/backend/meta_protected_range.h
+++ b/src/snmalloc/backend/meta_protected_range.h
@@ -75,11 +75,14 @@ namespace snmalloc
       CommitRange<PAL>,
       // In case of huge pages, we don't want to give each thread its own huge
       // page, so commit in the global range.
-      LargeBuddyRange<
-        max_page_chunk_size_bits,
-        max_page_chunk_size_bits,
-        Pagemap,
-        page_size_bits>,
+      std::conditional_t<
+        (max_page_chunk_size_bits > MIN_CHUNK_BITS),
+        LargeBuddyRange<
+          max_page_chunk_size_bits,
+          max_page_chunk_size_bits,
+          Pagemap,
+          page_size_bits>,
+        NopRange>,
       LogRange<4>,
       GlobalRange,
       StatsRange>;

--- a/src/snmalloc/backend_helpers/backend_helpers.h
+++ b/src/snmalloc/backend_helpers/backend_helpers.h
@@ -9,6 +9,7 @@
 #include "indirectrange.h"
 #include "largebuddyrange.h"
 #include "logrange.h"
+#include "noprange.h"
 #include "pagemap.h"
 #include "pagemapregisterrange.h"
 #include "palrange.h"

--- a/src/snmalloc/backend_helpers/buddy.h
+++ b/src/snmalloc/backend_helpers/buddy.h
@@ -15,6 +15,8 @@ namespace snmalloc
   template<typename Rep, size_t MIN_SIZE_BITS, size_t MAX_SIZE_BITS>
   class Buddy
   {
+    static_assert(MAX_SIZE_BITS > MIN_SIZE_BITS);
+
     struct Entry
     {
       typename Rep::Contents cache[3];

--- a/src/snmalloc/backend_helpers/noprange.h
+++ b/src/snmalloc/backend_helpers/noprange.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "range_helpers.h"
+
+namespace snmalloc
+{
+  struct NopRange
+  {
+    template<typename ParentRange>
+    class Type : public ContainsParent<ParentRange>
+    {
+      using ContainsParent<ParentRange>::parent;
+
+    public:
+      static constexpr bool Aligned = ParentRange::Aligned;
+
+      static constexpr bool ConcurrencySafe = ParentRange::ConcurrencySafe;
+
+      using ChunkBounds = typename ParentRange::ChunkBounds;
+      static_assert(
+        ChunkBounds::address_space_control ==
+        capptr::dimension::AddressSpaceControl::Full);
+
+      constexpr Type() = default;
+
+      CapPtr<void, ChunkBounds> alloc_range(size_t size)
+      {
+        return parent.alloc_range(size);
+      }
+
+      void dealloc_range(CapPtr<void, ChunkBounds> base, size_t size)
+      {
+        parent.dealloc_range(base, size);
+      }
+    };
+  };
+} // namespace snmalloc


### PR DESCRIPTION
`Buddy` ranges can be instantiated with `MAX_SIZE_BITS == MIN_SIZE_BITS` (or, in principle, `<=`).  If this happens, the resulting class will contain 0-length arrays, and code that appears to attempt to access an element therein trips gcc's `-Warray-bounds`.

This PR contains two commits: one that adds a `static_assert` to ensure that `Buddy`'s arrays are always of positive size, and one possible way to fix the case I'm tripping over.  The latter works because the Buddy's `MIN_SIZE_BITS` is instantiated at `MIN_CHUNK_BITS`, and so the change herein then ensures that its `MAX_SIZE_BITS` is strictly greater than `MIN_CHUNK_BITS`.

A different, and possibly better, solution would be to drop the `LargeBuddyRange` from `CentralMetaRange` when `max_page_chunk_size_bits` is computed to be equal to `MIN_CHUNK_BITS`.

Please advise.