### PR TITLE
Updating the build doc

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -13,7 +13,7 @@ To build with Visual Studio:
 ```
 mkdir build
 cd build
-cmake -G "Visual Studio 15 2019 Win64" ..
+cmake -G "Visual Studio 17 2022" -A x64 ..
 cmake --build . --config Debug
 cmake --build . --config Release
 cmake --build . --config RelWithDebInfo
@@ -112,8 +112,8 @@ target_link_libraries([lib_name] PRIVATE snmalloc_lib)
 You will also need to compile the relevant parts of snmalloc itself. Create a new file with the following contents and compile it with the rest of your application.
 
 ```c++
-#include "snmalloc/src/override/malloc.cc"
-#include "snmalloc/src/override/new.cc"
+#include "src/snmalloc/override/malloc.cc"
+#include "src/snmalloc/override/new.cc"
 ```
 
 To enable the `reallocarray` symbol export, this can be added to your cmake command line.


### PR DESCRIPTION
Hello snmalloc developers. I was going through the build in my project and saw a couple of things that might need updating.

First, it looks like Visual Studio 15 aligns with 2017, not 2019.

It appears this style of generator name "Visual Studio 15 2019 Win64" are for compatibility with CMake versions before 3.1 which was around 2014. In modern CMake, the Visual Studio generator is specified like so:

cmake -G "Visual Studio 15 2017" -A Win32
cmake -G "Visual Studio 15 2017" -A x64
cmake -G "Visual Studio 15 2017" -A ARM
cmake -G "Visual Studio 15 2017" -A ARM64

Since you mention VS 2022 being used in CI regularly, it seems like that should be the generator used in the doc.

The path to malloc.cc and new.cc seem incorrect. Maybe it changed overtime and wasn't updated in the doc.