### PR TITLE
Header-only build fix for WIN32_LEAN_AND_MEAN redefinition

### DIFF
--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -9,7 +9,9 @@
 #    include <errno.h>
 #    include <stdio.h>
 #  endif
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif


### PR DESCRIPTION
When using snmalloc as header-only library in a project that globally defines `WIN32_LEAN_AND_MEAN`, there is a compile error for macro redefinition.

Guard the pal_windows.h define.