### PR TITLE
Protection against fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,19 @@ int main()
  SNMALLOC_LINKER_SUPPORT_NOSTDLIBXX)
 set(CMAKE_REQUIRED_LINK_OPTIONS "")
 
+# Detect if pthread_atfork works
+CHECK_CXX_SOURCE_COMPILES("
+#include <pthread.h>
+void prepare() {}
+void parent() {}
+void child() {}
+int main() {
+  pthread_atfork(prepare, parent, child);
+  return 0;
+}
+" SNMALLOC_PTHREAD_ATFORK_WORKS)
+
+
 if (NOT MSVC AND NOT (SNMALLOC_CLEANUP STREQUAL CXX11_DESTRUCTORS))
   # If the target compiler doesn't support -nostdlib++ then we must enable C at
   # the global scope for the fallbacks to work.
@@ -320,6 +333,7 @@ add_as_define(SNMALLOC_QEMU_WORKAROUND)
 add_as_define(SNMALLOC_TRACING)
 add_as_define(SNMALLOC_CI_BUILD)
 add_as_define(SNMALLOC_PLATFORM_HAS_GETENTROPY)
+add_as_define(SNMALLOC_PTHREAD_ATFORK_WORKS)
 add_as_define(SNMALLOC_HAS_LINUX_RANDOM_H)
 add_as_define(SNMALLOC_HAS_LINUX_FUTEX_H)
 if (SNMALLOC_NO_REALLOCARRAY)

--- a/src/snmalloc/ds_aal/ds_aal.h
+++ b/src/snmalloc/ds_aal/ds_aal.h
@@ -6,4 +6,5 @@
 #pragma once
 #include "../aal/aal.h"
 #include "flaglock.h"
+#include "prevent_fork.h"
 #include "singleton.h"

--- a/src/snmalloc/ds_aal/flaglock.h
+++ b/src/snmalloc/ds_aal/flaglock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../aal/aal.h"
+#include "prevent_fork.h"
 #include "snmalloc/ds_core/ds_core.h"
 #include "snmalloc/stl/atomic.h"
 
@@ -107,6 +108,10 @@ namespace snmalloc
   {
   private:
     FlagWord& lock;
+
+    // A unix fork while holding a lock can lead to deadlock. Protect against
+    // this by not allowing a fork while holding a lock.
+    PreventFork pf{};
 
   public:
     FlagLock(FlagWord& lock) : lock(lock)

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -85,18 +85,18 @@ namespace snmalloc
       threads_preventing_fork = 0;
     }
 
-    // This function ensures that the fork handler has been installed at least once.
-    // It might be installed more than once, this is safe. As subsequent calls would
-    // be ignored.
+    // This function ensures that the fork handler has been installed at least
+    // once. It might be installed more than once, this is safe. As subsequent
+    // calls would be ignored.
     static void ensure_init()
     {
       static stl::Atomic<bool> initialised{false};
 
-      if (initialised.load(std::memory_order_acquire))
+      if (initialised.load(stl::memory_order_acquire))
         return;
 
       pthread_atfork(prefork, postfork, postfork);
-      initialised.store(true, std::memory_order_release);
+      initialised.store(true, stl::memory_order_release);
     };
 
   public:

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -127,7 +127,7 @@ namespace snmalloc
   class PreventFork
   {
   public:
-    static void init() {}
+    static void init(size_t*) noexcept {}
     static void ensure_init();
   };
 } // namespace snmalloc

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -135,7 +135,8 @@ namespace snmalloc
       // Allow other threads to allocate
       // There could have been threads spinning in the prefork handler having
       // optimistically increasing thread_preventing_fork by 2, but now the
-      // threads do not exist due to the fork. So restart the counter in the child.
+      // threads do not exist due to the fork. So restart the counter in the
+      // child.
       threads_preventing_fork = 0;
     }
 

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <snmalloc/aal/aal.h>
+#include <snmalloc/stl/atomic.h>
+#include <stddef.h>
+
+#ifdef SNMALLOC_PTHREAD_ATFORK_WORKS
+#  include <pthread.h>
+
+namespace snmalloc
+{
+  // This is a simple implementation of a class that can be
+  // used to prevent a process from forking. Holding a lock
+  // in the allocator while forking can lead to deadlocks.
+  // This causes the fork to wait out any other threads inside
+  // the allocators locks.
+  //
+  // The use is
+  // ```
+  //  {
+  //     PreventFork pf;
+  //     // Code that should not be running during a fork.
+  //  }
+  // ```
+  class PreventFork
+  {
+    // Global atomic counter of the number of threads currently preventing the
+    // system from forking. The bottom bit is used to signal that a thread is
+    // wanting to fork.
+    static inline stl::Atomic<size_t> threads_preventing_fork{0};
+
+    // The depth of the current thread's prevention of forking.
+    // This is used to enable reentrant prevention of forking.
+    static inline thread_local size_t depth_of_prevention{0};
+
+    // The function that notifies new threads not to enter PreventFork regions
+    // It waits until all threads are no longer in a PreventFork region before
+    // returning.
+    static void prefork()
+    {
+      if (depth_of_prevention != 0)
+      {
+        error("Fork attempted while in PreventFork region.");
+      }
+
+      while (true)
+      {
+        auto current = threads_preventing_fork.load();
+        if (
+          (current % 2 == 0) &&
+          (threads_preventing_fork.compare_exchange_weak(current, current + 1)))
+        {
+          break;
+        }
+        Aal::pause();
+      };
+
+      while (threads_preventing_fork.load() != 1)
+      {
+        Aal::pause();
+      }
+    }
+
+    // Unsets the flag that allows threads to enter PreventFork regions
+    // and for another thread to request a fork.
+    static void postfork()
+    {
+      threads_preventing_fork = 0;
+    }
+
+    // This is called by the Singleton class to ensure that it is
+    // only called once. Argument ignored, and only used for Singleton
+    // class design.
+    static void init(size_t*) noexcept
+    {
+      pthread_atfork(prefork, postfork, postfork);
+    }
+
+    // This function requires the Singleton class,
+    // which also depends on PreventFork. We define this
+    // implementation in singleton.h
+    static void ensure_init();
+
+  public:
+    PreventFork()
+    {
+      if (depth_of_prevention++ == 0)
+      {
+        // Ensure that the system is initialised before we start.
+        // Don't do this on nested Prevent calls.
+        ensure_init();
+        while (true)
+        {
+          auto current = threads_preventing_fork.load();
+
+          if (
+            (current % 2 == 0) &&
+            threads_preventing_fork.compare_exchange_weak(current, current + 2))
+          {
+            break;
+          }
+          Aal::pause();
+        };
+      }
+    }
+
+    ~PreventFork()
+    {
+      if (--depth_of_prevention == 0)
+      {
+        threads_preventing_fork -= 2;
+      }
+    }
+  };
+} // namespace snmalloc
+#else
+namespace snmalloc
+{
+  class PreventFork
+  {
+  public:
+    static void init() {}
+  };
+} // namespace snmalloc
+#endif

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -60,8 +60,9 @@ namespace snmalloc
         Aal::pause();
       }
 
-      // Finally set the flag that allows this thread to enter PreventFork regions
-      // This is safe as the only other calls here are to other prefork handlers.
+      // Finally set the flag that allows this thread to enter PreventFork
+      // regions This is safe as the only other calls here are to other prefork
+      // handlers.
       depth_of_prevention++;
     }
 
@@ -128,6 +129,7 @@ namespace snmalloc
   {
   public:
     static void init(size_t*) noexcept {}
+
     static void ensure_init();
   };
 } // namespace snmalloc

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -92,11 +92,11 @@ namespace snmalloc
     {
       static stl::Atomic<bool> initialised{false};
 
-      if (initialized.load(std::memory_order_acquire))
+      if (initialised.load(std::memory_order_acquire))
         return;
 
       pthread_atfork(prefork, postfork, postfork);
-      initialized.store(true, std::memory_order_release);
+      initialised.store(true, std::memory_order_release);
     };
 
   public:

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -128,6 +128,7 @@ namespace snmalloc
   {
   public:
     static void init() {}
+    static void ensure_init();
   };
 } // namespace snmalloc
 #endif

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -59,12 +59,20 @@ namespace snmalloc
       {
         Aal::pause();
       }
+
+      // Finally set the flag that allows this thread to enter PreventFork regions
+      // This is safe as the only other calls here are to other prefork handlers.
+      depth_of_prevention++;
     }
 
     // Unsets the flag that allows threads to enter PreventFork regions
     // and for another thread to request a fork.
     static void postfork()
     {
+      // This thread is no longer preventing a fork, so decrement the counter.
+      depth_of_prevention--;
+
+      // Allow other threads to allocate
       threads_preventing_fork = 0;
     }
 

--- a/src/snmalloc/ds_aal/prevent_fork.h
+++ b/src/snmalloc/ds_aal/prevent_fork.h
@@ -90,7 +90,7 @@ namespace snmalloc
     // be ignored.
     static void ensure_init()
     {
-      static std::Atomic<bool> initialised{false};
+      static stl::Atomic<bool> initialised{false};
 
       if (initialized.load(std::memory_order_acquire))
         return;

--- a/src/snmalloc/ds_aal/singleton.h
+++ b/src/snmalloc/ds_aal/singleton.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "prevent_fork.h"
 #include "snmalloc/stl/atomic.h"
 
 namespace snmalloc
@@ -36,6 +37,11 @@ namespace snmalloc
       auto state = initialised.load(stl::memory_order_acquire);
       if (SNMALLOC_UNLIKELY(state == State::Uninitialised))
       {
+        // A unix fork while initialising a singleton can lead to deadlock.
+        // Protect against this by not allowing a fork while attempting
+        // initialisation.
+        PreventFork pf;
+        snmalloc::UNUSED(pf);
         if (initialised.compare_exchange_strong(
               state, State::Initialising, stl::memory_order_relaxed))
         {
@@ -55,4 +61,10 @@ namespace snmalloc
       return obj;
     }
   };
+
+  inline void PreventFork::ensure_init()
+  {
+    static Singleton<size_t, &PreventFork::init> singleton;
+    singleton.get();
+  }
 } // namespace snmalloc

--- a/src/snmalloc/ds_aal/singleton.h
+++ b/src/snmalloc/ds_aal/singleton.h
@@ -61,10 +61,4 @@ namespace snmalloc
       return obj;
     }
   };
-
-  inline void PreventFork::ensure_init()
-  {
-    static Singleton<size_t, &PreventFork::init> singleton;
-    singleton.get();
-  }
 } // namespace snmalloc

--- a/src/snmalloc/mem/freelist_queue.h
+++ b/src/snmalloc/mem/freelist_queue.h
@@ -110,6 +110,14 @@ namespace snmalloc
       invariant();
       freelist::Object::atomic_store_null(last, Key, Key_tweak);
 
+      // The following non-linearisable effect is normally benign,
+      // but could lead to a remote list become completely detached
+      // during a fork in a multi-threaded process. This would lead
+      // to a memory leak, which is probably the least of your problems
+      // if you forked in during a deallocation.
+      PreventFork pf;
+      snmalloc::UNUSED(pf);
+
       // Exchange needs to be acq_rel.
       // *  It needs to be a release, so nullptr in next is visible.
       // *  Needs to be acquire, so linking into the list does not race with

--- a/src/snmalloc/stl/gnu/atomic.h
+++ b/src/snmalloc/stl/gnu/atomic.h
@@ -228,6 +228,13 @@ namespace snmalloc
           addressof(val), 1, order(MemoryOrder::SEQ_CST));
       }
 
+      SNMALLOC_FAST_PATH const T operator--(int)
+      {
+        static_assert(stl::is_integral_v<T>, "T must be an integral type.");
+        return __atomic_fetch_sub(
+          addressof(val), 1, order(MemoryOrder::SEQ_CST));
+      }
+
       SNMALLOC_FAST_PATH T operator-=(T decrement)
       {
         static_assert(stl::is_integral_v<T>, "T must be an integral type.");

--- a/src/snmalloc/stl/gnu/atomic.h
+++ b/src/snmalloc/stl/gnu/atomic.h
@@ -214,6 +214,13 @@ namespace snmalloc
           addressof(val), 1, order(MemoryOrder::SEQ_CST));
       }
 
+      SNMALLOC_FAST_PATH T operator--()
+      {
+        static_assert(stl::is_integral_v<T>, "T must be an integral type.");
+        return __atomic_sub_fetch(
+          addressof(val), 1, order(MemoryOrder::SEQ_CST));
+      }
+
       SNMALLOC_FAST_PATH const T operator++(int)
       {
         static_assert(stl::is_integral_v<T>, "T must be an integral type.");

--- a/src/test/func/protect_fork/protect_fork.cc
+++ b/src/test/func/protect_fork/protect_fork.cc
@@ -1,0 +1,60 @@
+#include <snmalloc/snmalloc.h>
+#include <iostream>
+
+#ifndef SNMALLOC_PTHREAD_ATFORK_WORKS
+int main()
+{
+  std::cout << "Test did not run" << std::endl;
+  return 0;
+}
+#else
+
+
+#include <pthread.h>
+#include <thread>
+
+int main()
+{
+  // Counter for the number of threads that are blocking the fork
+  std::atomic<size_t> block = false;
+  // Specifies that the forking thread has observed that all the blocking
+  // threads are in place.
+  std::atomic<bool> forking = false;
+
+  size_t N = 3;
+
+  for (size_t i = 0; i < N; i ++)
+  {
+    std::thread t([&block, &forking]() {
+      {
+        snmalloc::PreventFork pf;
+        block++;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        while (!forking)
+          std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        block--;
+      }
+    });
+
+    t.detach();
+  }
+
+  while(block != N)
+    std::this_thread::yield();
+
+  forking = true;
+
+  fork();
+
+  if (block)
+  {
+    snmalloc::message<1024>("PreventFork failed");
+    return 1;
+  }
+  snmalloc::message<1024>("PreventFork passed");
+  return 0;
+}
+
+#endif

--- a/src/test/func/protect_fork/protect_fork.cc
+++ b/src/test/func/protect_fork/protect_fork.cc
@@ -29,6 +29,7 @@ int main()
 
   pthread_atfork(simulate_allocation, simulate_allocation, simulate_allocation);
   {
+    // Cause initialisation of the PreventFork singleton to call pthread_atfork.
     snmalloc::PreventFork pf;
   }
   pthread_atfork(simulate_allocation, simulate_allocation, simulate_allocation);


### PR DESCRIPTION
If a thread forks, while another thread is holding an snmalloc lock, then the allocator could stop working.

This patch attempts to protect against the cases of this. There is one case that is not covered. If a fork occurs during the very first allocation. This can result in the installation of the fork handler racing with the fork, and all bets are off.

Address #630 