### PR TITLE
Implement tick() for RISC-V

### DIFF
--- a/src/snmalloc/aal/aal.h
+++ b/src/snmalloc/aal/aal.h
@@ -174,7 +174,7 @@ namespace snmalloc
       {
 #if __has_builtin(__builtin_readcyclecounter) && !defined(__APPLE__) && \
   !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && \
-  !defined(SNMALLOC_NO_AAL_BUILTINS)
+  !defined(__riscv) && !defined(SNMALLOC_NO_AAL_BUILTINS)
         return __builtin_readcyclecounter();
 #else
         return Arch::tick();

--- a/src/snmalloc/aal/aal_riscv.h
+++ b/src/snmalloc/aal/aal_riscv.h
@@ -21,6 +21,26 @@ namespace snmalloc
 
     static constexpr AalName aal_name = RISCV;
 
+    static inline uint64_t tick() noexcept
+    {
+#if __riscv_xlen == 64
+      uint64_t t;
+      __asm__ volatile("rdtime %0" : "=r"(t));
+      return t;
+#else
+      uint32_t hi;
+      uint32_t hi2;
+      uint32_t lo;
+      do
+      {
+        __asm__ volatile("rdtimeh %0" : "=r"(hi));
+        __asm__ volatile("rdtime %0" : "=r"(lo));
+        __asm__ volatile("rdtimeh %0" : "=r"(hi2));
+      } while (hi != hi2);
+      return (static_cast<uint64_t>(hi) << 32) | lo;
+#endif
+    }
+
     static void inline pause()
     {
       /*


### PR DESCRIPTION
RISC-V builds currently fail when code instantiates Aal::tick() if the compiler does not provide __builtin_readcyclecounter(). The generic AAL falls back to Arch::tick(), but AAL_RISCV has no implementation.