### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  groups:
+    github-actions:
+      patterns: ["*"]
+  schedule:
+    interval: "weekly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,15 +28,15 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       # Setup docker buildx
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
       - name: Build and run benchmarks in Docker
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: benchmark/Dockerfile
@@ -56,7 +56,7 @@ jobs:
 
       # Uploads the benchmark results as an artifact
       - name: Upload Benchmark Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-results
           path: bencher.dev.sn.json

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -48,7 +48,7 @@ jobs:
           github.event.repository.default_branch))
     steps:
       - name: Download merged coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           # Must match the upload name in coverage.yml's merge job.
           name: coverage-merged
@@ -119,7 +119,7 @@ jobs:
 
       - name: Resolve PR number
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           # Pass the event JSON via the environment, not via inline
           # `${{ toJson(...) }}` interpolation. Actions resolves
@@ -180,7 +180,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Comment on PR
         if: steps.pr.outputs.pr != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr }}
         with:
@@ -246,7 +246,7 @@ jobs:
       # ------------------------------------------------------------
       - name: Update tracking issue
         if: steps.pr.outputs.pr == '' && vars.COVERAGE_TRACKING_ISSUE != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ISSUE_NUMBER: ${{ vars.COVERAGE_TRACKING_ISSUE }}
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -172,10 +172,10 @@ jobs:
     needs: [ build, build-vm, windows ]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: coverage-artifacts
           pattern: coverage-*
@@ -242,7 +242,7 @@ jobs:
           python3 -c "import json; m=json.load(open('coverage-merged.json')); print('files:', len(m['files'])); print('totals:', m['totals']); print('platforms:', list(m['platforms'].keys()))"
 
       - name: Upload merged coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # Artifact name is consumed by coverage-comment.yml. If
           # this name changes, update coverage-comment.yml's

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,10 +151,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Bazel - ${{ matrix.os }} ${{ matrix.build-type }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: bazelbuild/setup-bazelisk@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3.0.0
     - name: Mount bazel cache  # Optional
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: "~/.cache/bazel"
         key: bazel-${{ matrix.os }}-${{ matrix.build-type }}
@@ -258,7 +258,7 @@ jobs:
     runs-on: ${{matrix.arch.host-os}}
     name: Crossbuild - ${{matrix.build-type}} ${{matrix.arch.triple}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install cross-compile toolchain and QEMU
       run: >
         sudo apt update &&
@@ -371,7 +371,7 @@ jobs:
     name: Format check
     # We don't need to do the build for this job, but we need to configure it to get the clang-format target
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install clang-tidy and clang-format
       run: |
         sudo apt update
@@ -400,7 +400,7 @@ jobs:
     name: Fuzzing
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DSNMALLOC_ENABLE_FUZZING=ON -DFUZZTEST_FUZZING_MODE=ON -DCMAKE_CXX_COMPILER=clang++
     - name: Build
@@ -420,17 +420,17 @@ jobs:
     runs-on: ${{matrix.os}}
     name: GWP-ASan - ${{matrix.os}} ${{matrix.profile}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install Ninja
       run: sudo apt-get install -y ninja-build
     - name: Set up sccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
       with:
         variant: sccache
         key: gwp-asan-${{matrix.os}}-${{matrix.profile}}
     - name: Cache compiler-rt
       id: cache-compiler-rt
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ${{ runner.temp }}/compiler-rt
@@ -484,7 +484,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: vcpkg - ${{ matrix.os }} ${{ matrix.feature }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Bootstrap vcpkg
       shell: bash

--- a/.github/workflows/morello.yml
+++ b/.github/workflows/morello.yml
@@ -70,7 +70,7 @@ jobs:
         inputs.bootenv_label || 'benchmark' )) }}
     name: ${{ matrix.os }} ${{ matrix.build-type }} ${{ matrix.caps }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: Install build dependencies
       run: |
         su -l root -c "pkg64 install -y ${{ matrix.dependencies }}"

--- a/.github/workflows/reusable-cmake-build.yml
+++ b/.github/workflows/reusable-cmake-build.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Validate coverage inputs
       if: inputs.coverage
@@ -95,7 +95,7 @@ jobs:
 
     - name: Pick the latest XCode (macOS)
       if: startsWith(inputs.os, 'macos')
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: latest-stable
 
@@ -105,7 +105,7 @@ jobs:
       run: echo "hash=$(echo '${{ inputs.cmake-config }} ${{ inputs.extra-cmake-flags }}' | shasum -a 256 | cut -c1-16)" >> "$GITHUB_OUTPUT"
 
     - name: Set up sccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
       with:
         variant: sccache
         key: ${{ inputs.os }}-${{ inputs.build-type }}-${{ steps.config-hash.outputs.hash }}
@@ -242,7 +242,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: ${{ !inputs.build-only && inputs.coverage }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: coverage-${{ inputs.coverage-artifact-name }}
         path: |

--- a/.github/workflows/reusable-vm-build.yml
+++ b/.github/workflows/reusable-vm-build.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ inputs.host-os }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Validate coverage inputs
       if: inputs.coverage
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build on FreeBSD
       if: inputs.vm-type == 'freebsd'
-      uses: vmactions/freebsd-vm@v1
+      uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1.5.3
       with:
         release: ${{ inputs.vm-version }}
         usesh: true
@@ -84,7 +84,7 @@ jobs:
 
     - name: Build on NetBSD
       if: inputs.vm-type == 'netbsd'
-      uses: vmactions/netbsd-vm@v1
+      uses: vmactions/netbsd-vm@00081e82b14bc40114eb97f32b4455306828516b # v1.4.6
       with:
         release: ${{ inputs.vm-version }}
         usesh: true
@@ -105,7 +105,7 @@ jobs:
 
     - name: Build on OpenBSD
       if: inputs.vm-type == 'openbsd'
-      uses: vmactions/openbsd-vm@v0
+      uses: vmactions/openbsd-vm@2cbd7618ff813d8235acc5ade8cb5260dcee4502 # v0.1.2
       with:
         release: ${{ inputs.vm-version }}
         usesh: true
@@ -126,7 +126,7 @@ jobs:
 
     - name: Upload coverage artifact
       if: inputs.coverage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: coverage-${{ inputs.coverage-artifact-name }}
         path: ${{ github.workspace }}/build/coverage.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,11 +54,11 @@ jobs:
       # Don't abort runners if a single one fails
       fail-fast: false
     steps:
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: ${{ matrix.rust }}
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: update dependency
       run: |
         if bash -c 'uname -s | grep 'Linux' >/dev/null'; then
@@ -77,11 +77,11 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: stable
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: update dependency
       run: sudo apt-get update -y && sudo apt-get --reinstall install -y libc6-dev
     - name: Dry-run workspace publish


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). This groups Dependabot PRs for GitHub Actions and enforces a minimum 7-day cooldown between updates. If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
