### PR TITLE
Prepare Rust crates for 0.7.5 release

### DIFF
--- a/snmalloc-rs/CHANGELOG.md
+++ b/snmalloc-rs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.7.5
+
+- Tracking upstream to match version 0.7.5.
+
 ### 0.7.4
 
 - Tracking upstream to match version 0.7.4.

--- a/snmalloc-rs/Cargo.toml
+++ b/snmalloc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snmalloc-rs"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["schrodingerzhu <i@zhuyi.fan>"]
 edition = "2021"
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-snmalloc-sys = { version = "0.7.4", path = "snmalloc-sys", default-features = false }
+snmalloc-sys = { version = "0.7.5", path = "snmalloc-sys", default-features = false }
 
 [features]
 default = ["snmalloc-sys/build_cmake", "snmalloc-sys/usewait-on-address"]

--- a/snmalloc-rs/README.md
+++ b/snmalloc-rs/README.md
@@ -56,7 +56,7 @@ To use `snmalloc-rs` add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-snmalloc-rs = "0.7.4"
+snmalloc-rs = "0.7.5"
 ```
 
 To set `SnMalloc` as the global allocator add this to your project:
@@ -76,6 +76,10 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
   default)~~ (`libstdc++` is no longer a dependency)
 
 ## Changelog
+
+### 0.7.5
+
+- Tracking upstream to match version 0.7.5.
 
 ### 0.7.4
 

--- a/snmalloc-rs/snmalloc-sys/Cargo.toml
+++ b/snmalloc-rs/snmalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snmalloc-sys"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["schrodingerzhu <i@zhuyi.fan>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump `snmalloc-rs` and `snmalloc-sys` to 0.7.5
- update the wrapper dependency requirement to 0.7.5
- update the Rust changelog and README release metadata

## Validation

- Debug build and 80/80 C++ tests passed on the 0.7.5 baseline
- `cargo build --all` passed
- 12 Rust tests passed
- package content checks passed for both crates
- `cargo publish --workspace --exclude xtask --dry-run` passed from the committed tree