### PR TITLE
aligned_alloc requirements update.

### DIFF
--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -84,7 +84,7 @@ extern "C"
   SNMALLOC_EXPORT void*
   SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
   {
-    return snmalloc::libc::memalign(alignment, size);
+    return snmalloc::libc::aligned_alloc(alignment, size);
   }
 
   SNMALLOC_EXPORT int SNMALLOC_NAME_MANGLE(posix_memalign)(


### PR DESCRIPTION
in addition, specs requires size to be a multiple of alignment.