### PR TITLE
CMAKE: Libs should not require headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,7 +508,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
 
   function(compile name TYPE ${ARGN})
     add_library(${name} ${TYPE} ${ARGN})
-    target_link_libraries(${name} snmalloc)
+    target_link_libraries(${name} PRIVATE snmalloc)
     target_compile_definitions(${name} PRIVATE "SNMALLOC_USE_${SNMALLOC_CLEANUP}")
 
     add_warning_flags(${name})


### PR DESCRIPTION
The API exposed by the various libraries in snmalloc all obey standard C std lib conventions, so no headers are required to consume them. This change updates the CMake configuration to not require headers for the libraries.