### PR TITLE
The _msize function has a non-const void* parameter in the msvc CRT.

### DIFF
--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -42,7 +42,7 @@ extern "C"
 
 #ifdef _WIN32
   SNMALLOC_EXPORT
-  size_t SNMALLOC_NAME_MANGLE(_msize)(MALLOC_USABLE_SIZE_QUALIFIER void* ptr)
+  size_t SNMALLOC_NAME_MANGLE(_msize)(void* ptr)
   {
     return snmalloc::libc::malloc_usable_size(ptr);
   }


### PR DESCRIPTION
When using snmalloc in my project as the "header-only library" style, I got a compile error for _msize:

`override\malloc.cc(45,10): error C2733: '_msize': you cannot overload a function with 'extern "C"' linkage`

I believe this is caused by the malloc.cc implementation using MALLOC_USABLE_SIZE_QUALIFIER which resolves to 'const', which is needed by malloc_usable_size's parameter (which _msize gets passed to). I think we must leave 'const' off of _msize's 'void*' parameter and it is ok to then pass as 'const void*' since it is becoming more restrictive.

With this fix my project can build and run successfully.