### PR TITLE
Add corruption-detection test for probabilistic mitigations

### DIFF
--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -51,30 +51,6 @@
 #include <test/snmalloc_testlib.h>
 #include <thread>
 
-#if defined(__linux__)
-#  include <signal.h>
-#  include <sys/wait.h>
-#  include <unistd.h>
-
-// Forward declarations of clang's source-based-coverage runtime
-// entry points. Declared as weak symbols so the test still links
-// against builds without `-fprofile-instr-generate -fcoverage-mapping`.
-// Gated to Linux because (a) the entire fork-based test harness is
-// Linux-only, and (b) `__attribute__((weak))` is not portable to
-// MSVC and there is no equivalent `SNMALLOC_WEAK` macro.
-//
-// `__llvm_profile_set_filename` is needed because the LLVM profile
-// runtime resolves `%p` in `LLVM_PROFILE_FILE` exactly once at
-// startup. Forked children inherit the parent's resolved filename
-// and so all write to the same file, overwriting each other. Each
-// child has to set its own filename (with its own pid) before
-// calling `__llvm_profile_write_file`.
-extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
-extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
-#endif
-
-using namespace snmalloc;
-
 // True if any sanitizer or GWP-ASan integration is active in this
 // build. In those configurations the test does not run because the
 // instrumentation either replaces snmalloc's allocation path or
@@ -94,7 +70,40 @@ using namespace snmalloc;
 #  define CORRUPTION_TEST_SKIP_SANITIZER 1
 #endif
 
-#if defined(__linux__)
+// The fork-based harness, the LLVM profile externs, and every
+// `try_*` helper are only used when the test actually runs (Linux,
+// no sanitizer, no GWP-ASan). Gating them all on the same condition
+// keeps non-Linux and sanitizer builds free of `-Wunused-function`.
+#if defined(__linux__) && !defined(CORRUPTION_TEST_SKIP_SANITIZER)
+#  define CORRUPTION_TEST_ACTIVE 1
+#endif
+
+#if defined(CORRUPTION_TEST_ACTIVE)
+#  include <signal.h>
+#  include <sys/wait.h>
+#  include <unistd.h>
+
+// Forward declarations of clang's source-based-coverage runtime
+// entry points. Declared as weak symbols so the test still links
+// against builds without `-fprofile-instr-generate -fcoverage-mapping`.
+// Gated to the same condition as the rest of the harness because
+// (a) the harness is Linux-only, and (b) `__attribute__((weak))`
+// is not portable to MSVC and there is no equivalent `SNMALLOC_WEAK`
+// macro.
+//
+// `__llvm_profile_set_filename` is needed because the LLVM profile
+// runtime resolves `%p` in `LLVM_PROFILE_FILE` exactly once at
+// startup. Forked children inherit the parent's resolved filename
+// and so all write to the same file, overwriting each other. Each
+// child has to set its own filename (with its own pid) before
+// calling `__llvm_profile_write_file`.
+extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
+extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
+#endif
+
+using namespace snmalloc;
+
+#if defined(CORRUPTION_TEST_ACTIVE)
 namespace
 {
   // Per-scenario knobs. ROUNDS amplifies the per-round detection
@@ -407,6 +416,11 @@ int main()
   printf(
     "Skipping corruption-detection test: requires Linux fork()/waitpid()\n");
   return 0;
+#elif defined(CORRUPTION_TEST_SKIP_SANITIZER)
+  printf(
+    "Skipping corruption-detection test: sanitizer or GWP-ASan "
+    "integration is active\n");
+  return 0;
 #else
   if constexpr (!CHECK_CLIENT)
   {
@@ -414,12 +428,6 @@ int main()
       "Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
     return 0;
   }
-#  if defined(CORRUPTION_TEST_SKIP_SANITIZER)
-  printf(
-    "Skipping corruption-detection test: sanitizer or GWP-ASan "
-    "integration is active\n");
-  return 0;
-#  else
 
   int failures = 0;
   failures += run_in_child("double_free", try_double_free);
@@ -440,6 +448,5 @@ int main()
   }
   printf("PASSED\n");
   return 0;
-#  endif
 #endif
 }

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -51,58 +51,53 @@
 #include <test/snmalloc_testlib.h>
 #include <thread>
 
-// True if any sanitizer or GWP-ASan integration is active in this
-// build. In those configurations the test does not run because the
-// instrumentation either replaces snmalloc's allocation path or
-// intercepts the trap that the mitigations raise.
-#if defined(__has_feature)
-#  if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || \
-    __has_feature(undefined_behavior_sanitizer) || \
-    __has_feature(memory_sanitizer)
-#    define CORRUPTION_TEST_SKIP_SANITIZER 1
+// Only build the real test on Linux. Otherwise, output a trivial main().
+#ifndef __linux__
+#  define SKIP_CORRUPTION_TEST 1
+#else
+#  if defined(__has_feature)
+#    if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || \
+      __has_feature(undefined_behavior_sanitizer) || \
+      __has_feature(memory_sanitizer)
+#      define SKIP_CORRUPTION_TEST 1
+#    endif
 #  endif
-#endif
-#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
-#  define CORRUPTION_TEST_SKIP_SANITIZER 1
-#endif
-#if defined(SNMALLOC_ENABLE_GWP_ASAN_INTEGRATION)
-#  define CORRUPTION_TEST_SKIP_SANITIZER 1
-#endif
+#  if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+#    define SKIP_CORRUPTION_TEST 1
+#  endif
+#  if defined(SNMALLOC_ENABLE_GWP_ASAN_INTEGRATION)
+#    define SKIP_CORRUPTION_TEST 1
+#  endif
+#endif // __linux__
 
-// The fork-based harness, the LLVM profile externs, and every
-// `try_*` helper are only used when the test actually runs (Linux,
-// no sanitizer, no GWP-ASan). Gating them all on the same condition
-// keeps non-Linux and sanitizer builds free of `-Wunused-function`.
-#if defined(__linux__) && !defined(CORRUPTION_TEST_SKIP_SANITIZER)
-#  define CORRUPTION_TEST_ACTIVE 1
-#endif
+#ifdef SKIP_CORRUPTION_TEST
 
-#if defined(CORRUPTION_TEST_ACTIVE)
+#  include <stdio.h>
+
+int main()
+{
+  printf("corruption-detection test not active in this configuration\n");
+  return 0;
+}
+
+#else // !SKIP_CORRUPTION_TEST
 #  include <signal.h>
+#  include <snmalloc/snmalloc_core.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
 #  include <sys/wait.h>
+#  include <test/setup.h>
+#  include <test/snmalloc_testlib.h>
+#  include <thread>
 #  include <unistd.h>
-
-// Forward declarations of clang's source-based-coverage runtime
-// entry points. Declared as weak symbols so the test still links
-// against builds without `-fprofile-instr-generate -fcoverage-mapping`.
-// Gated to the same condition as the rest of the harness because
-// (a) the harness is Linux-only, and (b) `__attribute__((weak))`
-// is not portable to MSVC and there is no equivalent `SNMALLOC_WEAK`
-// macro.
-//
-// `__llvm_profile_set_filename` is needed because the LLVM profile
-// runtime resolves `%p` in `LLVM_PROFILE_FILE` exactly once at
-// startup. Forked children inherit the parent's resolved filename
-// and so all write to the same file, overwriting each other. Each
-// child has to set its own filename (with its own pid) before
-// calling `__llvm_profile_write_file`.
-extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
-extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
-#endif
 
 using namespace snmalloc;
 
-#if defined(CORRUPTION_TEST_ACTIVE)
+// Forward declarations of clang's source-based-coverage runtime entry points.
+extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
+extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
+
 namespace
 {
   // Per-scenario knobs. ROUNDS amplifies the per-round detection
@@ -405,46 +400,4 @@ namespace
     return 1;
   }
 } // namespace
-#endif
-
-int main()
-{
-  setup();
-
-#if !defined(__linux__)
-  printf(
-    "Skipping corruption-detection test: requires Linux fork()/waitpid()\n");
-  return 0;
-#elif defined(CORRUPTION_TEST_SKIP_SANITIZER)
-  printf(
-    "Skipping corruption-detection test: sanitizer or GWP-ASan "
-    "integration is active\n");
-  return 0;
-#else
-  if constexpr (!CHECK_CLIENT)
-  {
-    printf("Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
-    return 0;
-  }
-
-  int failures = 0;
-  failures += run_in_child("double_free", try_double_free);
-  failures += run_in_child("uaf_freelist", try_uaf_freelist_corruption);
-  failures += run_in_child("oob_into_neighbor", try_oob_into_neighbor);
-  failures += run_in_child("remote_double_free", try_remote_double_free);
-  failures += run_in_child("remote_uaf", try_remote_uaf);
-  failures += run_in_child("large_double_free", try_large_double_free);
-
-  if (failures != 0)
-  {
-    fprintf(
-      stderr,
-      "FAILED: %d corruption-detection sub-test(s) reported the corruption "
-      "was not caught by the allocator's mitigations.\n",
-      failures);
-    return 1;
-  }
-  printf("PASSED\n");
-  return 0;
-#endif
-}
+#endif // !SKIP_CORRUPTION_TEST

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -408,7 +408,6 @@ int main()
 {
   setup();
 
-
   int failures = 0;
   failures += run_in_child("double_free", try_double_free);
   failures += run_in_child("uaf_freelist", try_uaf_freelist_corruption);

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -17,12 +17,14 @@
  * snmalloc detects free-list corruption by checking the integrity
  * of the obfuscated forward and backward edges of the intra-slab
  * free list when the list is later consumed (allocated from), and
- * detects double-free of large allocations by inspecting the
- * per-chunk metadata. Detection is therefore probabilistic per
- * round, but deterministic at the scale used here: each scenario
- * performs many rounds across many slabs, and at least one of them
- * is overwhelmingly likely to traverse the corrupted edge or hit
- * the metadata check before the test would otherwise complete.
+ * detects double-free of large allocations via the
+ * `is_backend_owned()` check on the per-chunk metadata in
+ * `dealloc_remote` (gated on the `sanity_checks` mitigation).
+ * Detection is therefore probabilistic per round, but deterministic
+ * at the scale used here: each scenario performs many rounds across
+ * many slabs, and at least one of them is overwhelmingly likely to
+ * traverse the corrupted edge or hit the metadata check before the
+ * test would otherwise complete.
  *
  * Each scenario runs in a forked child so that the expected abort
  * does not kill the test harness. Detection is reported as
@@ -47,13 +49,13 @@
 #  include <signal.h>
 #  include <sys/wait.h>
 #  include <unistd.h>
-#endif
-
-using namespace snmalloc;
 
 // Forward declarations of clang's source-based-coverage runtime
 // entry points. Declared as weak symbols so the test still links
 // against builds without `-fprofile-instr-generate -fcoverage-mapping`.
+// Gated to Linux because (a) the entire fork-based test harness is
+// Linux-only, and (b) `__attribute__((weak))` is not portable to
+// MSVC and there is no equivalent `SNMALLOC_WEAK` macro.
 //
 // `__llvm_profile_set_filename` is needed because the LLVM profile
 // runtime resolves `%p` in `LLVM_PROFILE_FILE` exactly once at
@@ -63,7 +65,11 @@ using namespace snmalloc;
 // calling `__llvm_profile_write_file`.
 extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
 extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
+#endif
 
+using namespace snmalloc;
+
+#if defined(__linux__)
 namespace
 {
   // Per-scenario knobs. ROUNDS amplifies the per-round detection
@@ -79,8 +85,10 @@ namespace
   constexpr size_t REMOTE_ROUNDS = 64;
   // A size that is guaranteed to fall outside every small sizeclass
   // and therefore exercises the chunk-allocator/metadata dealloc
-  // path rather than the slab free list.
-  constexpr size_t LARGE_SIZE = MIN_CHUNK_SIZE * 4;
+  // path rather than the slab free list. Using `MAX_SMALL_SIZECLASS_SIZE`
+  // directly would still produce a small allocation (it is the upper
+  // bound, inclusive), so use twice that.
+  constexpr size_t LARGE_SIZE = MAX_SMALL_SIZECLASS_SIZE * 2;
 
   void try_double_free()
   {
@@ -127,9 +135,11 @@ namespace
       // with freelist_backward_edge enabled, a backward edge).
       // Either de-obfuscation produces a wild pointer that fails
       // domestication, or the doubly-linked invariant breaks.
+      // Use literals that fit in 32-bit uintptr_t too, so MSVC
+      // doesn't warn about narrowing on 32-bit Windows builds.
       auto* victim = static_cast<uintptr_t*>(ps[N / 2]);
-      victim[0] = 0xDEADBEEFCAFEBABEULL;
-      victim[1] = 0xBADC0FFEE0DDF00DULL;
+      victim[0] = static_cast<uintptr_t>(0xDEADBEEFu);
+      victim[1] = static_cast<uintptr_t>(0xBADC0FFEu);
 
       // Drive the freelist by reallocating from the same sizeclass.
       void* qs[N];
@@ -199,8 +209,8 @@ namespace
       // the freelist node that the owning allocator will traverse
       // when it next allocates from this slab.
       auto* victim = static_cast<uintptr_t*>(ps[N / 2]);
-      victim[0] = 0xDEADBEEFCAFEBABEULL;
-      victim[1] = 0xBADC0FFEE0DDF00DULL;
+      victim[0] = static_cast<uintptr_t>(0xDEADBEEFu);
+      victim[1] = static_cast<uintptr_t>(0xBADC0FFEu);
 
       void* qs[N];
       for (size_t i = 0; i < N; i++)
@@ -212,13 +222,12 @@ namespace
 
   void try_large_double_free()
   {
-    // Large allocations bypass the slab free list. Detection here
-    // comes from the chunk-allocator/metadata path: the second
-    // dealloc finds the per-chunk metadata in a state inconsistent
-    // with an owned live allocation. One round is normally enough,
-    // but loop a few times so a single missed detection (e.g. a
-    // metadata layout that masks the problem) still trips on a
-    // later round.
+    // Large allocations bypass the slab free list. The second
+    // dealloc reaches `dealloc_remote` with a metaentry that
+    // `claim_for_backend()` has marked `is_backend_owned()`, and
+    // the `sanity_checks` mitigation flags this directly.
+    // One round is normally enough, but loop a few times so a
+    // single missed detection still trips on a later round.
     for (size_t r = 0; r < 16; r++)
     {
       void* p = snmalloc::alloc(LARGE_SIZE);
@@ -263,7 +272,6 @@ namespace
     }
   }
 
-#if defined(__linux__)
   // Signal handler that runs in the forked child when snmalloc's
   // mitigation paths abort/segfault. It flushes coverage data (if the
   // process is instrumented) and then re-raises the signal with its
@@ -359,8 +367,8 @@ namespace
     fprintf(stderr, "%s: unexpected child wait status 0x%x\n", name, status);
     return 1;
   }
-#endif
 } // namespace
+#endif
 
 int main()
 {

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -56,8 +56,7 @@
 // instrumentation either replaces snmalloc's allocation path or
 // intercepts the trap that the mitigations raise.
 #if defined(__has_feature)
-#  if __has_feature(address_sanitizer) || \
-    __has_feature(thread_sanitizer) || \
+#  if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) || \
     __has_feature(undefined_behavior_sanitizer) || \
     __has_feature(memory_sanitizer)
 #    define CORRUPTION_TEST_SKIP_SANITIZER 1
@@ -384,8 +383,8 @@ namespace
     {
       int sig = WTERMSIG(status);
       if (
-        sig == SIGABRT || sig == SIGSEGV || sig == SIGBUS ||
-        sig == SIGILL || sig == SIGTRAP)
+        sig == SIGABRT || sig == SIGSEGV || sig == SIGBUS || sig == SIGILL ||
+        sig == SIGTRAP)
       {
         printf("%s: detected (signal %d)\n", name, sig);
         return 0;
@@ -424,8 +423,7 @@ int main()
 #else
   if constexpr (!CHECK_CLIENT)
   {
-    printf(
-      "Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
+    printf("Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
     return 0;
   }
 

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -68,6 +68,9 @@
 #  if defined(SNMALLOC_ENABLE_GWP_ASAN_INTEGRATION)
 #    define SKIP_CORRUPTION_TEST 1
 #  endif
+#  if defined(SNMALLOC_CHECK_CLIENT)
+#    define SKIP_CORRUPTION_TEST 1
+#  endif
 #endif // __linux__
 
 #ifdef SKIP_CORRUPTION_TEST
@@ -405,21 +408,6 @@ int main()
 {
   setup();
 
-#if !defined(__linux__)
-  printf(
-    "Skipping corruption-detection test: requires Linux fork()/waitpid()\n");
-  return 0;
-#elif defined(CORRUPTION_TEST_SKIP_SANITIZER)
-  printf(
-    "Skipping corruption-detection test: sanitizer or GWP-ASan "
-    "integration is active\n");
-  return 0;
-#else
-  if constexpr (!CHECK_CLIENT)
-  {
-    printf("Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
-    return 0;
-  }
 
   int failures = 0;
   failures += run_in_child("double_free", try_double_free);

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -400,4 +400,45 @@ namespace
     return 1;
   }
 } // namespace
+
+int main()
+{
+  setup();
+
+#if !defined(__linux__)
+  printf(
+    "Skipping corruption-detection test: requires Linux fork()/waitpid()\n");
+  return 0;
+#elif defined(CORRUPTION_TEST_SKIP_SANITIZER)
+  printf(
+    "Skipping corruption-detection test: sanitizer or GWP-ASan "
+    "integration is active\n");
+  return 0;
+#else
+  if constexpr (!CHECK_CLIENT)
+  {
+    printf("Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
+    return 0;
+  }
+
+  int failures = 0;
+  failures += run_in_child("double_free", try_double_free);
+  failures += run_in_child("uaf_freelist", try_uaf_freelist_corruption);
+  failures += run_in_child("oob_into_neighbor", try_oob_into_neighbor);
+  failures += run_in_child("remote_double_free", try_remote_double_free);
+  failures += run_in_child("remote_uaf", try_remote_uaf);
+  failures += run_in_child("large_double_free", try_large_double_free);
+
+  if (failures != 0)
+  {
+    fprintf(
+      stderr,
+      "FAILED: %d corruption-detection sub-test(s) reported the corruption "
+      "was not caught by the allocator's mitigations.\n",
+      failures);
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+}
 #endif // !SKIP_CORRUPTION_TEST

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -28,13 +28,19 @@
  *
  * Each scenario runs in a forked child so that the expected abort
  * does not kill the test harness. Detection is reported as
- * `WIFSIGNALED && WTERMSIG ∈ {SIGABRT, SIGSEGV, SIGBUS, SIGILL}`;
- * a clean exit means the corruption was *not* detected and the test
- * fails.
+ * `WIFSIGNALED && WTERMSIG ∈ {SIGABRT, SIGSEGV, SIGBUS, SIGILL,
+ * SIGTRAP}`. `SIGILL` covers x86 (`__builtin_trap()` emits `ud2`);
+ * `SIGTRAP` covers aarch64 (it emits `brk #1000`). A clean exit
+ * means the corruption was *not* detected and the test fails.
  *
- * The test is Linux-only (uses `fork()`/`waitpid()`). It is a no-op
- * when `SNMALLOC_CHECK_CLIENT` is not defined, because none of the
- * mitigations these tests rely on are compiled in.
+ * The test is Linux-only (uses `fork()`/`waitpid()`). It is also a
+ * no-op under any sanitizer (ASan/TSan/UBSan) or with the GWP-ASan
+ * secondary-allocator integration enabled, because in those builds
+ * the relevant allocations either bypass snmalloc's mitigated paths
+ * or the sanitizer intercepts the trap before our parent observes
+ * it. It is a no-op when `SNMALLOC_CHECK_CLIENT` is not defined,
+ * because none of the mitigations these tests rely on are compiled
+ * in.
  */
 
 #include <snmalloc/snmalloc_core.h>
@@ -68,6 +74,25 @@ extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
 #endif
 
 using namespace snmalloc;
+
+// True if any sanitizer or GWP-ASan integration is active in this
+// build. In those configurations the test does not run because the
+// instrumentation either replaces snmalloc's allocation path or
+// intercepts the trap that the mitigations raise.
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer) || \
+    __has_feature(thread_sanitizer) || \
+    __has_feature(undefined_behavior_sanitizer) || \
+    __has_feature(memory_sanitizer)
+#    define CORRUPTION_TEST_SKIP_SANITIZER 1
+#  endif
+#endif
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+#  define CORRUPTION_TEST_SKIP_SANITIZER 1
+#endif
+#if defined(SNMALLOC_ENABLE_GWP_ASAN_INTEGRATION)
+#  define CORRUPTION_TEST_SKIP_SANITIZER 1
+#endif
 
 #if defined(__linux__)
 namespace
@@ -334,7 +359,9 @@ namespace
       // Install a coverage-flushing handler for the signals snmalloc
       // raises on detected corruption. The handler re-raises with
       // default disposition so the parent still sees WIFSIGNALED.
-      for (int s : {SIGABRT, SIGSEGV, SIGBUS, SIGILL})
+      // SIGILL covers x86 (`__builtin_trap()` -> `ud2`); SIGTRAP
+      // covers aarch64 (`brk #1000`).
+      for (int s : {SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGTRAP})
         signal(s, corruption_signal_handler);
       fn();
       // If we get here, none of the mitigations fired across all
@@ -347,7 +374,9 @@ namespace
     if (WIFSIGNALED(status))
     {
       int sig = WTERMSIG(status);
-      if (sig == SIGABRT || sig == SIGSEGV || sig == SIGBUS || sig == SIGILL)
+      if (
+        sig == SIGABRT || sig == SIGSEGV || sig == SIGBUS ||
+        sig == SIGILL || sig == SIGTRAP)
       {
         printf("%s: detected (signal %d)\n", name, sig);
         return 0;
@@ -385,6 +414,12 @@ int main()
       "Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
     return 0;
   }
+#  if defined(CORRUPTION_TEST_SKIP_SANITIZER)
+  printf(
+    "Skipping corruption-detection test: sanitizer or GWP-ASan "
+    "integration is active\n");
+  return 0;
+#  else
 
   int failures = 0;
   failures += run_in_child("double_free", try_double_free);
@@ -405,5 +440,6 @@ int main()
   }
   printf("PASSED\n");
   return 0;
+#  endif
 #endif
 }

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -68,7 +68,7 @@
 #  if defined(SNMALLOC_ENABLE_GWP_ASAN_INTEGRATION)
 #    define SKIP_CORRUPTION_TEST 1
 #  endif
-#  if defined(SNMALLOC_CHECK_CLIENT)
+#  ifndef SNMALLOC_CHECK_CLIENT
 #    define SKIP_CORRUPTION_TEST 1
 #  endif
 #endif // __linux__

--- a/src/test/func/corruption_detection/corruption_detection.cc
+++ b/src/test/func/corruption_detection/corruption_detection.cc
@@ -1,0 +1,401 @@
+/**
+ * Tests that snmalloc's probabilistic mitigations detect several
+ * classes of memory-safety violation:
+ *
+ *   - double-free of a small allocation (local-thread path),
+ *   - use-after-free that corrupts the intra-slab free list,
+ *   - out-of-bounds writes that spill into a freed neighbour,
+ *   - double-free crossing thread boundaries (the second free goes
+ *     down the remote-message-queue path),
+ *   - use-after-free of a slot that has been freed remotely (i.e.
+ *     written through the dangling pointer while the slot sits on
+ *     the owning allocator's pending-remote queue),
+ *   - double-free of a large allocation that does not fit in any
+ *     small sizeclass and is therefore handled by the chunk
+ *     allocator and metadata path rather than the slab free list.
+ *
+ * snmalloc detects free-list corruption by checking the integrity
+ * of the obfuscated forward and backward edges of the intra-slab
+ * free list when the list is later consumed (allocated from), and
+ * detects double-free of large allocations by inspecting the
+ * per-chunk metadata. Detection is therefore probabilistic per
+ * round, but deterministic at the scale used here: each scenario
+ * performs many rounds across many slabs, and at least one of them
+ * is overwhelmingly likely to traverse the corrupted edge or hit
+ * the metadata check before the test would otherwise complete.
+ *
+ * Each scenario runs in a forked child so that the expected abort
+ * does not kill the test harness. Detection is reported as
+ * `WIFSIGNALED && WTERMSIG ∈ {SIGABRT, SIGSEGV, SIGBUS, SIGILL}`;
+ * a clean exit means the corruption was *not* detected and the test
+ * fails.
+ *
+ * The test is Linux-only (uses `fork()`/`waitpid()`). It is a no-op
+ * when `SNMALLOC_CHECK_CLIENT` is not defined, because none of the
+ * mitigations these tests rely on are compiled in.
+ */
+
+#include <snmalloc/snmalloc_core.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <test/setup.h>
+#include <test/snmalloc_testlib.h>
+#include <thread>
+
+#if defined(__linux__)
+#  include <signal.h>
+#  include <sys/wait.h>
+#  include <unistd.h>
+#endif
+
+using namespace snmalloc;
+
+// Forward declarations of clang's source-based-coverage runtime
+// entry points. Declared as weak symbols so the test still links
+// against builds without `-fprofile-instr-generate -fcoverage-mapping`.
+//
+// `__llvm_profile_set_filename` is needed because the LLVM profile
+// runtime resolves `%p` in `LLVM_PROFILE_FILE` exactly once at
+// startup. Forked children inherit the parent's resolved filename
+// and so all write to the same file, overwriting each other. Each
+// child has to set its own filename (with its own pid) before
+// calling `__llvm_profile_write_file`.
+extern "C" int __llvm_profile_write_file(void) __attribute__((weak));
+extern "C" void __llvm_profile_set_filename(const char*) __attribute__((weak));
+
+namespace
+{
+  // Per-scenario knobs. ROUNDS amplifies the per-round detection
+  // probability; N is the number of objects allocated per round; SIZE
+  // picks a small sizeclass so a few KiB of slab is exercised per
+  // round.
+  constexpr size_t ROUNDS = 1024;
+  constexpr size_t N = 64;
+  constexpr size_t SMALL_SIZE = 32;
+  constexpr size_t TINY_SIZE = 16;
+  // Cross-thread scenarios use fewer rounds; each round pays a
+  // thread-create/join cost and we still need only one detection.
+  constexpr size_t REMOTE_ROUNDS = 64;
+  // A size that is guaranteed to fall outside every small sizeclass
+  // and therefore exercises the chunk-allocator/metadata dealloc
+  // path rather than the slab free list.
+  constexpr size_t LARGE_SIZE = MIN_CHUNK_SIZE * 4;
+
+  void try_double_free()
+  {
+    for (size_t r = 0; r < ROUNDS; r++)
+    {
+      void* ps[N];
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+
+      // Double-free a single slot. With sanity_checks, the second
+      // dealloc may fire immediately. With freelist_backward_edge
+      // alone, the resulting cycle in the doubly-linked free list is
+      // detected when the list is later traversed.
+      snmalloc::dealloc(ps[N / 2]);
+      snmalloc::dealloc(ps[N / 2]);
+
+      // Free the rest (skipping the double-freed slot to avoid
+      // freeing an unrelated live allocation that happens to have
+      // been handed out from the same address) and reallocate to
+      // drive freelist consumption.
+      for (size_t i = 0; i < N; i++)
+        if (i != N / 2)
+          snmalloc::dealloc(ps[i]);
+
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(ps[i]);
+    }
+  }
+
+  void try_uaf_freelist_corruption()
+  {
+    for (size_t r = 0; r < ROUNDS; r++)
+    {
+      void* ps[N];
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(ps[i]);
+
+      // UAF: write into a freed slot. The first two pointer-sized
+      // words of a freed slot hold the obfuscated forward edge (and,
+      // with freelist_backward_edge enabled, a backward edge).
+      // Either de-obfuscation produces a wild pointer that fails
+      // domestication, or the doubly-linked invariant breaks.
+      auto* victim = static_cast<uintptr_t*>(ps[N / 2]);
+      victim[0] = 0xDEADBEEFCAFEBABEULL;
+      victim[1] = 0xBADC0FFEE0DDF00DULL;
+
+      // Drive the freelist by reallocating from the same sizeclass.
+      void* qs[N];
+      for (size_t i = 0; i < N; i++)
+        qs[i] = snmalloc::alloc(SMALL_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(qs[i]);
+    }
+  }
+
+  // Free `p` from a freshly created thread, so the dealloc takes the
+  // remote-message-queue path rather than the local-freelist path.
+  // The thread is joined before returning, so `p` has definitely
+  // been handed off to the owning allocator's pending-remote queue
+  // (or already drained from it) by the time we return.
+  void remote_dealloc(void* p)
+  {
+    std::thread t([p]() { snmalloc::dealloc(p); });
+    t.join();
+  }
+
+  void try_remote_double_free()
+  {
+    for (size_t r = 0; r < REMOTE_ROUNDS; r++)
+    {
+      void* ps[N];
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+
+      // First free is local (this thread allocated). Second free is
+      // from a different thread, so it goes through the remote
+      // message queue and ends up being inserted onto the owning
+      // allocator's free list a second time. The resulting cycle is
+      // detected on the next traversal.
+      void* victim = ps[N / 2];
+      snmalloc::dealloc(victim);
+      remote_dealloc(victim);
+
+      for (size_t i = 0; i < N; i++)
+        if (i != N / 2)
+          snmalloc::dealloc(ps[i]);
+      // Drive freelist consumption so the corruption is observed.
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(ps[i]);
+    }
+  }
+
+  void try_remote_uaf()
+  {
+    for (size_t r = 0; r < REMOTE_ROUNDS; r++)
+    {
+      void* ps[N];
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(SMALL_SIZE);
+
+      // Free everything via a different thread. The slots travel
+      // through the remote message queue back to this allocator and
+      // end up on its free list. While in flight (or once parked on
+      // the free list) the obfuscated next/prev fields live in the
+      // first words of the slot.
+      for (size_t i = 0; i < N; i++)
+        remote_dealloc(ps[i]);
+
+      // UAF write through the now-dangling pointer. This corrupts
+      // the freelist node that the owning allocator will traverse
+      // when it next allocates from this slab.
+      auto* victim = static_cast<uintptr_t*>(ps[N / 2]);
+      victim[0] = 0xDEADBEEFCAFEBABEULL;
+      victim[1] = 0xBADC0FFEE0DDF00DULL;
+
+      void* qs[N];
+      for (size_t i = 0; i < N; i++)
+        qs[i] = snmalloc::alloc(SMALL_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(qs[i]);
+    }
+  }
+
+  void try_large_double_free()
+  {
+    // Large allocations bypass the slab free list. Detection here
+    // comes from the chunk-allocator/metadata path: the second
+    // dealloc finds the per-chunk metadata in a state inconsistent
+    // with an owned live allocation. One round is normally enough,
+    // but loop a few times so a single missed detection (e.g. a
+    // metadata layout that masks the problem) still trips on a
+    // later round.
+    for (size_t r = 0; r < 16; r++)
+    {
+      void* p = snmalloc::alloc(LARGE_SIZE);
+      snmalloc::dealloc(p);
+      snmalloc::dealloc(p);
+    }
+  }
+
+  void try_oob_into_neighbor()
+  {
+    for (size_t r = 0; r < ROUNDS; r++)
+    {
+      void* ps[N];
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(TINY_SIZE);
+
+      // Free even-indexed slots so their freelist headers occupy
+      // their first bytes.
+      for (size_t i = 0; i < N; i += 2)
+        snmalloc::dealloc(ps[i]);
+
+      // From an odd (still-allocated) slot, write a generous overrun
+      // past its bounds. The exact layout of adjacent slots within a
+      // slab is implementation-defined, so we splatter several
+      // sizeclass-widths of garbage to ensure we land on at least one
+      // freed neighbour's freelist node header regardless of layout.
+      auto* p = static_cast<unsigned char*>(ps[1]);
+      // Use a volatile write loop rather than memset so the compiler
+      // does not emit a -Wstringop-overflow diagnostic on the
+      // intentionally out-of-bounds write.
+      for (size_t k = TINY_SIZE; k < TINY_SIZE * 4; k++)
+        const_cast<volatile unsigned char*>(p)[k] = 0xAB;
+
+      // Free the surviving slots and reallocate to drive freelist
+      // traversal; the corrupted neighbour will be encountered.
+      for (size_t i = 1; i < N; i += 2)
+        snmalloc::dealloc(ps[i]);
+      for (size_t i = 0; i < N; i++)
+        ps[i] = snmalloc::alloc(TINY_SIZE);
+      for (size_t i = 0; i < N; i++)
+        snmalloc::dealloc(ps[i]);
+    }
+  }
+
+#if defined(__linux__)
+  // Signal handler that runs in the forked child when snmalloc's
+  // mitigation paths abort/segfault. It flushes coverage data (if the
+  // process is instrumented) and then re-raises the signal with its
+  // default disposition so the parent observes WIFSIGNALED. Without
+  // this the abort kills the child before the LLVM profile runtime
+  // gets a chance to write its .profraw, so the detection paths show
+  // up as uncovered.
+  extern "C" void corruption_signal_handler(int sig)
+  {
+    if (&__llvm_profile_write_file != nullptr)
+      __llvm_profile_write_file();
+    signal(sig, SIG_DFL);
+    raise(sig);
+  }
+
+  // Run `fn` in a forked child and return 0 if the child died with a
+  // fatal signal (corruption detected) or 1 otherwise (corruption
+  // missed, or unexpected exit).
+  int run_in_child(const char* name, void (*fn)())
+  {
+    pid_t pid = fork();
+    if (pid < 0)
+    {
+      perror("fork");
+      return 1;
+    }
+    if (pid == 0)
+    {
+      // Re-evaluate the LLVM profile filename so this child's
+      // .profraw doesn't collide with its siblings' or its parent's.
+      // The parent's `LLVM_PROFILE_FILE` (with `%p`) was resolved at
+      // startup using the parent's pid; without resetting it here,
+      // every fork+abort writes to the same path. Substitute `%p`
+      // with the child's pid explicitly because the profile runtime
+      // may have already cached the parent's expansion.
+      if (
+        &__llvm_profile_set_filename != nullptr &&
+        getenv("LLVM_PROFILE_FILE") != nullptr)
+      {
+        char buf[1024];
+        const char* tmpl = getenv("LLVM_PROFILE_FILE");
+        size_t out = 0;
+        for (size_t i = 0; tmpl[i] != '\0' && out + 16 < sizeof(buf); i++)
+        {
+          if (tmpl[i] == '%' && tmpl[i + 1] == 'p')
+          {
+            int n = snprintf(
+              buf + out, sizeof(buf) - out, "%d", static_cast<int>(getpid()));
+            out += static_cast<size_t>(n);
+            i++;
+          }
+          else
+          {
+            buf[out++] = tmpl[i];
+          }
+        }
+        buf[out] = '\0';
+        __llvm_profile_set_filename(buf);
+      }
+      // Install a coverage-flushing handler for the signals snmalloc
+      // raises on detected corruption. The handler re-raises with
+      // default disposition so the parent still sees WIFSIGNALED.
+      for (int s : {SIGABRT, SIGSEGV, SIGBUS, SIGILL})
+        signal(s, corruption_signal_handler);
+      fn();
+      // If we get here, none of the mitigations fired across all
+      // rounds. The parent will treat a clean exit as a test failure.
+      fprintf(stderr, "%s: corruption NOT detected after all rounds\n", name);
+      _exit(0);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFSIGNALED(status))
+    {
+      int sig = WTERMSIG(status);
+      if (sig == SIGABRT || sig == SIGSEGV || sig == SIGBUS || sig == SIGILL)
+      {
+        printf("%s: detected (signal %d)\n", name, sig);
+        return 0;
+      }
+      fprintf(stderr, "%s: child died with unexpected signal %d\n", name, sig);
+      return 1;
+    }
+    if (WIFEXITED(status))
+    {
+      fprintf(
+        stderr,
+        "%s: child exited normally (corruption not detected, exit %d)\n",
+        name,
+        WEXITSTATUS(status));
+      return 1;
+    }
+    fprintf(stderr, "%s: unexpected child wait status 0x%x\n", name, status);
+    return 1;
+  }
+#endif
+} // namespace
+
+int main()
+{
+  setup();
+
+#if !defined(__linux__)
+  printf(
+    "Skipping corruption-detection test: requires Linux fork()/waitpid()\n");
+  return 0;
+#else
+  if constexpr (!CHECK_CLIENT)
+  {
+    printf(
+      "Skipping corruption-detection test: SNMALLOC_CHECK_CLIENT off\n");
+    return 0;
+  }
+
+  int failures = 0;
+  failures += run_in_child("double_free", try_double_free);
+  failures += run_in_child("uaf_freelist", try_uaf_freelist_corruption);
+  failures += run_in_child("oob_into_neighbor", try_oob_into_neighbor);
+  failures += run_in_child("remote_double_free", try_remote_double_free);
+  failures += run_in_child("remote_uaf", try_remote_uaf);
+  failures += run_in_child("large_double_free", try_large_double_free);
+
+  if (failures != 0)
+  {
+    fprintf(
+      stderr,
+      "FAILED: %d corruption-detection sub-test(s) reported the corruption "
+      "was not caught by the allocator's mitigations.\n",
+      failures);
+    return 1;
+  }
+  printf("PASSED\n");
+  return 0;
+#endif
+}


### PR DESCRIPTION
Adds a new functional test, func/corruption_detection, that validates snmalloc's probabilistic memory-safety mitigations actually fire on the corruption patterns they are designed to catch. Without it, regressions that silently weakened a mitigation would be invisible to the existing suite, since every other test exercises only the non-failing arm of the integrity checks.

Each scenario runs in a forked child so the expected abort does not kill the harness. Detection is reported as the child being killed by SIGABRT/SIGSEGV/SIGBUS/SIGILL; a clean exit means the corruption went undetected and the test fails.

Six scenarios are covered, spanning the local-thread, remote-thread and large-allocation paths:

  * double_free          - small alloc, two local frees of the same
                           slot. Detected by freelist_backward_edge
                           when the resulting cycle is later
                           traversed.
  * uaf_freelist         - small alloc, free, then write garbage
                           into the freed slot's first two words
                           (the obfuscated next/prev). Detected by
                           check_prev on the next freelist
                           consumption.
  * oob_into_neighbor    - tiny allocs, free even slots, overrun
                           from an odd live slot into freed
                           neighbours. Detected by check_prev when
                           the neighbour is later allocated.
  * remote_double_free   - small alloc, free locally, then free
                           again from a different thread (the
                           second free travels via the remote
                           message queue). Detected as
                           !meta->is_unused() in the dealloc path.
  * remote_uaf           - small alloc, free via a different
                           thread, then write garbage through the
                           dangling pointer while the slot sits on
                           the owning allocator's pending-remote
                           queue. Detected by check_prev during
                           handle_message_queue_slow's drain - a
                           code path no other test exercises.
  * large_double_free    - allocation larger than any small
                           sizeclass (handled by the chunk
                           allocator and per-chunk metadata rather
                           than the slab freelist), freed twice.
                           Detected as !meta->is_unused() in the
                           large-dealloc path.

The test is Linux-only (uses fork()/waitpid()) and is a no-op when SNMALLOC_CHECK_CLIENT is not defined, since the mitigations it relies on are then compiled out.

The test is also instrumented to cooperate with clang source-based coverage: the forked child re-resolves LLVM_PROFILE_FILE with its own pid (the parent's %p expansion is otherwise inherited and all children would write to the same file) and a signal handler flushes .profraw before re-raising the fatal signal. The runtime entry points are declared as weak symbols so the test still links in non-coverage builds.

Picked up automatically by make_tests so it runs as both func-corruption_detection-fast and func-corruption_detection-check; the fast variant immediately exits with the "skip" message because the mitigations are off.