### PR TITLE
Release all pagemap reservations at the very end of the program or DLL

### DIFF
--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -231,57 +231,57 @@ public:
 };
 
 /**
-* atexit takes only function pointers that have no arguments
-* and return void. So we create this reservations vector with
-* static storage duration and internal linkage so it is visible
-* only to this translation unit and can be deleted by the
-* ReservationsCleanup
-*/
+ * atexit takes only function pointers that have no arguments
+ * and return void. So we create this reservations vector with
+ * static storage duration and internal linkage so it is visible
+ * only to this translation unit and can be deleted by the
+ * ReservationsCleanup
+ */
 static inline VirtualVector<void*> reservations;
 
 /**
-* This is the function that gets provided to atexit, and
-* calls VirtualFree on all the reservations.
-*/
+ * This is the function that gets provided to atexit, and
+ * calls VirtualFree on all the reservations.
+ */
 static inline void ReservationsCleanup()
 {
-for (size_t i = reservations.get_size(); i > 0; i--)
-{
+  for (size_t i = reservations.get_size(); i > 0; i--)
+  {
     volatile size_t index = i - 1;
     if (reservations[index] == nullptr)
-    continue;
-
+      continue;
+    
     BOOL ok = VirtualFree(reservations[index], 0, MEM_RELEASE);
-
+    
     reservations[index] = nullptr;
-
+    
     if (!ok)
     {
-        fputs("VirtualFree failed\n", stderr);
-        fflush(stderr);
-        abort();
+      fputs("VirtualFree failed\n", stderr);
+      fflush(stderr);
+      abort();
     }
-}
+  }
 }
 
 /**
-* The ReservationsCleanupHandler's constructor registers the
-* cleanup function with atexit.
-*/
+ * The ReservationsCleanupHandler's constructor registers the
+ * cleanup function with atexit.
+ */
 struct ReservationsCleanupHandler
 {
-ReservationsCleanupHandler()
-{
+  ReservationsCleanupHandler()
+  {
     atexit(ReservationsCleanup);
-}
+  }
 };
 
 /**
-* We create a static instance of the cleanup handler,
-* which will call the constructor and register the
-* ReservationsCleanup with atexit(). This is done before
-* all other statics because of init_seg(".CRT$XCB").
-*/
+ * We create a static instance of the cleanup handler,
+ * which will call the constructor and register the
+ * ReservationsCleanup with atexit(). This is done before
+ * all other statics because of init_seg(".CRT$XCB").
+ */
 static inline ReservationsCleanupHandler cleanup_handler;
 
 namespace snmalloc

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -382,8 +382,7 @@ namespace snmalloc
 
   public:
     VirtualVector(
-      size_t reserve_elems = MinReserve, 
-      size_t initial_commit = MinCommit)
+      size_t reserve_elems = MinReserve, size_t initial_commit = MinCommit)
     {
       reserve_and_commit(reserve_elems, initial_commit);
     }

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -38,7 +38,7 @@
  * in FILO order of when they were initialized. The pragma
  * init_seg makes sure the statics and globals in this
  * file are handled first, and thus will be the last to
- * be destroyed when the program exits or the DLL is 
+ * be destroyed when the program exits or the DLL is
  * unloaded.
  */
 #  pragma warning(disable : 4075)
@@ -371,16 +371,16 @@ namespace snmalloc
     size_t size = 0;
     size_t committed_elements = 0;
     size_t reserved_elements = 0;
-  
+
     // Lock for the reserved ranges.
     inline static snmalloc::FlagWord push_back_lock{};
-  
+
   public:
     VirtualVector(size_t reserve_elems = 64, size_t initial_commit = 32)
     {
       reserve_and_commit(reserve_elems, initial_commit);
     }
-  
+
     ~VirtualVector()
     {
       if (data)
@@ -390,42 +390,42 @@ namespace snmalloc
           size_t index = i - 1;
           if (data[index] == nullptr)
             continue;
-  
+
           BOOL ok = VirtualFree(data[index], 0, MEM_RELEASE);
-  
+
           data[index] = nullptr;
-  
+
           if (!ok)
           {
             snmalloc::PALWindows::error("VirtualFree failed");
           }
         }
-  
+
         BOOL ok = VirtualFree(data, 0, MEM_RELEASE);
-  
+
         data = nullptr;
-  
+
         if (!ok)
         {
           snmalloc::PALWindows::error("VirtualFree failed");
         }
       }
     }
-  
+
     void push_back(void* value)
     {
       snmalloc::FlagLock lock(push_back_lock);
       ensure_capacity();
       data[size++] = value;
     }
-  
+
   private:
     // Simple max function (avoiding <algorithm>)
     static size_t max_size_t(size_t a, size_t b)
     {
       return a > b ? a : b;
     }
-  
+
     void ensure_capacity()
     {
       if (size >= committed_elements)
@@ -433,33 +433,33 @@ namespace snmalloc
         size_t grow = max_size_t(64, committed_elements / 2);
         commit_more(committed_elements + grow);
       }
-  
+
       if (size >= reserved_elements)
       {
         grow_reserved();
       }
     }
-  
+
     void reserve_and_commit(size_t reserve_elems, size_t commit_elems)
     {
       size_t reserve_bytes = reserve_elems * sizeof(void*);
-      void** new_block =
-        (void**)VirtualAlloc(nullptr, reserve_bytes, MEM_RESERVE, PAGE_READWRITE);
+      void** new_block = (void**)VirtualAlloc(
+        nullptr, reserve_bytes, MEM_RESERVE, PAGE_READWRITE);
       if (!new_block)
         snmalloc::PALWindows::error("VirtualAlloc failed");
-  
+
       size_t commit_bytes = commit_elems * sizeof(void*);
       if (!VirtualAlloc(new_block, commit_bytes, MEM_COMMIT, PAGE_READWRITE))
       {
         VirtualFree(new_block, 0, MEM_RELEASE);
         snmalloc::PALWindows::error("VirtualAlloc failed");
       }
-  
+
       data = new_block;
       reserved_elements = reserve_elems;
       committed_elements = commit_elems;
     }
-  
+
     void commit_more(size_t new_commit_elements)
     {
       if (new_commit_elements > reserved_elements)
@@ -467,143 +467,143 @@ namespace snmalloc
         grow_reserved();
         return;
       }
-  
+
       size_t old_bytes = committed_elements * sizeof(void*);
       size_t new_bytes = new_commit_elements * sizeof(void*);
       size_t commit_bytes = new_bytes - old_bytes;
-  
+
       if (commit_bytes > 0)
       {
         void* result = VirtualAlloc(
           (char*)data + old_bytes, commit_bytes, MEM_COMMIT, PAGE_READWRITE);
         if (!result)
           throw std::bad_alloc();
-  
+
         committed_elements = new_commit_elements;
       }
     }
-  
+
     void grow_reserved()
     {
       size_t new_reserved = reserved_elements == 0 ? 64 : reserved_elements * 2;
       size_t new_commit = max_size_t(committed_elements, size + 64);
-  
+
       void** new_block = (void**)VirtualAlloc(
         nullptr, new_reserved * sizeof(void*), MEM_RESERVE, PAGE_READWRITE);
       if (!new_block)
         throw std::bad_alloc();
-  
+
       if (!VirtualAlloc(
             new_block, new_commit * sizeof(void*), MEM_COMMIT, PAGE_READWRITE))
       {
         VirtualFree(new_block, 0, MEM_RELEASE);
         throw std::bad_alloc();
       }
-  
+
       // Copy existing values
       for (size_t i = 0; i < size; ++i)
       {
         new_block[i] = data[i];
       }
-  
+
       VirtualFree(data, 0, MEM_RELEASE);
       data = new_block;
       reserved_elements = new_reserved;
       committed_elements = new_commit;
     }
-  
+
   public:
     void*& operator[](size_t index)
     {
       return data[index];
     }
-  
+
     const void* operator[](size_t index) const
     {
       return data[index];
     }
-  
+
     size_t get_size() const
     {
       return size;
     }
-  
+
     size_t get_capacity() const
     {
       return committed_elements;
     }
-  
+
     void** begin()
     {
       return data;
     }
-  
+
     void** end()
     {
       return data + size;
     }
-  
+
     const void* const* begin() const
     {
       return data;
     }
-  
+
     const void* const* end() const
     {
       return data + size;
     }
   };
-  
+
   /**
    * This will be destroyed last of all of the
    * statics and globals due to init_seg
    */
   static inline VirtualVector reservations;
-  
-  #  ifdef PLATFORM_HAS_VIRTUALALLOC2
+
+#  ifdef PLATFORM_HAS_VIRTUALALLOC2
   template<bool state_using>
   void* PALWindows::reserve_aligned(size_t size) noexcept
   {
-      SNMALLOC_ASSERT(bits::is_pow2(size));
-      SNMALLOC_ASSERT(size >= minimum_alloc_size);
-  
-      DWORD flags = MEM_RESERVE;
-  
-      if (state_using)
+    SNMALLOC_ASSERT(bits::is_pow2(size));
+    SNMALLOC_ASSERT(size >= minimum_alloc_size);
+
+    DWORD flags = MEM_RESERVE;
+
+    if (state_using)
       flags |= MEM_COMMIT;
-  
-      // If we're on Windows 10 or newer, we can use the VirtualAlloc2
-      // function.  The FromApp variant is useable by UWP applications and
-      // cannot allocate executable memory.
-      MEM_ADDRESS_REQUIREMENTS addressReqs = {NULL, NULL, size};
-  
-      MEM_EXTENDED_PARAMETER param = {
+
+    // If we're on Windows 10 or newer, we can use the VirtualAlloc2
+    // function.  The FromApp variant is useable by UWP applications and
+    // cannot allocate executable memory.
+    MEM_ADDRESS_REQUIREMENTS addressReqs = {NULL, NULL, size};
+
+    MEM_EXTENDED_PARAMETER param = {
       {MemExtendedParameterAddressRequirements, 0}, {0}};
-      // Separate assignment as MSVC doesn't support .Pointer in the
-      // initialisation list.
-      param.Pointer = &addressReqs;
-  
-      void* ret = VirtualAlloc2FromApp(
+    // Separate assignment as MSVC doesn't support .Pointer in the
+    // initialisation list.
+    param.Pointer = &addressReqs;
+
+    void* ret = VirtualAlloc2FromApp(
       nullptr, nullptr, size, flags, PAGE_READWRITE, &param, 1);
-      if (ret == nullptr)
+    if (ret == nullptr)
       errno = ENOMEM;
-  
-      reservations.push_back(ret);
-  
-      return ret;
+
+    reservations.push_back(ret);
+
+    return ret;
   }
-  #  endif
-  
+#  endif
+
   void* PALWindows::reserve(size_t size) noexcept
   {
-      void* ret = VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
-      if (ret == nullptr)
+    void* ret = VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
+    if (ret == nullptr)
       errno = ENOMEM;
 
-      reservations.push_back(ret);
+    reservations.push_back(ret);
 
-      return ret;
+    return ret;
   }
-  
+
 }
 #endif

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -33,256 +33,16 @@
  * allocations have been freed.
  *
  * One way to guarantee that the reservations get released
- * at the absolute end of the program is to use atexit.
- * The atexit() takes function pointers which are called
- * during exit in LIFO order. To make sure that we are
- * the first call in the atexit chain, we use the pragma
- * init_seg(".CRT$XCB")  which ensures that statics in
- * this translation unit get initialized first and that
- * atexit() in the constructor gets called first. Then,
- * on program or DLL exit, we know that our function will
- * be called last.
+ * at the absolute end of the program is to force them to
+ * be initialized first. Statics and globals get destroyed
+ * in FILO order of when they were initialized. The pragma
+ * init_seg makes sure the statics and globals in this
+ * file are handled first, and thus will be the last to
+ * be destroyed when the program exits or the DLL is 
+ * unloaded.
  */
 #  pragma warning(disable : 4075)
 #  pragma init_seg(".CRT$XCB")
-
-// Simple max function (avoiding <algorithm>)
-static size_t max_size_t(size_t a, size_t b)
-{
-  return a > b ? a : b;
-}
-
-/**
- * This VirtualVector class is an implementation of
- * a vector, but does not use new/malloc or any other
- * STL containers. These cannot be used in the
- * function given to atexit() when the pragma
- * init_seg(".CRT$XCB") is used, because the CRT
- * might not be fully initialized yet. The segments
- * compiler, lib, user cannot be used because of
- * CRT internals like std::locale facets
- */
-template<typename T>
-class VirtualVector
-{
-  T* data = nullptr;
-  size_t size = 0;
-  size_t committed_elements = 0;
-  size_t reserved_elements = 0;
-
-public:
-  VirtualVector(size_t reserve_elems = 64, size_t initial_commit = 32)
-  {
-    reserve_and_commit(reserve_elems, initial_commit);
-  }
-
-  ~VirtualVector()
-  {
-    if (data)
-    {
-      for (size_t i = 0; i < size; ++i)
-        data[i].~T();
-
-      VirtualFree(data, 0, MEM_RELEASE);
-    }
-  }
-
-  void push_back(const T& value)
-  {
-    ensure_capacity();
-    new (&data[size]) T(value);
-    ++size;
-  }
-
-  void push_back(T&& value)
-  {
-    ensure_capacity();
-    new (&data[size]) T((T &&) value);
-    ++size;
-  }
-
-private:
-  void ensure_capacity()
-  {
-    if (size >= committed_elements)
-    {
-      size_t grow = max_size_t(64, committed_elements / 2);
-      commit_more(committed_elements + grow);
-    }
-
-    if (size >= reserved_elements)
-    {
-      grow_reserved();
-    }
-  }
-
-  void reserve_and_commit(size_t reserve_elems, size_t commit_elems)
-  {
-    size_t reserve_bytes = reserve_elems * sizeof(T);
-    T* new_block =
-      (T*)VirtualAlloc(nullptr, reserve_bytes, MEM_RESERVE, PAGE_READWRITE);
-    if (!new_block)
-      throw std::bad_alloc();
-
-    size_t commit_bytes = commit_elems * sizeof(T);
-    if (!VirtualAlloc(new_block, commit_bytes, MEM_COMMIT, PAGE_READWRITE))
-    {
-      VirtualFree(new_block, 0, MEM_RELEASE);
-      throw std::bad_alloc();
-    }
-
-    data = new_block;
-    reserved_elements = reserve_elems;
-    committed_elements = commit_elems;
-  }
-
-  void commit_more(size_t new_commit_elements)
-  {
-    if (new_commit_elements > reserved_elements)
-    {
-      grow_reserved();
-      return;
-    }
-
-    size_t old_bytes = committed_elements * sizeof(T);
-    size_t new_bytes = new_commit_elements * sizeof(T);
-    size_t commit_bytes = new_bytes - old_bytes;
-
-    if (commit_bytes > 0)
-    {
-      void* result = VirtualAlloc(
-        (char*)data + old_bytes, commit_bytes, MEM_COMMIT, PAGE_READWRITE);
-      if (!result)
-        throw std::bad_alloc();
-
-      committed_elements = new_commit_elements;
-    }
-  }
-
-  void grow_reserved()
-  {
-    size_t new_reserved = reserved_elements == 0 ? 64 : reserved_elements * 2;
-    size_t new_commit = max_size_t(committed_elements, size + 64);
-
-    T* new_block = (T*)VirtualAlloc(
-      nullptr, new_reserved * sizeof(T), MEM_RESERVE, PAGE_READWRITE);
-    if (!new_block)
-      throw std::bad_alloc();
-
-    if (!VirtualAlloc(
-          new_block, new_commit * sizeof(T), MEM_COMMIT, PAGE_READWRITE))
-    {
-      VirtualFree(new_block, 0, MEM_RELEASE);
-      throw std::bad_alloc();
-    }
-
-    for (size_t i = 0; i < size; ++i)
-    {
-      new (&new_block[i]) T((T &&) data[i]);
-      data[i].~T();
-    }
-
-    VirtualFree(data, 0, MEM_RELEASE);
-    data = new_block;
-    reserved_elements = new_reserved;
-    committed_elements = new_commit;
-  }
-
-public:
-  T& operator[](size_t index)
-  {
-    return data[index];
-  }
-
-  const T& operator[](size_t index) const
-  {
-    return data[index];
-  }
-
-  size_t get_size() const
-  {
-    return size;
-  }
-
-  size_t get_capacity() const
-  {
-    return committed_elements;
-  }
-
-  T* begin()
-  {
-    return data;
-  }
-
-  T* end()
-  {
-    return data + size;
-  }
-
-  const T* begin() const
-  {
-    return data;
-  }
-
-  const T* end() const
-  {
-    return data + size;
-  }
-};
-
-/**
- * atexit takes only function pointers that have no arguments
- * and return void. So we create this reservations vector with
- * static storage duration and internal linkage so it is visible
- * only to this translation unit and can be deleted by the
- * ReservationsCleanup
- */
-static inline VirtualVector<void*> reservations;
-
-/**
- * This is the function that gets provided to atexit, and
- * calls VirtualFree on all the reservations.
- */
-static inline void ReservationsCleanup()
-{
-  for (size_t i = reservations.get_size(); i > 0; i--)
-  {
-    volatile size_t index = i - 1;
-    if (reservations[index] == nullptr)
-      continue;
-
-    BOOL ok = VirtualFree(reservations[index], 0, MEM_RELEASE);
-
-    reservations[index] = nullptr;
-
-    if (!ok)
-    {
-      fputs("VirtualFree failed\n", stderr);
-      fflush(stderr);
-      abort();
-    }
-  }
-}
-
-/**
- * The ReservationsCleanupHandler's constructor registers the
- * cleanup function with atexit.
- */
-struct ReservationsCleanupHandler
-{
-  ReservationsCleanupHandler()
-  {
-    atexit(ReservationsCleanup);
-  }
-};
-
-/**
- * We create a static instance of the cleanup handler,
- * which will call the constructor and register the
- * ReservationsCleanup with atexit(). This is done before
- * all other statics because of init_seg(".CRT$XCB").
- */
-static inline ReservationsCleanupHandler cleanup_handler;
 
 namespace snmalloc
 {
@@ -530,48 +290,10 @@ namespace snmalloc
 
 #  ifdef PLATFORM_HAS_VIRTUALALLOC2
     template<bool state_using>
-    static void* reserve_aligned(size_t size) noexcept
-    {
-      SNMALLOC_ASSERT(bits::is_pow2(size));
-      SNMALLOC_ASSERT(size >= minimum_alloc_size);
-
-      DWORD flags = MEM_RESERVE;
-
-      if (state_using)
-        flags |= MEM_COMMIT;
-
-      // If we're on Windows 10 or newer, we can use the VirtualAlloc2
-      // function.  The FromApp variant is useable by UWP applications and
-      // cannot allocate executable memory.
-      MEM_ADDRESS_REQUIREMENTS addressReqs = {NULL, NULL, size};
-
-      MEM_EXTENDED_PARAMETER param = {
-        {MemExtendedParameterAddressRequirements, 0}, {0}};
-      // Separate assignment as MSVC doesn't support .Pointer in the
-      // initialisation list.
-      param.Pointer = &addressReqs;
-
-      void* ret = VirtualAlloc2FromApp(
-        nullptr, nullptr, size, flags, PAGE_READWRITE, &param, 1);
-      if (ret == nullptr)
-        errno = ENOMEM;
-
-      reservations.push_back(ret);
-
-      return ret;
-    }
+    static void* reserve_aligned(size_t size) noexcept;
 #  endif
 
-    static void* reserve(size_t size) noexcept
-    {
-      void* ret = VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
-      if (ret == nullptr)
-        errno = ENOMEM;
-
-      reservations.push_back(ret);
-
-      return ret;
-    }
+    static void* reserve(size_t size) noexcept;
 
     /**
      * Source of Entropy
@@ -633,5 +355,255 @@ namespace snmalloc
     }
 #  endif
   };
+
+  /**
+   * This VirtualVector class is an implementation of
+   * a vector, but does not use new/malloc or any other
+   * STL containers. We cannot use these after
+   * init_seg(".CRT$XCB") usage, because the CRT
+   * might not be fully initialized yet. The segments
+   * compiler, lib, user cannot be used because of
+   * CRT internals like std::locale facets
+   */
+  class VirtualVector
+  {
+    void** data = nullptr;
+    size_t size = 0;
+    size_t committed_elements = 0;
+    size_t reserved_elements = 0;
+  
+    // Lock for the reserved ranges.
+    inline static snmalloc::FlagWord push_back_lock{};
+  
+  public:
+    VirtualVector(size_t reserve_elems = 64, size_t initial_commit = 32)
+    {
+      reserve_and_commit(reserve_elems, initial_commit);
+    }
+  
+    ~VirtualVector()
+    {
+      if (data)
+      {
+        for (size_t i = size; i > 0; i--)
+        {
+          size_t index = i - 1;
+          if (data[index] == nullptr)
+            continue;
+  
+          BOOL ok = VirtualFree(data[index], 0, MEM_RELEASE);
+  
+          data[index] = nullptr;
+  
+          if (!ok)
+          {
+            snmalloc::PALWindows::error("VirtualFree failed");
+          }
+        }
+  
+        BOOL ok = VirtualFree(data, 0, MEM_RELEASE);
+  
+        data = nullptr;
+  
+        if (!ok)
+        {
+          snmalloc::PALWindows::error("VirtualFree failed");
+        }
+      }
+    }
+  
+    void push_back(void* value)
+    {
+      snmalloc::FlagLock lock(push_back_lock);
+      ensure_capacity();
+      data[size++] = value;
+    }
+  
+  private:
+    // Simple max function (avoiding <algorithm>)
+    static size_t max_size_t(size_t a, size_t b)
+    {
+      return a > b ? a : b;
+    }
+  
+    void ensure_capacity()
+    {
+      if (size >= committed_elements)
+      {
+        size_t grow = max_size_t(64, committed_elements / 2);
+        commit_more(committed_elements + grow);
+      }
+  
+      if (size >= reserved_elements)
+      {
+        grow_reserved();
+      }
+    }
+  
+    void reserve_and_commit(size_t reserve_elems, size_t commit_elems)
+    {
+      size_t reserve_bytes = reserve_elems * sizeof(void*);
+      void** new_block =
+        (void**)VirtualAlloc(nullptr, reserve_bytes, MEM_RESERVE, PAGE_READWRITE);
+      if (!new_block)
+        snmalloc::PALWindows::error("VirtualAlloc failed");
+  
+      size_t commit_bytes = commit_elems * sizeof(void*);
+      if (!VirtualAlloc(new_block, commit_bytes, MEM_COMMIT, PAGE_READWRITE))
+      {
+        VirtualFree(new_block, 0, MEM_RELEASE);
+        snmalloc::PALWindows::error("VirtualAlloc failed");
+      }
+  
+      data = new_block;
+      reserved_elements = reserve_elems;
+      committed_elements = commit_elems;
+    }
+  
+    void commit_more(size_t new_commit_elements)
+    {
+      if (new_commit_elements > reserved_elements)
+      {
+        grow_reserved();
+        return;
+      }
+  
+      size_t old_bytes = committed_elements * sizeof(void*);
+      size_t new_bytes = new_commit_elements * sizeof(void*);
+      size_t commit_bytes = new_bytes - old_bytes;
+  
+      if (commit_bytes > 0)
+      {
+        void* result = VirtualAlloc(
+          (char*)data + old_bytes, commit_bytes, MEM_COMMIT, PAGE_READWRITE);
+        if (!result)
+          throw std::bad_alloc();
+  
+        committed_elements = new_commit_elements;
+      }
+    }
+  
+    void grow_reserved()
+    {
+      size_t new_reserved = reserved_elements == 0 ? 64 : reserved_elements * 2;
+      size_t new_commit = max_size_t(committed_elements, size + 64);
+  
+      void** new_block = (void**)VirtualAlloc(
+        nullptr, new_reserved * sizeof(void*), MEM_RESERVE, PAGE_READWRITE);
+      if (!new_block)
+        throw std::bad_alloc();
+  
+      if (!VirtualAlloc(
+            new_block, new_commit * sizeof(void*), MEM_COMMIT, PAGE_READWRITE))
+      {
+        VirtualFree(new_block, 0, MEM_RELEASE);
+        throw std::bad_alloc();
+      }
+  
+      // Copy existing values
+      for (size_t i = 0; i < size; ++i)
+      {
+        new_block[i] = data[i];
+      }
+  
+      VirtualFree(data, 0, MEM_RELEASE);
+      data = new_block;
+      reserved_elements = new_reserved;
+      committed_elements = new_commit;
+    }
+  
+  public:
+    void*& operator[](size_t index)
+    {
+      return data[index];
+    }
+  
+    const void* operator[](size_t index) const
+    {
+      return data[index];
+    }
+  
+    size_t get_size() const
+    {
+      return size;
+    }
+  
+    size_t get_capacity() const
+    {
+      return committed_elements;
+    }
+  
+    void** begin()
+    {
+      return data;
+    }
+  
+    void** end()
+    {
+      return data + size;
+    }
+  
+    const void* const* begin() const
+    {
+      return data;
+    }
+  
+    const void* const* end() const
+    {
+      return data + size;
+    }
+  };
+  
+  /**
+   * This will be destroyed last of all of the
+   * statics and globals due to init_seg
+   */
+  static inline VirtualVector reservations;
+  
+  #  ifdef PLATFORM_HAS_VIRTUALALLOC2
+  template<bool state_using>
+  void* PALWindows::reserve_aligned(size_t size) noexcept
+  {
+      SNMALLOC_ASSERT(bits::is_pow2(size));
+      SNMALLOC_ASSERT(size >= minimum_alloc_size);
+  
+      DWORD flags = MEM_RESERVE;
+  
+      if (state_using)
+      flags |= MEM_COMMIT;
+  
+      // If we're on Windows 10 or newer, we can use the VirtualAlloc2
+      // function.  The FromApp variant is useable by UWP applications and
+      // cannot allocate executable memory.
+      MEM_ADDRESS_REQUIREMENTS addressReqs = {NULL, NULL, size};
+  
+      MEM_EXTENDED_PARAMETER param = {
+      {MemExtendedParameterAddressRequirements, 0}, {0}};
+      // Separate assignment as MSVC doesn't support .Pointer in the
+      // initialisation list.
+      param.Pointer = &addressReqs;
+  
+      void* ret = VirtualAlloc2FromApp(
+      nullptr, nullptr, size, flags, PAGE_READWRITE, &param, 1);
+      if (ret == nullptr)
+      errno = ENOMEM;
+  
+      reservations.push_back(ret);
+  
+      return ret;
+  }
+  #  endif
+  
+  void* PALWindows::reserve(size_t size) noexcept
+  {
+      void* ret = VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
+      if (ret == nullptr)
+      errno = ENOMEM;
+
+      reservations.push_back(ret);
+
+      return ret;
+  }
+  
 }
 #endif

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -376,7 +376,9 @@ namespace snmalloc
     inline static snmalloc::FlagWord push_back_lock{};
 
   public:
-    VirtualVector(size_t reserve_elems = snmalloc::PALWindows::page_size, size_t initial_commit = 32)
+    VirtualVector(
+      size_t reserve_elems = snmalloc::PALWindows::page_size, 
+      size_t initial_commit = 32)
     {
       reserve_and_commit(reserve_elems, initial_commit);
     }

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -376,7 +376,7 @@ namespace snmalloc
     inline static snmalloc::FlagWord push_back_lock{};
 
   public:
-    VirtualVector(size_t reserve_elems = 64, size_t initial_commit = 32)
+    VirtualVector(size_t reserve_elems = snmalloc::PALWindows::page_size, size_t initial_commit = 32)
     {
       reserve_and_commit(reserve_elems, initial_commit);
     }
@@ -477,7 +477,7 @@ namespace snmalloc
         void* result = VirtualAlloc(
           (char*)data + old_bytes, commit_bytes, MEM_COMMIT, PAGE_READWRITE);
         if (!result)
-          throw std::bad_alloc();
+          error("VirtualAlloc failed");
 
         committed_elements = new_commit_elements;
       }
@@ -491,13 +491,13 @@ namespace snmalloc
       void** new_block = (void**)VirtualAlloc(
         nullptr, new_reserved * sizeof(void*), MEM_RESERVE, PAGE_READWRITE);
       if (!new_block)
-        throw std::bad_alloc();
+        error("VirtualAlloc failed");
 
       if (!VirtualAlloc(
             new_block, new_commit * sizeof(void*), MEM_COMMIT, PAGE_READWRITE))
       {
         VirtualFree(new_block, 0, MEM_RELEASE);
-        throw std::bad_alloc();
+        error("VirtualAlloc failed");
       }
 
       // Copy existing values

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -377,7 +377,7 @@ namespace snmalloc
 
   public:
     VirtualVector(
-      size_t reserve_elems = snmalloc::PALWindows::page_size, 
+      size_t reserve_elems = snmalloc::PALWindows::page_size,
       size_t initial_commit = 32)
     {
       reserve_and_commit(reserve_elems, initial_commit);

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -97,7 +97,7 @@ public:
   void push_back(T&& value)
   {
     ensure_capacity();
-    new (&data[size]) T((T&&)value);
+    new (&data[size]) T((T &&) value);
     ++size;
   }
 
@@ -178,7 +178,7 @@ private:
 
     for (size_t i = 0; i < size; ++i)
     {
-      new (&new_block[i]) T((T&&)data[i]);
+      new (&new_block[i]) T((T &&) data[i]);
       data[i].~T();
     }
 
@@ -250,11 +250,11 @@ static inline void ReservationsCleanup()
     volatile size_t index = i - 1;
     if (reservations[index] == nullptr)
       continue;
-    
+
     BOOL ok = VirtualFree(reservations[index], 0, MEM_RELEASE);
-    
+
     reservations[index] = nullptr;
-    
+
     if (!ok)
     {
       fputs("VirtualFree failed\n", stderr);

--- a/src/test/perf/lotsofthreads/lotsofthread.cc
+++ b/src/test/perf/lotsofthreads/lotsofthread.cc
@@ -96,6 +96,8 @@ int main()
   size_t iterations = 50000;
 #elif defined(__APPLE__) && !defined(SNMALLOC_APPLE_HAS_OS_SYNC_WAIT_ON_ADDRESS)
   size_t iterations = 50000;
+#elif defined(WIN32)
+  size_t iterations = 50000;
 #else
   size_t iterations = 200000;
 #endif


### PR DESCRIPTION
Continuation of: https://github.com/microsoft/snmalloc/pull/771. I made a new PR since it was a somewhat different concept from the original.

This seems to be a more correct way to cleanup at the end of the program or DLL.

1. Reservations are tracked in a static vector
2. This vector is a custom one that use VirtualAlloc and VirtualFree to avoid recursive calls
3. When it's time to exit, free the reservations we have created
4. #pragma init_seg(".CRT$XCB") is used to set this translation unit to be very early in the initialization phase. This means that our cleanup function passed to atexit() gets called at the very end, and our cleanup code can work properly.