### PR TITLE
The constructor left it indeterminate, so a non-static timer is linked

### DIFF
--- a/src/snmalloc/pal/pal_ds.h
+++ b/src/snmalloc/pal/pal_ds.h
@@ -103,7 +103,7 @@ namespace snmalloc
     template<typename T>
     friend class PalList;
 
-    stl::Atomic<PalTimerObject*> pal_next;
+    stl::Atomic<PalTimerObject*> pal_next{nullptr};
 
     void (*pal_notify)(PalTimerObject* self);
 


### PR DESCRIPTION
into PalTimer's list with a garbage next pointer that apply_all then dereferences. PalNotificationObject already initialises its equivalent.