### PR TITLE
PAL::haiku finally supports getentropy.

### DIFF
--- a/src/snmalloc/pal/pal_haiku.h
+++ b/src/snmalloc/pal/pal_haiku.h
@@ -37,15 +37,6 @@ namespace snmalloc
       SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
       posix_madvise(p, size, POSIX_MADV_DONTNEED);
     }
-
-    /**
-     * Hopefully a temporary workaround until the kernel random feature
-     * is exposed properly in the userspace ?
-     */
-    static uint64_t get_entropy64()
-    {
-      return PALPOSIX::dev_urandom();
-    }
   };
 } // namespace snmalloc
 #endif

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -135,7 +135,8 @@ namespace snmalloc
       bits::is_pow2(SNMALLOC_PAGESIZE), "Page size must be a power of 2");
     static constexpr size_t page_size = SNMALLOC_PAGESIZE;
 #elif defined(PAGESIZE)
-    static constexpr size_t page_size = max(Aal::smallest_page_size, PAGESIZE);
+    static constexpr size_t page_size =
+      bits::max(Aal::smallest_page_size, static_cast<size_t>(PAGESIZE));
 #else
     static constexpr size_t page_size = Aal::smallest_page_size;
 #endif


### PR DESCRIPTION
Also fixing the build with PAL::posix assuming the intent is to avoid using std namespace for max but rather using the in-house implementation.