### PR TITLE
Further gcc -Werror=array-bounds fix

### DIFF
--- a/src/test/perf/startup/startup.cc
+++ b/src/test/perf/startup/startup.cc
@@ -70,7 +70,8 @@ public:
 
 int main()
 {
-  counters.resize(std::thread::hardware_concurrency());
+  auto nthreads = std::thread::hardware_concurrency();
+  counters.resize(nthreads);
 
   ParallelTest test(
     [](size_t id) {
@@ -80,7 +81,7 @@ int main()
       auto end = Aal::tick();
       counters[id] = end - start;
     },
-    counters.size());
+    nthreads);
 
   std::cout << "Taken: " << test.time() << std::endl;
   std::sort(counters.begin(), counters.end());


### PR DESCRIPTION
In test/perf/startup, gcc (Debian 14.2.0-3) seems to get confused about the size of the counters vector as the code was written.  Rewrite the code to pass the same value (`std::thread::hardware_concurrency()`, but in a local) to both `counters.resize()` and the `ParallelTest` ctor.