### PR TITLE
Adding code to release the body of the pagemap when destructing.

### DIFF
--- a/src/snmalloc/ds/pagemap.h
+++ b/src/snmalloc/ds/pagemap.h
@@ -104,7 +104,7 @@ namespace snmalloc
 
       if constexpr (pal_supports<Release, PAL>)
       {
-       PAL::notify_release(body_allocation_base);
+        PAL::notify_release(body_allocation_base);
       }
     }
 

--- a/src/snmalloc/ds/pagemap.h
+++ b/src/snmalloc/ds/pagemap.h
@@ -93,7 +93,10 @@ namespace snmalloc
      */
     ~FlatPagemap()
     {
-      PAL::notify_release(body);
+      if constexpr (pal_supports<Release, PAL>)
+      {
+        PAL::notify_release(body);
+      }
     }
 
     /**

--- a/src/snmalloc/ds/pagemap.h
+++ b/src/snmalloc/ds/pagemap.h
@@ -86,6 +86,17 @@ namespace snmalloc
     constexpr FlatPagemap() = default;
 
     /**
+     * Destructor to free the pagemap body
+     *
+     * When the pagemap is destroyed, make sure that the memory reserved
+     * in the init function gets released back to the OS.
+     */
+    ~FlatPagemap()
+    {
+      PAL::notify_release(body);
+    }
+
+    /**
      * For pagemaps that cover an entire fixed address space, return the size
      * that they must be.  This allows the caller to allocate the correct
      * amount of memory to be passed to `init`.  This is not available for

--- a/src/snmalloc/pal/pal_consts.h
+++ b/src/snmalloc/pal/pal_consts.h
@@ -64,6 +64,11 @@ namespace snmalloc
      * This Pal provides a way for parking threads at a specific address.
      */
     WaitOnAddress = (1 << 7),
+
+    /**
+     * This Pal provides a way for releasing the the body allocation for a pagemap.
+     */
+    Release = (1 << 8),
   };
 
   /**

--- a/src/snmalloc/pal/pal_consts.h
+++ b/src/snmalloc/pal/pal_consts.h
@@ -66,7 +66,8 @@ namespace snmalloc
     WaitOnAddress = (1 << 7),
 
     /**
-     * This Pal provides a way for releasing the the body allocation for a pagemap.
+     * This Pal provides a way for releasing the the body allocation for a
+     * pagemap.
      */
     Release = (1 << 8),
   };

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -136,7 +136,7 @@ namespace snmalloc
      * PAL supports.  This PAL supports low-memory notifications.
      */
     static constexpr uint64_t pal_features = LowMemoryNotification | Entropy |
-      Time | LazyCommit
+      Time | LazyCommit | Release
 #  if defined(PLATFORM_HAS_VIRTUALALLOC2) && !defined(USE_SYSTEMATIC_TESTING)
       | AlignedAllocation
 #  endif

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -223,6 +223,17 @@ namespace snmalloc
         error("VirtualFree failed");
     }
 
+    /// Notify platform that we will release these pages
+    static void notify_release(void* p) noexcept
+    {
+      BOOL ok = VirtualFree(p, 0, MEM_RELEASE);
+
+      if (!ok)
+      {
+        error("VirtualFree failed");
+      }
+    }
+
     /// Notify platform that we will be using these pages
     template<ZeroMem zero_mem>
     static void notify_using(void* p, size_t size) noexcept

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -226,6 +226,9 @@ namespace snmalloc
     /// Notify platform that we will release these pages
     static void notify_release(void* p) noexcept
     {
+      if (p == nullptr)
+        return;
+
       BOOL ok = VirtualFree(p, 0, MEM_RELEASE);
 
       if (!ok)


### PR DESCRIPTION
This alleviates the primary memory leak when unloading a DLL with snmalloc.