### PR TITLE
gcc UAF warning in test/perf/singlethread -malloc

### DIFF
--- a/src/test/perf/singlethread/singlethread.cc
+++ b/src/test/perf/singlethread/singlethread.cc
@@ -34,9 +34,9 @@ void test_alloc_dealloc(size_t count, size_t size, bool write)
     {
       auto it = set.begin();
       void* p = *it;
-      alloc.dealloc(p, size);
       set.erase(it);
       SNMALLOC_CHECK(set.find(p) == set.end());
+      alloc.dealloc(p, size);
     }
 
     // alloc 1x objects


### PR DESCRIPTION
When building test/perf/singlethread to use the system allocator, gcc (Debian 14.2.0-3) correctly sees that we were using the value of a pointer after it had been passed to the privileged free(), which is UB.

Flip the check and dealloc, so that we query the set of pointers we're tracking first, using the pointer while the allocation is still live.