### PR TITLE
Fixes: Sets `_HAS_EXCEPTIONS=0` globally #701

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,9 +293,7 @@ if(${Backtrace_FOUND})
     $<${ci_or_debug}:${Backtrace_INCLUDE_DIRS}>)
 endif()
 
-if(MSVC)
-  target_compile_definitions(snmalloc INTERFACE -D_HAS_EXCEPTIONS=0)
-else()
+if(NOT MSVC)
   check_linker_flag(CXX "-rdynamic" SNMALLOC_LINKER_SUPPORT_RDYNAMIC)
   if (SNMALLOC_LINKER_SUPPORT_RDYNAMIC)
     # Get better stack traces in CI and debug builds.
@@ -428,6 +426,10 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
     target_link_libraries(${name} snmalloc)
     set_target_properties(${name} PROPERTIES CXX_VISIBILITY_PRESET hidden INTERPROCEDURAL_OPTIMIZATION ${SNMALLOC_COMPILER_SUPPORT_IPO})
     target_compile_definitions(${name} PRIVATE "SNMALLOC_USE_${SNMALLOC_CLEANUP}")
+
+    if(MSVC)
+      target_compile_definitions(${name} INTERFACE -D_HAS_EXCEPTIONS=0)
+    endif()
 
     add_warning_flags(${name})
     if(NOT MSVC)


### PR DESCRIPTION
This makes the `_HAS_EXCEPTIONS` flag on windows only apply to libraries, and not if the library is used header only.