### PR TITLE
Fix test when using GWP-Asan

### DIFF
--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -274,7 +274,7 @@ void test_external_pointer()
 
       if ((size_t)p4 != (size_t)p1 + size - 1)
       {
-        if (((size_t)p4 > (size_t)p1 + size - 1) || snmalloc::is_owned(p1))
+        if (((size_t)p4 < (size_t)p1 + size - 1) || snmalloc::is_owned(p1))
         {
           std::cout << "size: " << size << " end(p4): " << p4 << " p1: " << p1
                     << "  p1+size-1: " << pointer_offset(p1, size - 1)

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -262,7 +262,7 @@ void test_external_pointer()
       void* p4 = snmalloc::external_pointer<End>(p2);
       if (p1 != p3)
       {
-        if (p3 < p1 || snmalloc::is_owned(p1))
+        if (p3 > p1 || snmalloc::is_owned(p1))
         {
           std::cout << "size: " << size
                     << " alloc_size: " << snmalloc::alloc_size(p1)

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -540,33 +540,25 @@ int main(int argc, char** argv)
 #else
   UNUSED(argc, argv);
 #endif
-  std::cout << "test_alloc_dealloc_64k" << std::endl;
-  test_alloc_dealloc_64k();
-  std::cout << "test_random_allocation" << std::endl;
-  test_random_allocation();
-  std::cout << "test_calloc" << std::endl;
-  test_calloc();
-  std::cout << "test_double_alloc" << std::endl;
-  test_double_alloc();
-  std::cout << "test_remaining_bytes" << std::endl;
-  test_remaining_bytes();
-  std::cout << "test_static_sized_allocs" << std::endl;
-  test_static_sized_allocs();
-  std::cout << "test_calloc_large_bug" << std::endl;
-  test_calloc_large_bug();
-  std::cout << "test_external_pointer_stack" << std::endl;
-  test_external_pointer_stack();
-  std::cout << "test_external_pointer_dealloc_bug" << std::endl;
-  test_external_pointer_dealloc_bug();
-  std::cout << "test_external_pointer_large" << std::endl;
-  test_external_pointer_large();
-  std::cout << "test_external_pointer" << std::endl;
-  test_external_pointer();
-  std::cout << "test_alloc_16M" << std::endl;
-  test_alloc_16M();
-  std::cout << "test_calloc_16M" << std::endl;
-  test_calloc_16M();
-  std::cout << "test_consolidation_bug" << std::endl;
-  test_consolidaton_bug();
+#define TEST(testname) \
+  std::cout << "Running " #testname << std::endl; \
+  for (size_t i = 0; i < 100; i++) \
+    testname();
+
+  TEST(test_alloc_dealloc_64k);
+  TEST(test_random_allocation);
+  TEST(test_calloc);
+  TEST(test_double_alloc);
+  TEST(test_remaining_bytes);
+  TEST(test_static_sized_allocs);
+  TEST(test_calloc_large_bug);
+  TEST(test_external_pointer_stack);
+  TEST(test_external_pointer_dealloc_bug);
+  TEST(test_external_pointer_large);
+  TEST(test_external_pointer);
+  TEST(test_alloc_16M);
+  TEST(test_calloc_16M);
+  TEST(test_consolidaton_bug);
+
   return 0;
 }

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -541,19 +541,33 @@ int main(int argc, char** argv)
 #else
   UNUSED(argc, argv);
 #endif
+  std::cout << "test_alloc_dealloc_64k" << std::endl;
   test_alloc_dealloc_64k();
+  std::cout << "test_random_allocation" << std::endl;
   test_random_allocation();
+  std::cout << "test_calloc" << std::endl;
   test_calloc();
+  std::cout << "test_double_alloc" << std::endl;
   test_double_alloc();
+  std::cout << "test_remaining_bytes" << std::endl;
   test_remaining_bytes();
+  std::cout << "test_static_sized_allocs" << std::endl;
   test_static_sized_allocs();
+  std::cout << "test_calloc_large_bug" << std::endl;
   test_calloc_large_bug();
+  std::cout << "test_external_pointer_stack" << std::endl;
   test_external_pointer_stack();
+  std::cout << "test_external_pointer_dealloc_bug" << std::endl;
   test_external_pointer_dealloc_bug();
+  std::cout << "test_external_pointer_large" << std::endl;
   test_external_pointer_large();
+  std::cout << "test_external_pointer" << std::endl;
   test_external_pointer();
+  std::cout << "test_alloc_16M" << std::endl;
   test_alloc_16M();
+  std::cout << "test_calloc_16M" << std::endl;
   test_calloc_16M();
+  std::cout << "test_consolidation_bug" << std::endl;
   test_consolidaton_bug();
   return 0;
 }

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -483,14 +483,13 @@ void test_remaining_bytes()
         snmalloc::remaining_bytes(address_cast(pointer_offset(p, offset)));
       if (rem != (size - offset))
       {
-        printf(
-          "Allocation size: %zu,  Offset: %zu,  Remaining bytes: %zu, "
-          "Expected: %zu\n",
+        report_fatal_error(
+          "Allocation size: {},  Offset: {},  Remaining bytes: {}, "
+          "Expected: {}",
           size,
           offset,
           rem,
           size - offset);
-        abort();
       }
     }
     snmalloc::dealloc(p);


### PR DESCRIPTION
Fix tests for external pointer with GWP-Asan.  There was a latent bug in the conditions being checked in some of the func-memory tests. See here for the failure:
https://github.com/microsoft/snmalloc/actions/runs/13832280098/job/38699118822

This PR fixes the conditions and causes the tests to be run multiple times to increase the likelihood of GWP-Asan failing. 