### PR TITLE
[src/snmalloc/ds_core/redblacktree.h] Make free-standing

### DIFF
--- a/src/snmalloc/ds_core/redblacktree.h
+++ b/src/snmalloc/ds_core/redblacktree.h
@@ -3,7 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <cstring>
 
 namespace snmalloc
 {
@@ -439,9 +439,14 @@ namespace snmalloc
           depth);
         if (!(get_dir(true, curr).is_null() && get_dir(false, curr).is_null()))
         {
-          auto s_indent = std::string(indent);
-          print(get_dir(true, curr), (s_indent + "|").c_str(), depth + 1);
-          print(get_dir(false, curr), (s_indent + " ").c_str(), depth + 1);
+          const size_t len = strlen(indent);
+          char *indent_p2 = static_cast<char*>(malloc(sizeof (*indent_p2) * len + 2));
+          indent_p2[len + 1] = NULL;
+          indent_p2[len] = '|';
+          print(get_dir(true, curr), indent_p2, depth + 1);
+          indent_p2[len] = ' ';
+          print(get_dir(false, curr), indent_p2, depth + 1);
+          free(indent_p2);
         }
       }
     }


### PR DESCRIPTION
Closes #670.

Taking a quick look:
```sh
$ rg -IFNth --trim '#include <' | sort -u
#include <array>
#include <atomic>
#include <chrono>
#include <climits>
#include <cstddef>
#include <cstdint>
#include <cstdlib>
#include <cstring>
#include <errno.h>
#include <fcntl.h>
#include <functional>
#include <iomanip>
#include <iostream>
#include <limits>
#include <new>
#include <sstream>
#include <stddef.h>
#include <stdio.h>
#include <string>
#include <string.h>
#include <strings.h>
#include <string_view>
#include <sys/mman.h>
#include <sys/uio.h>
#include <type_traits>
#include <unistd.h>
#include <utility>
```

I'm not sure how much of this can obviously be removed without looking really wonky in the C++ world.

Maintainers / @SchrodingerZhu - do you just want a C port of this?