### PR TITLE
build: Fix nothrow include.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
         extra-cmake-flags: [ "" ]
         # Modify the complete matrix
         include:
+          - os: "ubuntu-22.04"
+            variant: "C++17"
+            build-type: "Debug"
+            extra-cmake-flags: "-DSNMALLOC_USE_CXX17=ON"
           - os: "ubuntu-20.04"
             variant: "C++17"
             build-type: "Debug"

--- a/src/snmalloc/override/new.cc
+++ b/src/snmalloc/override/new.cc
@@ -1,5 +1,7 @@
 #include "snmalloc/snmalloc.h"
 
+#include <new>
+
 #ifdef _WIN32
 #  ifdef __clang__
 #    define EXCEPTSPEC noexcept


### PR DESCRIPTION
With STL no longer being included by the primary headers the `new.cc` override needs to include `<new>` to get `nothrow`