### PR TITLE
Update minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.21)
 project(snmalloc CXX)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
The use of CACHE in the SNMALLOC_STATIC_LIBRARY_PREFIX was not correctly handled by cmake before 3.21.

> The “set(CACHE)” command no longer removes a normal variable of the
same name, if any. See policy “CMP0126”.

Changing the minimum version means that containing projects can do:

```CMake
set(SNMALLOC_STATIC_LIBRARY_PREFIX "my_prefix")
```

Without this, there were weird behaviours that the first compile used "sn_" and then subsequent compiles used "my_prefix".

Thanks to @achamayou for debugging this in CCF. https://github.com/microsoft/CCF/pull/7161