### PR TITLE
remove extra puts definitions

### DIFF
--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -19,7 +19,7 @@
 #    include <linux/futex.h>
 #  endif
 
-extern "C" int puts(const char* str);
+#  include <stdio.h>
 
 namespace snmalloc
 {

--- a/src/snmalloc/pal/pal_posix.h
+++ b/src/snmalloc/pal/pal_posix.h
@@ -23,8 +23,6 @@
 #  include <sys/random.h>
 #endif
 
-extern "C" int puts(const char* str);
-
 namespace snmalloc
 {
   /**


### PR DESCRIPTION
Use the definition from `stdio.h` directly. Manually defining such symbol may lead to mismatched exception spec.

```
/code/snmalloc/src/snmalloc/backend_helpers/../mem/../ds/../pal/pal_linux.h:22:16: error: 'puts' is missing exception specification 'throw()'
   22 | extern "C" int puts(const char* str);
      |                ^
      |                                      throw()
/code/snmalloc/src/snmalloc/backend_helpers/../mem/../ds/../pal/pal_posix.h:26:16: note: previous declaration is here
   26 | extern "C" int puts(const char* str);
      |                ^
1 error generated.
ninja: build stopped: subcommand failed.
```