### PR TITLE
Pass continuations for success and failure cases

### DIFF
--- a/fuzzing/snmalloc-fuzzer.cpp
+++ b/fuzzing/snmalloc-fuzzer.cpp
@@ -166,7 +166,7 @@ void snmalloc_random_walk(
       case EventKind::AllocZero:
       {
         auto ptr =
-          static_cast<char*>(scoped->alloc<snmalloc::YesZero>(e.size_or_index));
+          static_cast<char*>(scoped->alloc<snmalloc::Zero>(e.size_or_index));
         results.emplace_back(0, ptr, e.size_or_index);
         break;
       }
@@ -174,7 +174,7 @@ void snmalloc_random_walk(
       case EventKind::AllocNoZero:
       {
         auto ptr =
-          static_cast<char*>(scoped->alloc<snmalloc::NoZero>(e.size_or_index));
+          static_cast<char*>(scoped->alloc<snmalloc::Uninit>(e.size_or_index));
         std::fill(ptr, ptr + e.size_or_index, e.filler);
         results.emplace_back(e.filler, ptr, e.size_or_index);
         break;

--- a/src/snmalloc/backend/backend.h
+++ b/src/snmalloc/backend/backend.h
@@ -59,7 +59,6 @@ namespace snmalloc
 
       if (p == nullptr)
       {
-        errno = ENOMEM;
         return nullptr;
       }
 
@@ -112,7 +111,6 @@ namespace snmalloc
 
       if (meta == nullptr)
       {
-        errno = ENOMEM;
         return {nullptr, nullptr};
       }
 
@@ -124,7 +122,6 @@ namespace snmalloc
       if (p == nullptr)
       {
         local_state.get_meta_range().dealloc_range(meta_cap, meta_size);
-        errno = ENOMEM;
 #ifdef SNMALLOC_TRACING
         message<1024>("Out of memory");
 #endif

--- a/src/snmalloc/global/globalalloc.h
+++ b/src/snmalloc/global/globalalloc.h
@@ -321,24 +321,24 @@ namespace snmalloc
     return sizeclass_full_to_size(entry.get_sizeclass());
   }
 
-  template<size_t size, ZeroMem zero_mem = NoZero, size_t align = 1>
+  template<size_t size, typename Conts = Uninit, size_t align = 1>
   SNMALLOC_FAST_PATH_INLINE void* alloc()
   {
-    return ThreadAlloc::get().alloc<zero_mem, ThreadAlloc::CheckInit>(
+    return ThreadAlloc::get().alloc<Conts, ThreadAlloc::CheckInit>(
       aligned_size(align, size));
   }
 
-  template<ZeroMem zero_mem = NoZero, size_t align = 1>
+  template<typename Conts = Uninit, size_t align = 1>
   SNMALLOC_FAST_PATH_INLINE void* alloc(size_t size)
   {
-    return ThreadAlloc::get().alloc<zero_mem, ThreadAlloc::CheckInit>(
+    return ThreadAlloc::get().alloc<Conts, ThreadAlloc::CheckInit>(
       aligned_size(align, size));
   }
 
-  template<ZeroMem zero_mem = NoZero>
+  template<typename Conts = Uninit>
   SNMALLOC_FAST_PATH_INLINE void* alloc_aligned(size_t align, size_t size)
   {
-    return ThreadAlloc::get().alloc<zero_mem, ThreadAlloc::CheckInit>(
+    return ThreadAlloc::get().alloc<Conts, ThreadAlloc::CheckInit>(
       aligned_size(align, size));
   }
 

--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -47,7 +47,7 @@ namespace snmalloc::libc
     {
       return set_error();
     }
-    return alloc<ZeroMem::YesZero>(sz);
+    return alloc<Zero>(sz);
   }
 
   SNMALLOC_FAST_PATH_INLINE void* realloc(void* ptr, size_t size)

--- a/src/snmalloc/override/jemalloc_compat.cc
+++ b/src/snmalloc/override/jemalloc_compat.cc
@@ -143,7 +143,7 @@ extern "C"
     }
     if (f.should_zero())
     {
-      *ptr = alloc<ZeroMem::YesZero>(size);
+      *ptr = alloc<Zero>(size);
     }
     else
     {
@@ -187,7 +187,7 @@ extern "C"
       asize = f.aligned_size(size + extra);
     }
 
-    void* p = f.should_zero() ? alloc<YesZero>(asize) : alloc(asize);
+    void* p = f.should_zero() ? alloc<Zero>(asize) : alloc(asize);
     if (SNMALLOC_LIKELY(p != nullptr))
     {
       sz = bits::min(asize, sz);
@@ -255,7 +255,7 @@ extern "C"
     size = f.aligned_size(size);
     if (f.should_zero())
     {
-      return alloc<ZeroMem::YesZero>(size);
+      return alloc<Zero>(size);
     }
     return alloc(size);
   }
@@ -289,7 +289,7 @@ extern "C"
     // allocations, because we get zeroed memory from the PAL and don't zero it
     // twice.  This is not profiled and so should be considered for refactoring
     // if anyone cares about the performance of these APIs.
-    void* p = f.should_zero() ? alloc<YesZero>(size) : alloc(size);
+    void* p = f.should_zero() ? alloc<Zero>(size) : alloc(size);
     if (SNMALLOC_LIKELY(p != nullptr))
     {
       sz = bits::min(size, sz);
@@ -376,7 +376,7 @@ extern "C"
     }
     // Include size 0 in the first sizeclass.
     sz = ((sz - 1) >> (bits::BITS - 1)) + sz;
-    return get_scoped_allocator()->alloc<ZeroMem::YesZero>(sz);
+    return get_scoped_allocator()->alloc<Zero>(sz);
   }
 
   void __je_bootstrap_free(void* ptr)

--- a/src/snmalloc/override/rust.cc
+++ b/src/snmalloc/override/rust.cc
@@ -24,7 +24,7 @@ SNMALLOC_NAME_MANGLE(rust_alloc)(size_t alignment, size_t size)
 extern "C" SNMALLOC_EXPORT void*
 SNMALLOC_NAME_MANGLE(rust_alloc_zeroed)(size_t alignment, size_t size)
 {
-  return alloc<YesZero>(aligned_size(alignment, size));
+  return alloc<Zero>(aligned_size(alignment, size));
 }
 
 extern "C" SNMALLOC_EXPORT void

--- a/src/snmalloc/pal/pal_windows.h
+++ b/src/snmalloc/pal/pal_windows.h
@@ -592,8 +592,6 @@ namespace snmalloc
 
     void* ret = VirtualAlloc2FromApp(
       nullptr, nullptr, size, flags, PAGE_READWRITE, &param, 1);
-    if (ret == nullptr)
-      errno = ENOMEM;
 
     reservations.push_back(ret);
 
@@ -604,8 +602,6 @@ namespace snmalloc
   void* PALWindows::reserve(size_t size) noexcept
   {
     void* ret = VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_READWRITE);
-    if (ret == nullptr)
-      errno = ENOMEM;
 
     reservations.push_back(ret);
 

--- a/src/test/func/cheri/cheri.cc
+++ b/src/test/func/cheri/cheri.cc
@@ -91,7 +91,7 @@ int main()
   {
     static const size_t sz = 1024 * 1024;
     errno = 0;
-    void* olarge = alloc->alloc<YesZero>(sz);
+    void* olarge = alloc->alloc<Zero>(sz);
     int err = errno;
 
     SNMALLOC_CHECK(alarge == address_cast(olarge));

--- a/src/test/func/first_operation/first_operation.cc
+++ b/src/test/func/first_operation/first_operation.cc
@@ -47,14 +47,14 @@ void check_calloc(void* p, size_t size)
 
 void calloc1(size_t size)
 {
-  void* r = snmalloc::alloc<snmalloc::ZeroMem::YesZero>(size);
+  void* r = snmalloc::alloc<snmalloc::Zero>(size);
   check_calloc(r, size);
   snmalloc::dealloc(r);
 }
 
 void calloc2(size_t size)
 {
-  void* r = snmalloc::alloc<snmalloc::ZeroMem::YesZero>(size);
+  void* r = snmalloc::alloc<snmalloc::Zero>(size);
   check_calloc(r, size);
   snmalloc::dealloc(r, size);
 }

--- a/src/test/func/jemalloc/jemalloc.cc
+++ b/src/test/func/jemalloc/jemalloc.cc
@@ -173,10 +173,12 @@ namespace
         size * 2);
       EXPECT(
         ptr[size] == 0,
-        "Memory not zero initialised for {} byte reallocation from {} "
+        "Memory not zero initialised for {} byte reallocation from {} with "
+        "align {}"
         "byte allocation",
         size * 2,
-        size);
+        size,
+        align);
       // The second time we run this test, we if we're allocating from a free
       // list then we will reuse this, so make sure it requires explicit
       // zeroing.

--- a/src/test/func/memory/memory.cc
+++ b/src/test/func/memory/memory.cc
@@ -178,7 +178,7 @@ void test_calloc()
     memset(p, 0xFF, size);
     snmalloc::dealloc(p, size);
 
-    p = snmalloc::alloc<YesZero>(size);
+    p = snmalloc::alloc<Zero>(size);
 
     for (size_t i = 0; i < size; i++)
     {
@@ -417,7 +417,7 @@ void test_calloc_16M()
   // sizes >= 16M use large_alloc
   const size_t size = 16'000'000;
 
-  void* p1 = snmalloc::alloc<YesZero>(size);
+  void* p1 = snmalloc::alloc<Zero>(size);
   SNMALLOC_CHECK(snmalloc::alloc_size(snmalloc::external_pointer(p1)) >= size);
   snmalloc::dealloc(p1);
 }
@@ -430,7 +430,7 @@ void test_calloc_large_bug()
   // not a multiple of page size.
   const size_t size = (MAX_SMALL_SIZECLASS_SIZE << 3) - 7;
 
-  void* p1 = snmalloc::alloc<YesZero>(size);
+  void* p1 = snmalloc::alloc<Zero>(size);
   SNMALLOC_CHECK(snmalloc::alloc_size(snmalloc::external_pointer(p1)) >= size);
   snmalloc::dealloc(p1);
 }

--- a/src/test/func/teardown/teardown.cc
+++ b/src/test/func/teardown/teardown.cc
@@ -59,7 +59,7 @@ void check_calloc(void* p, size_t size)
 void calloc1(size_t size)
 {
   trigger_teardown();
-  void* r = snmalloc::alloc<snmalloc::ZeroMem::YesZero>(size);
+  void* r = snmalloc::alloc<snmalloc::Zero>(size);
   check_calloc(r, size);
   snmalloc::dealloc(r);
 }
@@ -67,7 +67,7 @@ void calloc1(size_t size)
 void calloc2(size_t size)
 {
   trigger_teardown();
-  void* r = snmalloc::alloc<snmalloc::ZeroMem::YesZero>(size);
+  void* r = snmalloc::alloc<snmalloc::Zero>(size);
   check_calloc(r, size);
   snmalloc::dealloc(r, size);
 }

--- a/src/test/perf/singlethread/singlethread.cc
+++ b/src/test/perf/singlethread/singlethread.cc
@@ -5,20 +5,21 @@
 
 using namespace snmalloc;
 
-template<ZeroMem zero_mem>
+template<typename Conts>
 void test_alloc_dealloc(size_t count, size_t size, bool write)
 {
   {
     MeasureTime m;
     m << "Count: " << std::setw(6) << count << ", Size: " << std::setw(6)
-      << size << ", ZeroMem: " << (zero_mem == YesZero) << ", Write: " << write;
+      << size
+      << ", ZeroMem: " << std::is_same_v<Conts, Zero> << ", Write: " << write;
 
     std::unordered_set<void*> set;
 
     // alloc 1.5x objects
     for (size_t i = 0; i < ((count * 3) / 2); i++)
     {
-      void* p = snmalloc::alloc<zero_mem>(size);
+      void* p = snmalloc::alloc<Conts>(size);
       SNMALLOC_CHECK(set.find(p) == set.end());
 
       if (write)
@@ -40,7 +41,7 @@ void test_alloc_dealloc(size_t count, size_t size, bool write)
     // alloc 1x objects
     for (size_t i = 0; i < count; i++)
     {
-      void* p = snmalloc::alloc<zero_mem>(size);
+      void* p = snmalloc::alloc<Conts>(size);
       SNMALLOC_CHECK(set.find(p) == set.end());
 
       if (write)
@@ -67,18 +68,18 @@ int main(int, char**)
 
   for (size_t size = 16; size <= 128; size <<= 1)
   {
-    test_alloc_dealloc<NoZero>(1 << 15, size, false);
-    test_alloc_dealloc<NoZero>(1 << 15, size, true);
-    test_alloc_dealloc<YesZero>(1 << 15, size, false);
-    test_alloc_dealloc<YesZero>(1 << 15, size, true);
+    test_alloc_dealloc<Uninit>(1 << 15, size, false);
+    test_alloc_dealloc<Uninit>(1 << 15, size, true);
+    test_alloc_dealloc<Zero>(1 << 15, size, false);
+    test_alloc_dealloc<Zero>(1 << 15, size, true);
   }
 
   for (size_t size = 1 << 12; size <= 1 << 17; size <<= 1)
   {
-    test_alloc_dealloc<NoZero>(1 << 10, size, false);
-    test_alloc_dealloc<NoZero>(1 << 10, size, true);
-    test_alloc_dealloc<YesZero>(1 << 10, size, false);
-    test_alloc_dealloc<YesZero>(1 << 10, size, true);
+    test_alloc_dealloc<Uninit>(1 << 10, size, false);
+    test_alloc_dealloc<Uninit>(1 << 10, size, true);
+    test_alloc_dealloc<Zero>(1 << 10, size, false);
+    test_alloc_dealloc<Zero>(1 << 10, size, true);
   }
 
   return 0;


### PR DESCRIPTION
This PR provides a templated parameter to the allocation routines. This can be used to add special behaviour in both the successful allocation behaviour, and in the failing to allocate cases.

The intent of this is to enable two future features
* set_new_handler - so that the failure case doesn't just set ENOMEM, and return nullptr.  But can handle both the Windows and C++ versions of (_)set_new_handler.
* The success handler can be used to add checking, zeroing and in the future storing precise size information in metadata for each allocation.