### PR TITLE
expose c23 free_sized/free_aligned_sized

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,7 +373,10 @@ jobs:
     # Run the clang-format check and error if it generates a diff
     - name: Run clang-format
       working-directory: ${{github.workspace}}/build
-      run: make clangformat-check
+      run: |
+        set -eo pipefail
+        make clangformat
+        git diff --exit-code
     - name: Run clang-tidy
       run: |
         clang-tidy-15  src/snmalloc/override/malloc.cc  -header-filter="`pwd`/*" -warnings-as-errors='*' -export-fixes=tidy.fail -- -std=c++17 -mcx16 -DSNMALLOC_USE_WAIT_ON_ADDRESS=1 -DSNMALLOC_PLATFORM_HAS_GETENTROPY=0 -Isrc

--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -39,6 +39,11 @@ namespace snmalloc::libc
     dealloc(ptr, size);
   }
 
+  SNMALLOC_FAST_PATH_INLINE void free_aligned_sized(void* ptr, size_t alignment, size_t size)
+  {
+    dealloc(ptr, alignment, size);
+  }
+
   SNMALLOC_FAST_PATH_INLINE void* calloc(size_t nmemb, size_t size)
   {
     bool overflow = false;

--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -41,7 +41,7 @@ namespace snmalloc::libc
 
   SNMALLOC_FAST_PATH_INLINE void free_aligned_sized(void* ptr, size_t alignment, size_t size)
   {
-    dealloc(ptr, alignment, size);
+    dealloc(ptr, size, alignment);
   }
 
   SNMALLOC_FAST_PATH_INLINE void* calloc(size_t nmemb, size_t size)

--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -39,7 +39,8 @@ namespace snmalloc::libc
     dealloc(ptr, size);
   }
 
-  SNMALLOC_FAST_PATH_INLINE void free_aligned_sized(void* ptr, size_t alignment, size_t size)
+  SNMALLOC_FAST_PATH_INLINE void free_aligned_sized(
+    void* ptr, size_t alignment, size_t size)
   {
     dealloc(ptr, size, alignment);
   }

--- a/src/snmalloc/global/libc.h
+++ b/src/snmalloc/global/libc.h
@@ -39,8 +39,8 @@ namespace snmalloc::libc
     dealloc(ptr, size);
   }
 
-  SNMALLOC_FAST_PATH_INLINE void free_aligned_sized(
-    void* ptr, size_t alignment, size_t size)
+  SNMALLOC_FAST_PATH_INLINE void
+  free_aligned_sized(void* ptr, size_t alignment, size_t size)
   {
     dealloc(ptr, size, alignment);
   }

--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -23,8 +23,7 @@ extern "C"
     snmalloc::libc::free(ptr);
   }
 
-  SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free_sized)(
-    void* ptr, size_t size)
+  SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free_sized)(void* ptr, size_t size)
   {
     snmalloc::libc::free_sized(ptr, size);
   }

--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -23,6 +23,18 @@ extern "C"
     snmalloc::libc::free(ptr);
   }
 
+  SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free_sized)(
+    void* ptr, size_t size)
+  {
+    snmalloc::libc::free_sized(ptr, size);
+  }
+
+  SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free_aligned_sized)(
+    void* ptr, size_t alignment, size_t size)
+  {
+    snmalloc::libc::free_aligned_sized(ptr, alignment, size);
+  }
+
   SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(cfree)(void* ptr)
   {
     snmalloc::libc::free(ptr);


### PR DESCRIPTION
See https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf `7.24.3.4` and `7.24.3.5` for newly added free functions.

A peculiar requirement is that:
- the result of an malloc, calloc, or realloc call may not be passed to free_aligned_sized
- the result of an aligned_alloc call may not be passed to free_sized

In SCUDO, this is tracked by attaching tag in alloc metadata. not sure if we want to check this or not.