### PR TITLE
avoid chrono inclusion when clock_gettime is available

### DIFF
--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -15,11 +15,13 @@
 #  ifdef CLOCK_MONOTONIC
 #    define SNMALLOC_TICK_USE_CLOCK_GETTIME
 #  endif
-#else
-#  include <chrono>
 #endif
 #include <cstdint>
 #include <utility>
+
+#ifndef SNMALLOC_TICK_USE_CLOCK_GETTIME
+#  include <chrono>
+#endif
 
 #if ( \
   defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \

--- a/src/snmalloc/ds_core/defines.h
+++ b/src/snmalloc/ds_core/defines.h
@@ -194,6 +194,15 @@ namespace snmalloc
 #  endif
 #endif
 
+// Used to suppress pattern filling for potentially unintialized variables with
+// automatic storage duration.
+// https://clang.llvm.org/docs/AttributeReference.html#uninitialized
+#ifdef __clang__
+#  define SNMALLOC_UNINITIALISED [[clang::uninitialized]]
+#else
+#  define SNMALLOC_UNINITIALISED
+#endif
+
 namespace snmalloc
 {
   /**

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -6,6 +6,7 @@
 #if defined(SNMALLOC_BACKTRACE_HEADER)
 #  include SNMALLOC_BACKTRACE_HEADER
 #endif
+#include <cstdlib>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>

--- a/src/snmalloc/pal/pal_timer_default.h
+++ b/src/snmalloc/pal/pal_timer_default.h
@@ -4,8 +4,6 @@
 #include "pal_consts.h"
 #include "pal_ds.h"
 
-#include <chrono>
-
 namespace snmalloc
 {
   template<typename PalTime>


### PR DESCRIPTION
Avoid pulling in non freestanding chrono dependency if we can use `clock_gettime`.