### PR TITLE
Changing DEBUG constexpr to SNMALLOC_DEBUG

### DIFF
--- a/src/snmalloc/ds_core/defines.h
+++ b/src/snmalloc/ds_core/defines.h
@@ -118,9 +118,9 @@
 namespace snmalloc
 {
 #ifdef NDEBUG
-  static constexpr bool DEBUG = false;
+  static constexpr bool Debug = false;
 #else
-  static constexpr bool DEBUG = true;
+  static constexpr bool Debug = true;
 #endif
 
   // Forwards reference so that the platform can define how to handle errors.

--- a/src/snmalloc/ds_core/mitigations.h
+++ b/src/snmalloc/ds_core/mitigations.h
@@ -19,7 +19,7 @@ namespace snmalloc
   {
     if (SNMALLOC_UNLIKELY(!test))
     {
-      if constexpr (!DEBUG)
+      if constexpr (!Debug)
       {
         UNUSED(str, args...);
         SNMALLOC_FAST_FAIL();

--- a/src/snmalloc/ds_core/redblacktree.h
+++ b/src/snmalloc/ds_core/redblacktree.h
@@ -86,7 +86,7 @@ namespace snmalloc
    */
   template<
     SNMALLOC_CONCEPT(RBRep) Rep,
-    bool run_checks = DEBUG,
+    bool run_checks = Debug,
     bool TRACE = false>
   class RBTree
   {

--- a/src/snmalloc/global/bounds_checks.h
+++ b/src/snmalloc/global/bounds_checks.h
@@ -12,7 +12,7 @@ namespace snmalloc
 #ifdef SNMALLOC_CHECK_LOADS
     SNMALLOC_CHECK_LOADS
 #else
-    DEBUG
+    Debug
 #endif
     ;
 

--- a/src/snmalloc/pal/pal_apple.h
+++ b/src/snmalloc/pal/pal_apple.h
@@ -144,7 +144,7 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
 
-      if constexpr (DEBUG)
+      if constexpr (Debug)
         memset(p, 0x5a, size);
 
       // `MADV_FREE_REUSABLE` can only be applied to writable pages,

--- a/src/snmalloc/pal/pal_bsd.h
+++ b/src/snmalloc/pal/pal_bsd.h
@@ -35,7 +35,7 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<OS::page_size>(p, size));
 
-      if constexpr (DEBUG)
+      if constexpr (Debug)
         memset(p, 0x5a, size);
 
       madvise(p, size, MADV_FREE);

--- a/src/snmalloc/pal/pal_freebsd.h
+++ b/src/snmalloc/pal/pal_freebsd.h
@@ -80,7 +80,7 @@ namespace snmalloc
     {
       SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
 
-      if constexpr (DEBUG)
+      if constexpr (Debug)
         memset(p, 0x5a, size);
 
       madvise(p, size, MADV_FREE);

--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -130,7 +130,7 @@ namespace snmalloc
 
       // Fill memory so that when we switch the pages back on we don't make
       // assumptions on the content.
-      if constexpr (DEBUG)
+      if constexpr (Debug)
         memset(p, 0x5a, size);
 
       madvise(p, size, madvise_free_flags);

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -215,7 +215,7 @@ namespace snmalloc
       {
         // Fill memory so that when we switch the pages back on we don't make
         // assumptions on the content.
-        if constexpr (DEBUG)
+        if constexpr (Debug)
           memset(p, 0x5a, size);
 
         mprotect(p, size, PROT_NONE);

--- a/src/test/perf/external_pointer/externalpointer.cc
+++ b/src/test/perf/external_pointer/externalpointer.cc
@@ -96,7 +96,7 @@ int main(int, char**)
 
   xoroshiro::p128r64 r;
 
-  size_t nn = snmalloc::DEBUG ? 30 : 3;
+  size_t nn = snmalloc::Debug ? 30 : 3;
 
   for (size_t n = 0; n < nn; n++)
     test::test_external_pointer(r);


### PR DESCRIPTION
Defining the constexpr DEBUG caused problems when building SNMALLOC into our project. This change simply changes the constexpr's name to SNMALLOC_DEBUG.