### PR TITLE
Minor update to clangformat file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,6 +91,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
+SeparateDefinitionBlocks: Always
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/src/snmalloc/aal/aal_arm.h
+++ b/src/snmalloc/aal/aal_arm.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <cstddef>
+
 namespace snmalloc
 {
   /**

--- a/src/snmalloc/backend_helpers/buddy.h
+++ b/src/snmalloc/backend_helpers/buddy.h
@@ -100,6 +100,7 @@ namespace snmalloc
 
   public:
     constexpr Buddy() = default;
+
     /**
      * Add a block to the buddy allocator.
      *

--- a/src/snmalloc/backend_helpers/commonconfig.h
+++ b/src/snmalloc/backend_helpers/commonconfig.h
@@ -159,4 +159,5 @@ namespace snmalloc
     }
   }
 } // namespace snmalloc
+
 #include "../mem/remotecache.h"

--- a/src/snmalloc/backend_helpers/smallbuddyrange.h
+++ b/src/snmalloc/backend_helpers/smallbuddyrange.h
@@ -31,6 +31,7 @@ namespace snmalloc
     static constexpr Contents root = nullptr;
 
     static constexpr address_t MASK = 1;
+
     static void set(Handle ptr, Contents r)
     {
       SNMALLOC_ASSERT((address_cast(r) & MASK) == 0);

--- a/src/snmalloc/ds/flaglock.h
+++ b/src/snmalloc/ds/flaglock.h
@@ -92,7 +92,9 @@ namespace snmalloc
     {}
 
     void set_owner() {}
+
     void clear_owner() {}
+
     void assert_not_owned_by_current_thread() {}
   };
 

--- a/src/snmalloc/ds_core/helpers.h
+++ b/src/snmalloc/ds_core/helpers.h
@@ -96,6 +96,7 @@ namespace snmalloc
    */
   template<typename Fn>
   struct function_ref;
+
   template<typename R, typename... Args>
   struct function_ref<R(Args...)>
   {

--- a/src/snmalloc/ds_core/redblacktree.h
+++ b/src/snmalloc/ds_core/redblacktree.h
@@ -137,6 +137,7 @@ namespace snmalloc
       {
         return ptr != t.ptr;
       }
+
       ///@}
 
       bool is_null()

--- a/src/snmalloc/global/memcpy.h
+++ b/src/snmalloc/global/memcpy.h
@@ -22,6 +22,7 @@ namespace snmalloc
     {
       char data[Size];
     };
+
     auto* d = static_cast<Block*>(dst);
     auto* s = static_cast<const Block*>(src);
     *d = *s;
@@ -254,6 +255,7 @@ namespace snmalloc
           {
             void* p[2];
           };
+
           if (sizeof(Ptr2) <= len)
           {
             auto dp = static_cast<Ptr2*>(dst);

--- a/src/snmalloc/mem/backend_concept.h
+++ b/src/snmalloc/mem/backend_concept.h
@@ -5,6 +5,7 @@
 #  include "sizeclasstable.h"
 
 #  include <cstddef>
+
 namespace snmalloc
 {
   /**

--- a/src/snmalloc/mem/corealloc.h
+++ b/src/snmalloc/mem/corealloc.h
@@ -48,6 +48,7 @@ namespace snmalloc
      */
     using BackendSlabMetadata = typename Config::Backend::SlabMetadata;
     using PagemapEntry = typename Config::PagemapEntry;
+
     /// }@
 
     /**
@@ -197,6 +198,7 @@ namespace snmalloc
         {
           capptr::AllocFull<PreAllocObject> next;
         };
+
         // The following code implements Sattolo's algorithm for generating
         // random cyclic permutations.  This implementation is in the opposite
         // direction, so that the original space does not need initialising.

--- a/src/snmalloc/mem/external_alloc.h
+++ b/src/snmalloc/mem/external_alloc.h
@@ -21,6 +21,7 @@ namespace snmalloc::external_alloc
 }
 #    elif defined(__APPLE__)
 #      include <malloc/malloc.h>
+
 namespace snmalloc::external_alloc
 {
   inline size_t malloc_usable_size(void* ptr)
@@ -30,6 +31,7 @@ namespace snmalloc::external_alloc
 }
 #    elif defined(__linux__) || defined(__HAIKU__)
 #      include <malloc.h>
+
 namespace snmalloc::external_alloc
 {
   using ::malloc_usable_size;
@@ -41,6 +43,7 @@ namespace snmalloc::external_alloc
 }
 #    elif defined(__FreeBSD__)
 #      include <malloc_np.h>
+
 namespace snmalloc::external_alloc
 {
   using ::malloc_usable_size;

--- a/src/snmalloc/mem/freelist.h
+++ b/src/snmalloc/mem/freelist.h
@@ -528,6 +528,7 @@ namespace snmalloc
 
     protected:
       constexpr Prev(address_t prev) : prev(prev) {}
+
       constexpr Prev() = default;
 
       address_t replace(address_t next)
@@ -570,10 +571,12 @@ namespace snmalloc
       struct KeyTweak
       {
         address_t key_tweak = 0;
+
         SNMALLOC_FAST_PATH address_t get()
         {
           return key_tweak;
         }
+
         void set(address_t kt)
         {
           key_tweak = kt;
@@ -588,6 +591,7 @@ namespace snmalloc
         {
           return 0;
         }
+
         void set(address_t) {}
       };
 

--- a/src/snmalloc/mem/localalloc.h
+++ b/src/snmalloc/mem/localalloc.h
@@ -22,6 +22,7 @@
 
 #include <string.h>
 #include <utility>
+
 namespace snmalloc
 {
   enum Boundary

--- a/src/snmalloc/mem/metadata.h
+++ b/src/snmalloc/mem/metadata.h
@@ -189,6 +189,7 @@ namespace snmalloc
     {
       return meta &= ~META_BOUNDARY_BIT;
     }
+
     ///@}
 
     /**

--- a/src/snmalloc/override/jemalloc_compat.cc
+++ b/src/snmalloc/override/jemalloc_compat.cc
@@ -4,6 +4,7 @@
 #include <string.h>
 
 using namespace snmalloc;
+
 namespace
 {
   /**
@@ -88,7 +89,9 @@ extern "C"
   // statistics on fork if built with statistics.
 
   SNMALLOC_EXPORT SNMALLOC_USED_FUNCTION inline void _malloc_prefork(void) {}
+
   SNMALLOC_EXPORT SNMALLOC_USED_FUNCTION inline void _malloc_postfork(void) {}
+
   SNMALLOC_EXPORT SNMALLOC_USED_FUNCTION inline void _malloc_first_thread(void)
   {}
 

--- a/src/snmalloc/override/malloc-extensions.h
+++ b/src/snmalloc/override/malloc-extensions.h
@@ -1,4 +1,5 @@
 #pragma once
+
 /**
  * Malloc extensions
  *

--- a/src/snmalloc/pal/pal_freebsd.h
+++ b/src/snmalloc/pal/pal_freebsd.h
@@ -22,6 +22,7 @@
  */
 extern "C" ssize_t __sys_writev(int fd, const struct iovec* iov, int iovcnt);
 extern "C" int __sys_fsync(int fd);
+
 /// @}
 
 namespace snmalloc
@@ -57,6 +58,7 @@ namespace snmalloc
     static constexpr size_t address_bits = (Aal::bits == 32) ?
       Aal::address_bits :
       (Aal::aal_name == RISCV ? 38 : Aal::address_bits);
+
     // TODO, if we ever backport to MIPS, this should yield 39 there.
 
     /**

--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -172,6 +172,7 @@ namespace snmalloc
         uint64_t result;
         char buffer[sizeof(uint64_t)];
       };
+
       ssize_t ret;
 
       // give a try to SYS_getrandom

--- a/src/snmalloc/pal/pal_netbsd.h
+++ b/src/snmalloc/pal/pal_netbsd.h
@@ -14,6 +14,7 @@
  */
 extern "C" ssize_t _sys_writev(int fd, const struct iovec* iov, int iovcnt);
 extern "C" int _sys_fsync(int fd);
+
 /// @}
 
 namespace snmalloc

--- a/src/snmalloc/pal/pal_open_enclave.h
+++ b/src/snmalloc/pal/pal_open_enclave.h
@@ -20,6 +20,7 @@ namespace snmalloc
       UNUSED(str);
       oe_abort();
     }
+
     static constexpr size_t address_bits = Aal::address_bits;
     static constexpr size_t page_size = Aal::smallest_page_size;
   };

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -407,6 +407,7 @@ namespace snmalloc
         uint64_t result;
         char buffer[sizeof(uint64_t)];
       };
+
       ssize_t ret;
       int flags = O_RDONLY;
 #if defined(O_CLOEXEC)

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -238,6 +238,7 @@ namespace snmalloc
 
 #  ifdef PLATFORM_HAS_WAITONADDRESS
     using WaitingWord = char;
+
     template<class T>
     static void wait_on_address(std::atomic<T>& addr, T expected)
     {
@@ -247,11 +248,13 @@ namespace snmalloc
           break;
       }
     }
+
     template<class T>
     static void notify_one_on_address(std::atomic<T>& addr)
     {
       ::WakeByAddressSingle(&addr);
     }
+
     template<class T>
     static void notify_all_on_address(std::atomic<T>& addr)
     {

--- a/src/test/func/client_meta/client_meta.cc
+++ b/src/test/func/client_meta/client_meta.cc
@@ -16,6 +16,7 @@ namespace snmalloc
   using Alloc = snmalloc::LocalAllocator<snmalloc::StandardConfigClientMeta<
     ArrayClientMetaDataProvider<std::atomic<size_t>>>>;
 }
+
 #define SNMALLOC_PROVIDE_OWN_CONFIG
 #include <snmalloc/snmalloc.h>
 

--- a/src/test/func/domestication/domestication.cc
+++ b/src/test/func/domestication/domestication.cc
@@ -17,6 +17,7 @@ int main()
 
 // Specify type of allocator
 #  define SNMALLOC_PROVIDE_OWN_CONFIG
+
 namespace snmalloc
 {
   class CustomConfig : public CommonConfig

--- a/src/test/func/miracle_ptr/miracle_ptr.cc
+++ b/src/test/func/miracle_ptr/miracle_ptr.cc
@@ -27,6 +27,7 @@ namespace snmalloc
   using Alloc = snmalloc::LocalAllocator<snmalloc::StandardConfigClientMeta<
     ArrayClientMetaDataProvider<std::atomic<size_t>>>>;
 }
+
 #  define SNMALLOC_PROVIDE_OWN_CONFIG
 #  include <snmalloc/snmalloc.h>
 

--- a/src/test/func/pagemap/pagemap.cc
+++ b/src/test/func/pagemap/pagemap.cc
@@ -12,10 +12,13 @@
 
 using namespace snmalloc;
 static constexpr size_t GRANULARITY_BITS = 20;
+
 struct T
 {
   size_t v = 99;
+
   T(size_t v) : v(v) {}
+
   T() {}
 };
 

--- a/src/test/func/redblack/redblack.cc
+++ b/src/test/func/redblack/redblack.cc
@@ -22,28 +22,36 @@ struct NodeRef
   static constexpr size_t offset = 10000;
 
   size_t* ptr;
+
   constexpr NodeRef(size_t* p) : ptr(p) {}
+
   constexpr NodeRef() : ptr(nullptr) {}
+
   constexpr NodeRef(const NodeRef& other) : ptr(other.ptr) {}
+
   constexpr NodeRef(NodeRef&& other) : ptr(other.ptr) {}
 
   bool operator!=(const NodeRef& other) const
   {
     return ptr != other.ptr;
   }
+
   NodeRef& operator=(const NodeRef& other)
   {
     ptr = other.ptr;
     return *this;
   }
+
   void set(uint16_t val)
   {
     *ptr = ((size_t(val) + offset) << 1) + (*ptr & 1);
   }
+
   explicit operator uint16_t()
   {
     return uint16_t((*ptr >> 1) - offset);
   }
+
   explicit operator size_t*()
   {
     return ptr;

--- a/src/test/func/sandbox/sandbox.cc
+++ b/src/test/func/sandbox/sandbox.cc
@@ -25,6 +25,7 @@ namespace
   {
     SNMALLOC_CHECK(0 && "Should never be called!");
   }
+
   /**
    * Sandbox class.  Allocates a memory region and an allocator that can
    * allocate into this from the outside.

--- a/src/test/func/two_alloc_types/alloc1.cc
+++ b/src/test/func/two_alloc_types/alloc1.cc
@@ -10,6 +10,7 @@
 
 // Specify type of allocator
 #define SNMALLOC_PROVIDE_OWN_CONFIG
+
 namespace snmalloc
 {
   using CustomGlobals = FixedRangeConfig<PALNoAlloc<DefaultPal>>;

--- a/src/test/func/two_alloc_types/main.cc
+++ b/src/test/func/two_alloc_types/main.cc
@@ -30,6 +30,7 @@ extern "C" void* enclave_malloc(size_t);
 extern "C" void enclave_free(void*);
 
 using namespace snmalloc;
+
 int main()
 {
   setup();

--- a/src/test/perf/msgpass/msgpass.cc
+++ b/src/test/perf/msgpass/msgpass.cc
@@ -46,10 +46,12 @@ void chatty(const char* p, ...)
 struct MyAlloc
 {
   MyAlloc() {}
+
   void* alloc(size_t sz)
   {
     return malloc(sz);
   }
+
   void dealloc(void* p)
   {
     free(p);
@@ -59,11 +61,14 @@ struct MyAlloc
 struct MyAlloc
 {
   snmalloc::Alloc& a;
+
   MyAlloc() : a(ThreadAlloc::get()) {}
+
   void* alloc(size_t sz)
   {
     return a.alloc(sz);
   }
+
   void dealloc(void* p)
   {
     a.dealloc(p);

--- a/src/test/setup.h
+++ b/src/test/setup.h
@@ -97,12 +97,14 @@ void setup()
 }
 #  else
 #    include <signal.h>
+
 void error_handle(int signal)
 {
   snmalloc::UNUSED(signal);
   snmalloc::error("Seg Fault");
   _exit(1);
 }
+
 void setup()
 {
   signal(SIGSEGV, error_handle);


### PR DESCRIPTION
This introduces 
```
SeparateDefinitionBlocks: Always
```

This enforces spacing between definitions. This wasn't available until the recent upgrade to clangformat we took.