### PR TITLE
Fix shell quoting in coverage-comment workflow

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -119,13 +119,25 @@ jobs:
 
       - name: Resolve PR number
         id: pr
+        env:
+          # Pass the event JSON via the environment rather than
+          # interpolating it directly into the shell script. The
+          # `${{ toJson(...) }}` expansion happens *before* bash
+          # parses the script, so any single quote inside the JSON
+          # (e.g. an apostrophe in a commit message or branch
+          # name) would terminate the surrounding `'...'` quoting
+          # and corrupt the rest of the step — manifesting as a
+          # bewildering syntax error like
+          # "syntax error near unexpected token `else`" several
+          # commands later.
+          EVENT_JSON: ${{ toJson(github.event) }}
         run: |
           set -euo pipefail
           # workflow_run.pull_requests[] is empty for fork PRs and
           # for default-branch schedule/push runs. Empty == no PR
           # to comment on; fall through to the tracking-issue path.
           pr=$(jq -r '.workflow_run.pull_requests[0].number // empty' \
-            <<<'${{ toJson(github.event) }}')
+            <<<"$EVENT_JSON")
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
           if [ -n "$pr" ]; then
             echo "Will comment on PR #$pr"


### PR DESCRIPTION
The "Resolve PR number" step embedded the event JSON via `<<<'${{ toJson(github.event) }}'`. Actions performs the `${{...}}` interpolation *before* bash parses the script, so the single-quoted heredoc string contained the entire raw event payload inline. As soon as the payload contained a single quote — e.g. an apostrophe in a commit message, branch name, or any string field — bash's '...' quoting closed early and the rest of the step's body became malformed, producing the GitHub-Actions error:

  syntax error near unexpected token `else`

(reported against the assembled temp script's line number, not the workflow file's). The first PR opened after the coverage workflow landed happened to have such a quote.

Pass the JSON via an environment variable instead. The shell sees only `"$EVENT_JSON"`, which is safe regardless of what characters the payload contains. Add a comment recording the failure mode so no future maintainer reintroduces the inline-interpolation pattern.