### PR TITLE
Fix bug in pool sort

### DIFF
--- a/src/snmalloc/mem/pool.h
+++ b/src/snmalloc/mem/pool.h
@@ -202,7 +202,6 @@ namespace snmalloc
         else
         {
           last->next = pool.front;
-          pool.back->next = capptr::Alloc<T>::unsafe_from(first);
         }
         pool.front = capptr::Alloc<T>::unsafe_from(first);
       });


### PR DESCRIPTION
The pool sort routine is used by Verona's systematic testing.  There was a bug introduced in #612 that could corrupt the list when a sort occured.

This is not used by snmalloc and the test coverage was insufficient to expose the bug.

This PR fixes the bug, and improves test coverage.