### PR TITLE
Adding a function to deinitialise the singleton so we can remove our exception handler.

### DIFF
--- a/src/snmalloc/ds_aal/singleton.h
+++ b/src/snmalloc/ds_aal/singleton.h
@@ -9,7 +9,7 @@ namespace snmalloc
    * initialised.  This singleton class is designed to not depend on the
    * runtime.
    */
-  template<class Object, void init(Object*) noexcept>
+  template<class Object, void init(Object*) noexcept, void deinit(Object*) noexcept>
   class Singleton
   {
     enum class State
@@ -23,6 +23,14 @@ namespace snmalloc
     inline static Object obj;
 
   public:
+    ~Singleton()
+    {
+      if(deinit)
+      {
+        deinit(&obj);
+      }
+    }
+
     /**
      * If argument is non-null, then it is assigned the value
      * true, if this is the first call to get.


### PR DESCRIPTION
When using snmalloc in a DLL, the exception handler is not removed when the DLL is unloaded. This will cause a crash if the EXE later throws an exception.

Example:
1. An EXE loads a DLL which uses snmalloc
2. AddVectoredExceptionHandler gets called to add HandleReadonlyLazyCommit as an exception handler
3. The EXE unloads the DLL (the memory at the address where the function HandleReadonlyLazyCommit existed has been freed)
4. The EXE throws an exception, and is expecting its own exception handler to handle it
5. While throwing the EXE's exception, MSVC tries to call HandleReadonlyLazyCommit and hits an access violation since that no longer exists

We resolve this, I'm adding code to call RemoveVectoredExceptionHandler when the Singleton is destroyed. That way MSVC won't have a dangling function pointer after the DLL is unloaded.

Note: This adds an extra template param to Singleton class, which probably will affect other platforms, which I have not updated.