### PR TITLE
Removing benchmarking from PR triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,11 +10,13 @@ concurrency:
 on:
   schedule:
     - cron: "0 0 * * 1"  # Runs every Monday at midnight UTC
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push to main or any branch starting bench.
+  # The bench/** branches can be used for test before merge any PR that
+  # might regress performance.
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'bench/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The benchmarking workflow cannot run successfully on the PR as it requires access to secrets which are not available in PR contexts.

This commit removes that trigger and adds a trigger on pushes to branches starting with "bench/" so that testing can be done before merging to main by those with write access.