### PR TITLE
Expose memory usage statistics to Rust via SnMalloc::memory_stats()

### DIFF
--- a/snmalloc-rs/snmalloc-sys/src/lib.rs
+++ b/snmalloc-rs/snmalloc-sys/src/lib.rs
@@ -41,6 +41,12 @@ extern "C" {
 
     /// Return the available bytes in a memory block.
     pub fn sn_rust_usable_size(p: *const c_void) -> usize;
+
+    /// Write current and peak OS-level memory reservation bytes into the given pointers.
+    pub fn sn_rust_statistics(
+        current_memory_usage: *mut usize,
+        peak_memory_usage: *mut usize,
+    );
 }
 
 #[cfg(feature = "libc-api")]

--- a/snmalloc-rs/src/lib.rs
+++ b/snmalloc-rs/src/lib.rs
@@ -245,6 +245,10 @@ mod tests {
 
         let during = SnMalloc::memory_stats();
         assert!(
+            during.current_memory_usage > 0,
+            "current usage should be non-zero after allocation"
+        );
+        assert!(
             during.current_memory_usage >= before.current_memory_usage,
             "current usage should not decrease after allocation"
         );
@@ -256,6 +260,10 @@ mod tests {
         unsafe { alloc.dealloc(ptr, layout) };
 
         let after = SnMalloc::memory_stats();
+        assert!(
+            after.current_memory_usage <= during.current_memory_usage,
+            "current usage should decrease after dealloc"
+        );
         assert!(
             after.peak_memory_usage >= during.peak_memory_usage,
             "peak usage should never decrease"

--- a/snmalloc-rs/src/lib.rs
+++ b/snmalloc-rs/src/lib.rs
@@ -32,6 +32,18 @@ use core::{
     ptr::NonNull,
 };
 
+/// Memory usage statistics from the snmalloc backend.
+///
+/// These are range-level figures (slab/chunk granularity) reflecting bytes
+/// reserved from the OS, not the count of live individual allocations.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct AllocStats {
+    /// Bytes currently reserved from the OS.
+    pub current_memory_usage: usize,
+    /// High-water mark of `current_memory_usage`.
+    pub peak_memory_usage: usize,
+}
+
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct SnMalloc;
@@ -52,6 +64,15 @@ impl SnMalloc {
             true => None,
             false => Some(unsafe { ffi::sn_rust_usable_size(ptr.cast()) })
         }
+    }
+
+    /// Returns current and peak OS-level memory reservation statistics.
+    /// See [`AllocStats`] for what the values measure.
+    pub fn memory_stats() -> AllocStats {
+        let mut current = 0usize;
+        let mut peak = 0usize;
+        unsafe { ffi::sn_rust_statistics(&mut current, &mut peak) };
+        AllocStats { current_memory_usage: current, peak_memory_usage: peak }
     }
 
     /// Allocates memory with the given layout, returning a non-null pointer on success
@@ -211,5 +232,33 @@ mod tests {
             alloc.dealloc(ptr, layout);
             assert!(usz >= 8);
         }
+    }
+
+    #[test]
+    fn test_memory_stats() {
+        let alloc = SnMalloc::new();
+        let before = SnMalloc::memory_stats();
+
+        let layout = Layout::from_size_align(1 << 20, 64).unwrap();
+        let ptr = unsafe { alloc.alloc(layout) };
+        assert!(!ptr.is_null());
+
+        let during = SnMalloc::memory_stats();
+        assert!(
+            during.current_memory_usage >= before.current_memory_usage,
+            "current usage should not decrease after allocation"
+        );
+        assert!(
+            during.peak_memory_usage >= before.peak_memory_usage,
+            "peak usage should not decrease after allocation"
+        );
+
+        unsafe { alloc.dealloc(ptr, layout) };
+
+        let after = SnMalloc::memory_stats();
+        assert!(
+            after.peak_memory_usage >= during.peak_memory_usage,
+            "peak usage should never decrease"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `AllocStats { current_memory_usage, peak_memory_usage }` to `snmalloc-rs`
- Adds `SnMalloc::memory_stats() -> AllocStats` associated function
- Adds FFI binding for `sn_rust_statistics` in `snmalloc-sys`

No C++ changes were required — `sn_rust_statistics` already existed in `rust.cc` and `StatsRange` counters are always active regardless of the `stats` build feature.

The returned values are OS-level memory reservation figures at slab/chunk granularity (tracked atomically by `StatsRange`), not the sum of individual live allocation sizes.

## Usage

```rust
let stats = SnMalloc::memory_stats();
println!("current: {} bytes, peak: {} bytes",
    stats.current_memory_usage,
    stats.peak_memory_usage);
```

## Test plan

- [x] `cargo test --package snmalloc-rs` — 7/7 tests pass including new `test_memory_stats`
- `test_memory_stats` allocates 1 MiB, verifies current/peak are non-decreasing after allocation, and that peak never decreases after free