### PR TITLE
Limit Linux RISC-V address bits

### DIFF
--- a/src/snmalloc/pal/pal_linux.h
+++ b/src/snmalloc/pal/pal_linux.h
@@ -42,6 +42,9 @@ namespace snmalloc
     static constexpr size_t page_size =
       Aal::aal_name == PowerPC ? 0x10000 : PALPOSIX::page_size;
 
+    static constexpr size_t address_bits =
+      Aal::aal_name == RISCV ? 38 : PALPOSIX::address_bits;
+
     /**
      * Linux requires an explicit no-reserve flag in `mmap` to guarantee lazy
      * commit if /proc/sys/vm/overcommit_memory is set to `heuristic` (0).


### PR DESCRIPTION
Linux RISC-V systems may run with an Sv39 user address space. The generic AAL default reports 48 address bits for 64-bit targets, which makes the default pagemap cover a much larger range than the process can reserve on those systems.

On an Sv39 Linux host, allocator initialisation tried to reserve a 256 GiB pagemap and mmap returned ENOMEM. Use the same conservative 38-bit RISC-V limit that the FreeBSD PAL already uses so the Linux PAL sizes its pagemap for the usable lower address range.