### PR TITLE
Implement accurate size storage for Windows _msize and _recalloc (#786)

### DIFF
--- a/src/snmalloc/backend_helpers/commonconfig.h
+++ b/src/snmalloc/backend_helpers/commonconfig.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <atomic>
 #include "../mem/mem.h"
 
 namespace snmalloc
@@ -102,33 +102,34 @@ namespace snmalloc
     }
   };
 
-  // Specialization for bool to pack 8 bits into a single uint8_t
   template <>
   struct ArrayClientMetaDataProvider<bool>
   {
-    using StorageType = uint8_t;
+    using StorageType = std::atomic<uint8_t>;
 
     struct BitRef
     {
-      uint8_t* byte;
+      std::atomic<uint8_t>* byte;
       uint8_t mask;
 
       BitRef& operator=(bool val)
       {
         if (val)
         {
-          *byte |= mask;
+          // Thread-safe bit set
+          byte->fetch_or(mask, std::memory_order_relaxed);
         }
         else
         {
-          *byte &= static_cast<uint8_t>(~mask);
+          // Thread-safe bit clear
+          byte->fetch_and(static_cast<uint8_t>(~mask), std::memory_order_relaxed);
         }
         return *this;
       }
 
       operator bool() const
       {
-        return (*byte & mask) != 0;
+        return (byte->load(std::memory_order_relaxed) & mask) != 0;
       }
     };
 

--- a/src/snmalloc/backend_helpers/commonconfig.h
+++ b/src/snmalloc/backend_helpers/commonconfig.h
@@ -102,6 +102,52 @@ namespace snmalloc
     }
   };
 
+  // Specialization for bool to pack 8 bits into a single uint8_t
+  template <>
+  struct ArrayClientMetaDataProvider<bool>
+  {
+    using StorageType = uint8_t;
+
+    struct BitRef
+    {
+      uint8_t* byte;
+      uint8_t mask;
+
+      BitRef& operator=(bool val)
+      {
+        if (val)
+        {
+          *byte |= mask;
+        }
+        else
+        {
+          *byte &= static_cast<uint8_t>(~mask);
+        }
+        return *this;
+      }
+
+      operator bool() const
+      {
+        return (*byte & mask) != 0;
+      }
+    };
+
+    using DataRef = BitRef;
+
+    static size_t required_count(size_t max_count)
+    {
+      return (max_count + 7) / 8;
+    }
+
+    static DataRef get(StorageType* base, size_t index)
+    {
+      return BitRef{
+        &base[index / 8], 
+        static_cast<uint8_t>(1 << (index % 8))
+      };
+    }
+  };
+
   /**
    * Class containing definitions that are likely to be used by all except for
    * the most unusual back-end implementations.  This can be subclassed as a

--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -6,6 +6,52 @@ using namespace snmalloc;
 #  define MALLOC_USABLE_SIZE_QUALIFIER
 #endif
 
+#ifdef _WIN32
+#  include <cstring>
+
+namespace
+{
+  inline void win_set_exact_size(void* ptr, size_t req_size)
+  {
+    if (!ptr)
+      return;
+      
+    auto* alloc = snmalloc::ThreadAlloc::get();
+    size_t alloc_size = alloc->alloc_size(ptr);
+    size_t diff = alloc_size - req_size;
+    
+    // We have 1 byte to store the difference (max 255 bytes of padding).
+    if (diff > 0 && diff <= 255)
+    {
+      alloc->set_client_meta_data<bool>(ptr, true);
+      static_cast<uint8_t*>(ptr)[alloc_size - 1] = static_cast<uint8_t>(diff);
+    }
+    else
+    {
+      alloc->set_client_meta_data<bool>(ptr, false);
+    }
+  }
+
+  inline size_t win_get_exact_size(void* ptr)
+  {
+    if (!ptr)
+      return 0;
+      
+    auto* alloc = snmalloc::ThreadAlloc::get();
+    size_t alloc_size = alloc->alloc_size(ptr);
+    bool has_padding = alloc->get_client_meta_data<bool>(ptr);
+    
+    if (has_padding)
+    {
+      uint8_t unused = static_cast<uint8_t*>(ptr)[alloc_size - 1];
+      return alloc_size - unused;
+    }
+    
+    return alloc_size;
+  }
+} // namespace
+#endif
+
 extern "C"
 {
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(__malloc_end_pointer)(void* ptr)
@@ -15,7 +61,11 @@ extern "C"
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(malloc)(size_t size)
   {
-    return snmalloc::libc::malloc(size);
+    void* ptr = snmalloc::libc::malloc(size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, size);
+#endif
+    return ptr;
   }
 
   SNMALLOC_EXPORT void SNMALLOC_NAME_MANGLE(free)(void* ptr)
@@ -41,7 +91,11 @@ extern "C"
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(calloc)(size_t nmemb, size_t size)
   {
-    return snmalloc::libc::calloc(nmemb, size);
+    void* ptr = snmalloc::libc::calloc(nmemb, size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, nmemb * size);
+#endif
+    return ptr;
   }
 
   SNMALLOC_EXPORT
@@ -55,7 +109,37 @@ extern "C"
   SNMALLOC_EXPORT
   size_t SNMALLOC_NAME_MANGLE(_msize)(void* ptr)
   {
-    return snmalloc::libc::malloc_usable_size(ptr);
+    return win_get_exact_size(ptr);
+  }
+
+  SNMALLOC_EXPORT
+  void* SNMALLOC_NAME_MANGLE(_recalloc)(void* ptr, size_t num, size_t size)
+  {
+    size_t req_size = num * size;
+    if (!ptr)
+    {
+      return SNMALLOC_NAME_MANGLE(calloc)(num, size);
+    }
+
+    size_t old_exact_size = win_get_exact_size(ptr);
+    void* new_ptr = SNMALLOC_NAME_MANGLE(malloc)(req_size);
+
+    if (new_ptr)
+    {
+      size_t copy_size = (old_exact_size < req_size) ? old_exact_size : req_size;
+      std::memcpy(new_ptr, ptr, copy_size);
+
+      if (req_size > old_exact_size)
+      {
+        std::memset(
+          static_cast<uint8_t*>(new_ptr) + old_exact_size,
+          0,
+          req_size - old_exact_size);
+      }
+
+      SNMALLOC_NAME_MANGLE(free)(ptr);
+    }
+    return new_ptr;
   }
 #endif
 
@@ -67,14 +151,22 @@ extern "C"
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(realloc)(void* ptr, size_t size)
   {
-    return snmalloc::libc::realloc(ptr, size);
+    void* new_ptr = snmalloc::libc::realloc(ptr, size);
+#ifdef _WIN32
+    win_set_exact_size(new_ptr, size);
+#endif
+    return new_ptr;
   }
 
 #if !defined(SNMALLOC_NO_REALLOCARRAY)
   SNMALLOC_EXPORT void*
   SNMALLOC_NAME_MANGLE(reallocarray)(void* ptr, size_t nmemb, size_t size)
   {
-    return snmalloc::libc::reallocarray(ptr, nmemb, size);
+    void* new_ptr = snmalloc::libc::reallocarray(ptr, nmemb, size);
+#ifdef _WIN32
+    win_set_exact_size(new_ptr, nmemb * size);
+#endif
+    return new_ptr;
   }
 #endif
 
@@ -82,39 +174,70 @@ extern "C"
   SNMALLOC_EXPORT int
   SNMALLOC_NAME_MANGLE(reallocarr)(void* ptr, size_t nmemb, size_t size)
   {
-    return snmalloc::libc::reallocarr(ptr, nmemb, size);
+    int ret = snmalloc::libc::reallocarr(ptr, nmemb, size);
+#ifdef _WIN32
+    if (ret == 0 && ptr != nullptr) 
+    {
+      void* p = *static_cast<void**>(ptr);
+      win_set_exact_size(p, nmemb * size);
+    }
+#endif
+    return ret;
   }
 #endif
 
   SNMALLOC_EXPORT void*
   SNMALLOC_NAME_MANGLE(memalign)(size_t alignment, size_t size)
   {
-    return snmalloc::libc::memalign(alignment, size);
+    void* ptr = snmalloc::libc::memalign(alignment, size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, size);
+#endif
+    return ptr;
   }
 
   SNMALLOC_EXPORT void*
   SNMALLOC_NAME_MANGLE(aligned_alloc)(size_t alignment, size_t size)
   {
-    return snmalloc::libc::aligned_alloc(alignment, size);
+    void* ptr = snmalloc::libc::aligned_alloc(alignment, size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, size);
+#endif
+    return ptr;
   }
 
   SNMALLOC_EXPORT int SNMALLOC_NAME_MANGLE(posix_memalign)(
     void** memptr, size_t alignment, size_t size)
   {
-    return snmalloc::libc::posix_memalign(memptr, alignment, size);
+    int ret = snmalloc::libc::posix_memalign(memptr, alignment, size);
+#ifdef _WIN32
+    if (ret == 0 && memptr != nullptr) 
+    {
+      win_set_exact_size(*memptr, size);
+    }
+#endif
+    return ret;
   }
 
 #if !defined(__FreeBSD__) && !defined(__OpenBSD__)
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(valloc)(size_t size)
   {
-    return snmalloc::libc::memalign(OS_PAGE_SIZE, size);
+    void* ptr = snmalloc::libc::memalign(OS_PAGE_SIZE, size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, size);
+#endif
+    return ptr;
   }
 #endif
 
   SNMALLOC_EXPORT void* SNMALLOC_NAME_MANGLE(pvalloc)(size_t size)
   {
-    return snmalloc::libc::memalign(
-      OS_PAGE_SIZE, (size + OS_PAGE_SIZE - 1) & ~(OS_PAGE_SIZE - 1));
+    size_t rounded_size = (size + OS_PAGE_SIZE - 1) & ~(OS_PAGE_SIZE - 1);
+    void* ptr = snmalloc::libc::memalign(OS_PAGE_SIZE, rounded_size);
+#ifdef _WIN32
+    win_set_exact_size(ptr, rounded_size);
+#endif
+    return ptr;
   }
 
 #if __has_include(<features.h>)

--- a/src/snmalloc/override/malloc.cc
+++ b/src/snmalloc/override/malloc.cc
@@ -20,7 +20,9 @@ namespace
     size_t alloc_size = alloc->alloc_size(ptr);
     size_t diff = alloc_size - req_size;
     
-    // We have 1 byte to store the difference (max 255 bytes of padding).
+    // We use the last byte of the allocation to store the padding size.
+    // If the padding exceeds 255 bytes, we cannot store it, so we fall back 
+    // to reporting the full alloc_size (standard Windows _msize behavior).
     if (diff > 0 && diff <= 255)
     {
       alloc->set_client_meta_data<bool>(ptr, true);


### PR DESCRIPTION
**Fixes #786** 

This PR implements exact size tracking for allocations on Windows, allowing `_msize` to report the precise requested size and enabling `_recalloc` to accurately zero out only the newly appended memory.

#### Implementation Details:
1. **Metadata Provider (`src/snmalloc/backend_helpers/commonconfig.h`)**:
   * Added a template specialization for `ArrayClientMetaDataProvider<bool>`.
   * To minimize overhead, the provider packs 8 boolean flags into a single `uint8_t`. 
   * **Thread-Safety:** Since adjacent objects share the same metadata byte, the storage type uses `std::atomic<uint8_t>` with `fetch_or`/`fetch_and` and `std::memory_order_relaxed`. This safely prevents data races and torn reads/writes during highly concurrent allocations/deallocations.

2. **Allocation Hooks & Size Tracking (`src/snmalloc/override/malloc.cc`)**:
   * Introduced `win_set_exact_size` and `win_get_exact_size` helpers.
   * When an allocation does not consume the whole space, the metadata bit is set to `true`, and the difference (`alloc_size - req_size`) is written to the very last byte of the allocated block.
   * Integrated `win_set_exact_size` into all standard allocation functions (`malloc`, `calloc`, `realloc`, `memalign`, etc.) when `_WIN32` is defined.

3. **`_msize` and `_recalloc` Implementation**:
   * `_msize` checks the metadata bit. If true, it subtracts the trailing padding byte from the `alloc_size`. Otherwise, it returns the standard `alloc_size`.
   * `_recalloc` now relies on the accurate `_msize` to safely calculate boundaries, copying the exact original data and exclusively zero-initializing the new expanded memory.

#### Notes / Edge Cases Handled:
* **Large Padding Fallback**: Because we are using a single byte at the end of the block to store the offset, the maximum trackable difference is 255 bytes. If the difference between `alloc_size` and `req_size` exceeds 255 bytes (which can happen in larger size classes), the implementation safely falls back to standard behavior (setting the bit to `false` and reporting the full `alloc_size`).
* `_recalloc` is implemented using `malloc` + `memcpy` + `memset` + `free` as a functionally correct baseline. 

*** 

### Reviewer Checklist:
- [x] Tested locally on Windows.
- [x] Verified concurrent safety (Atomics utilized for bit-packing).